### PR TITLE
Reset Slidev's style on p elements in Anipres

### DIFF
--- a/.changeset/tender-hoops-unite.md
+++ b/.changeset/tender-hoops-unite.md
@@ -1,0 +1,5 @@
+---
+"slidev-addon-anipres": patch
+---
+
+Fix line height

--- a/packages/slidev-addon-anipres/components/SlidevAnipres.vue
+++ b/packages/slidev-addon-anipres/components/SlidevAnipres.vue
@@ -287,6 +287,13 @@ function onKeyDown(e: KeyboardEvent) {
   transform-origin: top left;
 }
 
+.container :deep(p) {
+  /* Disable Slidev's styles in Anipres */
+  margin-top: inherit;
+  margin-bottom: inherit;
+  line-height: inherit;
+}
+
 .container :deep(.tl-theme__light, .tl-theme__dark) {
   --color-background: rgba(0, 0, 0, 0);
 }


### PR DESCRIPTION
Line height is now broken, not sure since when it has been though.

Current
![CleanShot 2025-03-29 at 23 31 30@2x](https://github.com/user-attachments/assets/fe5608c9-83e4-4fc4-ab73-70bf5f67d919)

Should be:
![CleanShot 2025-03-29 at 23 31 55@2x](https://github.com/user-attachments/assets/6a18d4c4-7861-4332-91e5-ce1258db7e7d)

https://slides.whitphx.info/202502-oss-pycon-and-me/5