### PR TITLE
Fix/group cur frame button style

### DIFF
--- a/.changeset/silly-grapes-wish.md
+++ b/.changeset/silly-grapes-wish.md
@@ -1,0 +1,5 @@
+---
+"anipres": patch
+---
+
+Very rough styling on the add-cue-frame button on a group

--- a/packages/anipres/src/Timeline/GroupSelection.tsx
+++ b/packages/anipres/src/Timeline/GroupSelection.tsx
@@ -68,9 +68,13 @@ export function GroupSelection(props: GroupSelectionProps) {
         onClick={() => props.requestCueFrameAddAfter(props.groupSelection)}
         style={{
           pointerEvents: "auto",
+          position: "absolute",
+          left: "100%",
+          top: "50%",
+          transform: "translate(0, -50%)",
         }}
       >
-        Add Cue Frame
+        +
       </button>
     </div>
   );

--- a/packages/anipres/src/Timeline/GroupSelection.tsx
+++ b/packages/anipres/src/Timeline/GroupSelection.tsx
@@ -66,6 +66,7 @@ export function GroupSelection(props: GroupSelectionProps) {
     >
       <button
         onClick={() => props.requestCueFrameAddAfter(props.groupSelection)}
+        aria-label="Add Cue Frame"
         style={{
           pointerEvents: "auto",
           position: "absolute",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Add Cue Frame button on the timeline group with refined positioning, improved vertical alignment, and a simplified label for better visual clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->