### PR TITLE
Bump prettier from 3.6.2 to 3.8.1

### DIFF
--- a/.changeset/update-prettier-3-8.md
+++ b/.changeset/update-prettier-3-8.md
@@ -1,0 +1,4 @@
+---
+---
+
+Update prettier from 3.6.2 to 3.8.1

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "globals": "^16.0.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.6",
-    "prettier": "3.6.2",
+    "prettier": "3.8.1",
     "sass-embedded": "^1.93.3",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.46.2",

--- a/packages/anipres/src/models.ts
+++ b/packages/anipres/src/models.ts
@@ -26,15 +26,17 @@ export interface FrameBase {
   id: string;
   type: string;
 }
-export interface CueFrame<T extends FrameAction = FrameAction>
-  extends FrameBase {
+export interface CueFrame<
+  T extends FrameAction = FrameAction,
+> extends FrameBase {
   type: "cue";
   globalIndex: OrderedTrackItem["globalIndex"];
   trackId: OrderedTrackItem["trackId"];
   action: T;
 }
-export interface SubFrame<T extends FrameAction = FrameAction>
-  extends FrameBase {
+export interface SubFrame<
+  T extends FrameAction = FrameAction,
+> extends FrameBase {
   type: "sub";
   prevFrameId: Frame["id"];
   action: T;

--- a/packages/anipres/src/shapes/theme-image/ThemeImageShape.ts
+++ b/packages/anipres/src/shapes/theme-image/ThemeImageShape.ts
@@ -13,8 +13,10 @@ export interface ThemeDimension {
   h: number;
 }
 
-export interface ThemeImageShapeProps
-  extends Omit<TLImageShapeProps, "assetId"> {
+export interface ThemeImageShapeProps extends Omit<
+  TLImageShapeProps,
+  "assetId"
+> {
   assetIdLight: TLAssetId | null;
   assetIdDark: TLAssetId | null;
   syncThemeDimensionsAndCrops: boolean;

--- a/packages/slidev-addon-anipres/tsconfig.json
+++ b/packages/slidev-addon-anipres/tsconfig.json
@@ -35,7 +35,7 @@
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     "types": [
       "vite/client",
-      "vite-plugin-font/src/font",
+      "vite-plugin-font/src/font"
     ] /* Specify type package names to be included without being referenced in a source file. */,
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 10.1.8(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-prettier:
         specifier: ^5.5.4
-        version: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))(prettier@3.6.2)
+        version: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))(prettier@3.8.1)
       eslint-plugin-react:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -54,8 +54,8 @@ importers:
         specifier: ^16.2.6
         version: 16.2.6
       prettier:
-        specifier: 3.6.2
-        version: 3.6.2
+        specifier: 3.8.1
+        version: 3.8.1
       sass-embedded:
         specifier: ^1.93.3
         version: 1.93.3
@@ -5712,6 +5712,11 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  prettier@3.8.1:
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   prism-theme-vars@0.2.5:
     resolution: {integrity: sha512-/D8gBTScYzi9afwE6v3TC1U/1YFZ6k+ly17mtVRdLpGy7E79YjJJWkXFgUDHJ2gDksV/ZnXF7ydJ4TvoDm2z/Q==}
 
@@ -7008,6 +7013,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -12318,10 +12324,10 @@ snapshots:
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)
 
-  eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))(prettier@3.6.2):
+  eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))(prettier@3.8.1):
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)
-      prettier: 3.6.2
+      prettier: 3.8.1
       prettier-linter-helpers: 1.0.0
       synckit: 0.11.11
     optionalDependencies:
@@ -14057,6 +14063,8 @@ snapshots:
   prettier@2.8.8: {}
 
   prettier@3.6.2: {}
+
+  prettier@3.8.1: {}
 
   prism-theme-vars@0.2.5: {}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Prettier to 3.8.1 and added a changelog entry.

* **Style**
  * Applied non-functional formatting changes across type declarations and configs (whitespace/reflow only; no behavioral or public API changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->