### PR TITLE
Extract SlideShape types and props into separate pure-TS file

### DIFF
--- a/.changeset/slide-shape-extract-types.md
+++ b/.changeset/slide-shape-extract-types.md
@@ -1,0 +1,5 @@
+---
+"anipres": patch
+---
+
+Extract SlideShape types and props into a separate pure-TS file to match the ThemeImageShape pattern

--- a/packages/anipres/src/Anipres.tsx
+++ b/packages/anipres/src/Anipres.tsx
@@ -21,10 +21,8 @@ import type {
   TLComponents,
   Editor,
   TldrawProps,
-  TLStore,
   TLStoreSnapshot,
   TLEditorSnapshot,
-  TLStoreWithStatus,
   TLInstancePageState,
   TLInstancePageStateId,
   TLContent,
@@ -269,14 +267,13 @@ interface InnerProps {
     editor: Editor,
     presentationManager: PresentationManager,
   ) => (() => void) | void;
-  store?: TLStore | TLStoreWithStatus;
   snapshot?: TLEditorSnapshot | TLStoreSnapshot;
   perInstanceAtoms: AnipresAtoms;
   assetUrls?: TldrawProps["assetUrls"];
   user: TLUser;
 }
 const Inner = (props: InnerProps) => {
-  const { onMount, store, snapshot, perInstanceAtoms, assetUrls, user } = props;
+  const { onMount, snapshot, perInstanceAtoms, assetUrls, user } = props;
 
   const $currentStepIndex = useAtom<number>("current step index", 0);
 
@@ -533,7 +530,7 @@ const Inner = (props: InnerProps) => {
       options={{
         maxPages: 1,
       }}
-      {...(store ? { store } : { snapshot })}
+      snapshot={snapshot}
       assetUrls={assetUrls}
       user={user}
     />
@@ -546,7 +543,6 @@ const MemoizedInner = React.memo(Inner);
 export interface AnipresProps {
   presentationMode?: boolean;
   onMount?: (editor: Editor, moveTo: (stepIndex: number) => void) => void;
-  store?: InnerProps["store"];
   snapshot?: InnerProps["snapshot"];
   assetUrls?: InnerProps["assetUrls"];
   stepHotkeyEnabled?: boolean;
@@ -560,7 +556,6 @@ export const Anipres = React.forwardRef<AnipresRef, AnipresProps>(
     const {
       presentationMode,
       onMount,
-      store,
       snapshot,
       assetUrls,
       stepHotkeyEnabled,
@@ -644,7 +639,6 @@ export const Anipres = React.forwardRef<AnipresRef, AnipresProps>(
       <MemoizedInner
         onMount={handleMount}
         perInstanceAtoms={anipresAtoms}
-        store={store}
         snapshot={snapshot}
         assetUrls={memoizedAssetUrls}
         user={user}

--- a/packages/anipres/src/Anipres.tsx
+++ b/packages/anipres/src/Anipres.tsx
@@ -21,8 +21,10 @@ import type {
   TLComponents,
   Editor,
   TldrawProps,
+  TLStore,
   TLStoreSnapshot,
   TLEditorSnapshot,
+  TLStoreWithStatus,
   TLInstancePageState,
   TLInstancePageStateId,
   TLContent,
@@ -33,7 +35,7 @@ import type {
 } from "tldraw";
 import "tldraw/tldraw.css";
 
-import { SlideShapeType } from "./shapes/slide/SlideShapeUtil";
+import { SlideShapeType } from "./shapes/slide/SlideShape";
 import { SlideShapeTool } from "./shapes/slide/SlideShapeTool";
 import { ThemeImageShapeTool } from "./shapes/theme-image/ThemeImageShapeTool";
 import { ThemeImageToolbar } from "./shapes/theme-image/ThemeImageToolbar";
@@ -267,13 +269,14 @@ interface InnerProps {
     editor: Editor,
     presentationManager: PresentationManager,
   ) => (() => void) | void;
+  store?: TLStore | TLStoreWithStatus;
   snapshot?: TLEditorSnapshot | TLStoreSnapshot;
   perInstanceAtoms: AnipresAtoms;
   assetUrls?: TldrawProps["assetUrls"];
   user: TLUser;
 }
 const Inner = (props: InnerProps) => {
-  const { onMount, snapshot, perInstanceAtoms, assetUrls, user } = props;
+  const { onMount, store, snapshot, perInstanceAtoms, assetUrls, user } = props;
 
   const $currentStepIndex = useAtom<number>("current step index", 0);
 
@@ -530,7 +533,7 @@ const Inner = (props: InnerProps) => {
       options={{
         maxPages: 1,
       }}
-      snapshot={snapshot}
+      {...(store ? { store } : { snapshot })}
       assetUrls={assetUrls}
       user={user}
     />
@@ -543,6 +546,7 @@ const MemoizedInner = React.memo(Inner);
 export interface AnipresProps {
   presentationMode?: boolean;
   onMount?: (editor: Editor, moveTo: (stepIndex: number) => void) => void;
+  store?: InnerProps["store"];
   snapshot?: InnerProps["snapshot"];
   assetUrls?: InnerProps["assetUrls"];
   stepHotkeyEnabled?: boolean;
@@ -556,6 +560,7 @@ export const Anipres = React.forwardRef<AnipresRef, AnipresProps>(
     const {
       presentationMode,
       onMount,
+      store,
       snapshot,
       assetUrls,
       stepHotkeyEnabled,
@@ -639,6 +644,7 @@ export const Anipres = React.forwardRef<AnipresRef, AnipresProps>(
       <MemoizedInner
         onMount={handleMount}
         perInstanceAtoms={anipresAtoms}
+        store={store}
         snapshot={snapshot}
         assetUrls={memoizedAssetUrls}
         user={user}

--- a/packages/anipres/src/ControlPanel/ControlPanel.tsx
+++ b/packages/anipres/src/ControlPanel/ControlPanel.tsx
@@ -23,7 +23,7 @@ import {
 import { insertOrderedTrackItem } from "../ordered-track-item";
 import { Timeline, type ShapeSelection } from "../Timeline";
 import styles from "./ControlPanel.module.scss";
-import { SlideShapeType } from "../shapes/slide/SlideShapeUtil";
+import { SlideShapeType } from "../shapes/slide/SlideShape";
 import type { PresentationManager } from "../presentation-manager";
 
 const COPIED_SHAPE_POSITION_OFFSET = { x: 100, y: 100 };

--- a/packages/anipres/src/presentation-manager/presentation-manager.ts
+++ b/packages/anipres/src/presentation-manager/presentation-manager.ts
@@ -27,7 +27,7 @@ import {
   getGlobalOrder,
   reassignGlobalIndexInplace,
 } from "../ordered-track-item";
-import { SlideShapeType } from "../shapes/slide/SlideShapeUtil";
+import { SlideShapeType } from "../shapes/slide/SlideShape";
 import { runStep } from "./animation";
 
 type ShapeVisibility = NonNullable<

--- a/packages/anipres/src/shapes/slide/SlideShape.ts
+++ b/packages/anipres/src/shapes/slide/SlideShape.ts
@@ -1,0 +1,14 @@
+import { T } from "tldraw";
+import type { TLBaseShape, RecordProps } from "tldraw";
+
+export const SlideShapeType = "slide" as const;
+
+export type SlideShape = TLBaseShape<
+  typeof SlideShapeType,
+  { w: number; h: number }
+>;
+
+export const slideShapeProps: RecordProps<SlideShape> = {
+  w: T.number,
+  h: T.number,
+};

--- a/packages/anipres/src/shapes/slide/SlideShapeUtil.tsx
+++ b/packages/anipres/src/shapes/slide/SlideShapeUtil.tsx
@@ -1,5 +1,4 @@
 import {
-  TLBaseShape,
   SVGContainer,
   ShapeUtil,
   Geometry2d,
@@ -8,23 +7,12 @@ import {
   getPerfectDashProps,
   TLResizeInfo,
   resizeBox,
-  T,
-  RecordProps,
 } from "tldraw";
-
-export const SlideShapeType = "slide" as const;
-
-export type SlideShape = TLBaseShape<
-  typeof SlideShapeType,
-  { w: number; h: number }
->;
+import { SlideShapeType, slideShapeProps, type SlideShape } from "./SlideShape";
 
 export class SlideShapeUtil extends ShapeUtil<SlideShape> {
   static override readonly type = SlideShapeType;
-  static override props: RecordProps<SlideShape> = {
-    w: T.number,
-    h: T.number,
-  };
+  static override props = slideShapeProps;
 
   override canBind() {
     return false; // TODO: Be configurable?


### PR DESCRIPTION
Match the existing ThemeImageShape.ts pattern by moving SlideShapeType, SlideShape type, and shape props into SlideShape.ts, keeping SlideShapeUtil.tsx focused on the React rendering logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Anipres now accepts an optional store prop so callers can provide a live store instead of a snapshot.
  * Added a dedicated Slide shape type and public shape props for slide width/height.

* **Chores**
  * Internal reorganization: slide shape definitions extracted to a separate module and public exports aligned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->