### PR TITLE
fix(app): skip push-or-fork when no pending offline edits

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -12,5 +12,5 @@ Tasks deferred during development that should be addressed before production rel
 
 - **Phase 4 — Local-to-cloud asset migration**: R2 asset storage and remote `TLAssetStore` are implemented. Remaining: migrate inline data-URL assets from local IDB snapshots to R2 on first login/sync.
 - **Phase 4.x — Persist synced document snapshots on the server**: `DocumentSyncRoom` still keeps the live tldraw room state in memory only. Persisting/restoring the server snapshot would let asset reconciliation trust `getCurrentSnapshot()` even after the last socket disconnects, instead of relying on current stopgap behavior around stale uploaded assets.
-- **Phase 5 — Offline support + IDB cache**: Debounced IDB cache in synced mode, offline fallback, push-or-fork reconnection logic. Follow-up: skip push-or-fork entirely when the offline copy is unchanged so reconnecting against a newer server document does not create a redundant `(offline copy)` fork.
+- **Phase 5 — Offline support + IDB cache**: Debounced IDB cache in synced mode, offline fallback, push-or-fork reconnection logic.
 - **Phase 6 — Anonymous mode + polish**: Online/offline indicator, reconnection UX, user profile/settings, rate limiting, input validation.

--- a/packages/app/src/documents/reconnect.test.ts
+++ b/packages/app/src/documents/reconnect.test.ts
@@ -28,10 +28,12 @@ describe("reconcileOfflineEdits", () => {
     vi.unstubAllGlobals();
   });
 
-  it("skips reconnect without touching the network when the local snapshot matches the baseline", async () => {
+  it("skips the push-or-fork network round-trips when the local snapshot matches the baseline", async () => {
     const snapshot = createSnapshot("doc");
     const repository = {
-      get: vi.fn(),
+      get: vi.fn().mockResolvedValue({
+        meta: { id: "doc-id", title: "Foo", order: 1 },
+      }),
       save: vi.fn(),
     } as const;
 
@@ -47,12 +49,13 @@ describe("reconcileOfflineEdits", () => {
       repository: repository as never,
     });
 
-    expect(repository.get).not.toHaveBeenCalled();
+    expect(repository.get).toHaveBeenCalledWith("doc-id");
     expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+    expect(repository.save).not.toHaveBeenCalled();
     expect(result).toEqual({ action: "noop" });
   });
 
-  it("returns an error when the server document was deleted remotely", async () => {
+  it("returns an error when the server document was deleted remotely while offline edits are pending", async () => {
     const localSnapshot = createSnapshot("local");
     const repository = {
       get: vi.fn().mockResolvedValue(null),
@@ -65,6 +68,32 @@ describe("reconcileOfflineEdits", () => {
         baselineSnapshot: createSnapshot("baseline"),
         reconnectSnapshot: createSnapshot("reconnect"),
         hasPendingOfflineChanges: true,
+      },
+      snapshotVersion: 3,
+      repository: repository as never,
+    });
+
+    expect(repository.get).toHaveBeenCalledWith("doc-id");
+    expect(result).toEqual({
+      action: "error",
+      reason: "Document no longer exists on server",
+      reasonCode: "other",
+    });
+  });
+
+  it("returns an error when a remotely-deleted document has an unchanged local snapshot", async () => {
+    const snapshot = createSnapshot("doc");
+    const repository = {
+      get: vi.fn().mockResolvedValue(null),
+    } as const;
+
+    const result = await reconcileOfflineEdits({
+      documentId: "doc-id",
+      localSnapshot: snapshot,
+      recovery: {
+        baselineSnapshot: snapshot,
+        reconnectSnapshot: snapshot,
+        hasPendingOfflineChanges: false,
       },
       snapshotVersion: 3,
       repository: repository as never,

--- a/packages/app/src/documents/reconnect.test.ts
+++ b/packages/app/src/documents/reconnect.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TLStoreSnapshot } from "tldraw";
 import { reconcileOfflineEdits } from "./reconnect";
 
@@ -11,9 +11,49 @@ function createSnapshot(id: string): TLStoreSnapshot {
   } as unknown as TLStoreSnapshot;
 }
 
+function mockResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
 describe("reconcileOfflineEdits", () => {
-  it("returns an error when an unchanged offline document was deleted remotely", async () => {
-    const localSnapshot = createSnapshot("doc");
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("skips reconnect without touching the network when the local snapshot matches the baseline", async () => {
+    const snapshot = createSnapshot("doc");
+    const repository = {
+      get: vi.fn(),
+      save: vi.fn(),
+    } as const;
+
+    const result = await reconcileOfflineEdits({
+      documentId: "doc-id",
+      localSnapshot: snapshot,
+      recovery: {
+        baselineSnapshot: snapshot,
+        reconnectSnapshot: snapshot,
+        hasPendingOfflineChanges: false,
+      },
+      snapshotVersion: 3,
+      repository: repository as never,
+    });
+
+    expect(repository.get).not.toHaveBeenCalled();
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+    expect(result).toEqual({ action: "noop" });
+  });
+
+  it("returns an error when the server document was deleted remotely", async () => {
+    const localSnapshot = createSnapshot("local");
     const repository = {
       get: vi.fn().mockResolvedValue(null),
     } as const;
@@ -22,9 +62,9 @@ describe("reconcileOfflineEdits", () => {
       documentId: "doc-id",
       localSnapshot,
       recovery: {
-        baselineSnapshot: localSnapshot,
-        reconnectSnapshot: localSnapshot,
-        hasPendingOfflineChanges: false,
+        baselineSnapshot: createSnapshot("baseline"),
+        reconnectSnapshot: createSnapshot("reconnect"),
+        hasPendingOfflineChanges: true,
       },
       snapshotVersion: 3,
       repository: repository as never,
@@ -36,5 +76,115 @@ describe("reconcileOfflineEdits", () => {
       reason: "Document no longer exists on server",
       reasonCode: "other",
     });
+  });
+
+  it("returns noop when no pending offline changes exist and the server has diverged", async () => {
+    const local = createSnapshot("local");
+    const baseline = createSnapshot("baseline");
+    const server = createSnapshot("server-diverged");
+
+    const repository = {
+      get: vi.fn().mockResolvedValue({
+        meta: { id: "doc-id", title: "Foo", order: 1 },
+      }),
+      save: vi.fn(),
+    } as const;
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        mockResponse({ reason: "version-conflict", snapshotVersion: 10 }, 409),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({ snapshot: server, snapshotVersion: 10 }),
+      );
+
+    const result = await reconcileOfflineEdits({
+      documentId: "doc-id",
+      localSnapshot: local,
+      recovery: {
+        baselineSnapshot: baseline,
+        reconnectSnapshot: baseline,
+        hasPendingOfflineChanges: false,
+      },
+      snapshotVersion: 3,
+      repository: repository as never,
+    });
+
+    expect(result).toEqual({ action: "noop" });
+    expect(repository.save).not.toHaveBeenCalled();
+  });
+
+  it("forks when pending offline changes exist and the server has diverged", async () => {
+    const local = createSnapshot("local-edits");
+    const baseline = createSnapshot("baseline");
+    const server = createSnapshot("server-diverged");
+
+    const repository = {
+      get: vi.fn().mockResolvedValue({
+        meta: { id: "doc-id", title: "Foo", order: 1 },
+      }),
+      save: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn(),
+    } as const;
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        mockResponse({ reason: "version-conflict", snapshotVersion: 10 }, 409),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({ snapshot: server, snapshotVersion: 10 }),
+      )
+      .mockResolvedValueOnce(mockResponse({ ok: true }));
+
+    const result = await reconcileOfflineEdits({
+      documentId: "doc-id",
+      localSnapshot: local,
+      recovery: {
+        baselineSnapshot: baseline,
+        reconnectSnapshot: local,
+        hasPendingOfflineChanges: true,
+      },
+      snapshotVersion: 3,
+      repository: repository as never,
+    });
+
+    expect(result).toMatchObject({ action: "forked" });
+    expect(repository.save).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a stale-revision push without forking when the server still matches the baseline", async () => {
+    const local = createSnapshot("local");
+    const baseline = createSnapshot("baseline");
+
+    const repository = {
+      get: vi.fn().mockResolvedValue({
+        meta: { id: "doc-id", title: "Foo", order: 1 },
+      }),
+      save: vi.fn(),
+    } as const;
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        mockResponse({ reason: "version-conflict", snapshotVersion: 10 }, 409),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({ snapshot: baseline, snapshotVersion: 10 }),
+      )
+      .mockResolvedValueOnce(mockResponse({ ok: true }));
+
+    const result = await reconcileOfflineEdits({
+      documentId: "doc-id",
+      localSnapshot: local,
+      recovery: {
+        baselineSnapshot: baseline,
+        reconnectSnapshot: local,
+        hasPendingOfflineChanges: true,
+      },
+      snapshotVersion: 3,
+      repository: repository as never,
+    });
+
+    expect(result).toEqual({ action: "pushed" });
+    expect(repository.save).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/documents/reconnect.ts
+++ b/packages/app/src/documents/reconnect.ts
@@ -42,11 +42,9 @@ export async function reconcileOfflineEdits(params: {
   const { documentId, localSnapshot, recovery, snapshotVersion, repository } =
     params;
 
-  if (shouldSkipReconnect({ snapshot: localSnapshot, recovery })) {
-    return { action: "noop" };
-  }
-
   // Fetch current server metadata before deciding whether to fork on conflict.
+  // Running this before shouldSkipReconnect ensures a remotely-deleted document
+  // surfaces as an error instead of being silently treated as successful.
   const serverDoc = await repository.get(documentId);
   if (!serverDoc) {
     return {
@@ -54,6 +52,10 @@ export async function reconcileOfflineEdits(params: {
       reason: "Document no longer exists on server",
       reasonCode: "other",
     };
+  }
+
+  if (shouldSkipReconnect({ snapshot: localSnapshot, recovery })) {
+    return { action: "noop" };
   }
 
   // Try to push: the server endpoint rejects with 409 if the DO snapshot

--- a/packages/app/src/documents/reconnect.ts
+++ b/packages/app/src/documents/reconnect.ts
@@ -42,6 +42,10 @@ export async function reconcileOfflineEdits(params: {
   const { documentId, localSnapshot, recovery, snapshotVersion, repository } =
     params;
 
+  if (shouldSkipReconnect({ snapshot: localSnapshot, recovery })) {
+    return { action: "noop" };
+  }
+
   // Fetch current server metadata before deciding whether to fork on conflict.
   const serverDoc = await repository.get(documentId);
   if (!serverDoc) {
@@ -50,10 +54,6 @@ export async function reconcileOfflineEdits(params: {
       reason: "Document no longer exists on server",
       reasonCode: "other",
     };
-  }
-
-  if (shouldSkipReconnect({ snapshot: localSnapshot, recovery })) {
-    return { action: "noop" };
   }
 
   // Try to push: the server endpoint rejects with 409 if the DO snapshot
@@ -148,6 +148,12 @@ export async function reconcileOfflineEdits(params: {
     }
   } catch (error) {
     console.error("Failed to compare server snapshot after conflict:", error);
+  }
+
+  // No pending offline edits: let live sync pick up the server state instead
+  // of creating a redundant "(offline copy)" fork.
+  if (!recovery.hasPendingOfflineChanges) {
+    return { action: "noop" };
   }
 
   // Server has diverged — fork the local version as a new document.


### PR DESCRIPTION
## Summary

- Return `noop` instead of forking when a 409 `version-conflict` push fails and the local offline copy has no pending user edits — reconnecting with an untouched cache against a newer server document no longer creates a redundant `(offline copy)` fork.
- `shouldSkipReconnect` continues to run *after* the `repository.get` existence check so a remotely-deleted document still surfaces as an error rather than silently landing in a broken synced state.
- Closes the Phase 5 follow-up noted in `docs/TODO.md`.

## Test plan

- [x] `pnpm -F app exec vitest run documents` — 6 reconnect cases, 19 total, all green. New cases cover: no-pending + diverged server → noop, pending + diverged → forked (regression), stale-revision retry-push still wins, and remotely-deleted doc with unchanged local snapshot → error (not noop).
- [x] `pnpm -F app typecheck` — clean.
- [ ] Manual: synced doc online → devtools offline → close tab → edit the doc in a second tab → reopen the first tab online. Expect direct transition to synced with the second tab's state, no `(offline copy)` document created.
- [ ] Manual regression: while offline with an unchanged cached copy, delete the document from another session → come back online → first tab should surface the deleted-remotely error, not silently switch to synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)