### PR TITLE
feat(app): hold local and synced repositories simultaneously

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -9,10 +9,10 @@ import { AuthProvider, useAuth } from "./auth/AuthContext";
 
 function AuthenticatedApp() {
   const { user, loading: authLoading } = useAuth();
-  const synced = user !== null;
-  const repository = useMemo(
-    () => (synced ? new ApiDocumentRepository() : new IdbDocumentRepository()),
-    [synced],
+  const localRepository = useMemo(() => new IdbDocumentRepository(), []);
+  const syncedRepository = useMemo(
+    () => (user !== null ? new ApiDocumentRepository() : undefined),
+    [user],
   );
 
   if (authLoading) {
@@ -33,7 +33,10 @@ function AuthenticatedApp() {
           --tl-font-draw: Excalifont-Regular, '${xiaolai.css.family}', ${xiaolai.fontFamilyFallback}, 'tldraw_draw';
         }
       `}</style>
-      <DocumentManagerProvider repository={repository} synced={synced}>
+      <DocumentManagerProvider
+        localRepository={localRepository}
+        syncedRepository={syncedRepository}
+      >
         <AppContent />
       </DocumentManagerProvider>
     </>

--- a/packages/app/src/AppContent.tsx
+++ b/packages/app/src/AppContent.tsx
@@ -6,7 +6,7 @@ import { OfflineAwareSyncedContainer } from "./components/OfflineAwareSyncedCont
 import { useColorScheme } from "./hooks/useColorScheme";
 
 export function AppContent() {
-  const { activeDocumentId, activeSnapshot, loading, synced } =
+  const { activeDocument, activeSnapshot, loading } =
     useDocumentManagerContext();
 
   const { preference, changePreference } = useColorScheme();
@@ -24,17 +24,17 @@ export function AppContent() {
         />
       }
     >
-      {activeDocumentId &&
-        (synced ? (
+      {activeDocument &&
+        (activeDocument.origin === "synced" ? (
           <OfflineAwareSyncedContainer
-            key={activeDocumentId}
-            documentId={activeDocumentId}
+            key={activeDocument.id}
+            documentId={activeDocument.id}
             colorScheme={preference}
           />
         ) : (
           <AnipresContainer
-            key={activeDocumentId}
-            documentId={activeDocumentId}
+            key={activeDocument.id}
+            documentId={activeDocument.id}
             snapshot={activeSnapshot}
             colorScheme={preference}
           />

--- a/packages/app/src/components/DocumentSidebar.module.css
+++ b/packages/app/src/components/DocumentSidebar.module.css
@@ -66,6 +66,15 @@
   padding: 4px;
 }
 
+.groupHeader {
+  padding: 8px 6px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #888;
+}
+
 .toggleButton {
   position: absolute;
   top: 50px;
@@ -128,6 +137,10 @@
 
 :global([data-color-scheme="dark"]) .headerTitle {
   color: #999;
+}
+
+:global([data-color-scheme="dark"]) .groupHeader {
+  color: #888;
 }
 
 :global([data-color-scheme="dark"]) .newButton {

--- a/packages/app/src/components/DocumentSidebar.tsx
+++ b/packages/app/src/components/DocumentSidebar.tsx
@@ -6,9 +6,10 @@ import {
   PanelLeftClose,
   Plus,
 } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useAuth } from "../auth/AuthContext";
 import { useDocumentManagerContext } from "../documents/useDocumentManagerContext";
+import type { DocumentMeta } from "../documents/types";
 import type { ColorSchemePreference } from "../hooks/useColorScheme";
 import { ColorSchemeSwitcher } from "./ColorSchemeSwitcher";
 import { DocumentListItem } from "./DocumentListItem";
@@ -36,6 +37,17 @@ export function DocumentSidebar({
 
   const [collapsed, setCollapsed] = useState(false);
 
+  const { syncedDocs, localDocs } = useMemo(() => {
+    const synced: DocumentMeta[] = [];
+    const local: DocumentMeta[] = [];
+    for (const doc of documents) {
+      (doc.origin === "synced" ? synced : local).push(doc);
+    }
+    return { syncedDocs: synced, localDocs: local };
+  }, [documents]);
+
+  const showGroupHeaders = syncedDocs.length > 0 && localDocs.length > 0;
+
   if (collapsed) {
     return (
       <button
@@ -50,6 +62,18 @@ export function DocumentSidebar({
     );
   }
 
+  const renderGroup = (docs: DocumentMeta[]) =>
+    docs.map((doc) => (
+      <DocumentListItem
+        key={doc.id}
+        doc={doc}
+        isActive={doc.id === activeDocumentId}
+        onSelect={selectDocument}
+        onRename={renameDocument}
+        onDelete={deleteDocument}
+      />
+    ));
+
   return (
     <div className={styles.sidebar}>
       <div className={styles.header}>
@@ -58,7 +82,7 @@ export function DocumentSidebar({
           <button
             type="button"
             className={styles.newButton}
-            onClick={createDocument}
+            onClick={() => createDocument()}
           >
             <Plus size={14} /> New
           </button>
@@ -74,16 +98,14 @@ export function DocumentSidebar({
         </div>
       </div>
       <div className={styles.list}>
-        {documents.map((doc) => (
-          <DocumentListItem
-            key={doc.id}
-            doc={doc}
-            isActive={doc.id === activeDocumentId}
-            onSelect={selectDocument}
-            onRename={renameDocument}
-            onDelete={deleteDocument}
-          />
-        ))}
+        {showGroupHeaders && syncedDocs.length > 0 && (
+          <div className={styles.groupHeader}>Synced</div>
+        )}
+        {renderGroup(syncedDocs)}
+        {showGroupHeaders && localDocs.length > 0 && (
+          <div className={styles.groupHeader}>Local</div>
+        )}
+        {renderGroup(localDocs)}
       </div>
       <div className={styles.footer}>
         {user ? (

--- a/packages/app/src/documents/DocumentManagerContext.tsx
+++ b/packages/app/src/documents/DocumentManagerContext.tsx
@@ -4,15 +4,15 @@ import { useDocumentManager } from "./useDocumentManager";
 import { DocumentManagerContext } from "./useDocumentManagerContext";
 
 export function DocumentManagerProvider({
-  repository,
-  synced,
+  localRepository,
+  syncedRepository,
   children,
 }: {
-  repository: DocumentRepository;
-  synced?: boolean;
+  localRepository: DocumentRepository;
+  syncedRepository?: DocumentRepository;
   children: ReactNode;
 }) {
-  const manager = useDocumentManager(repository, { synced });
+  const manager = useDocumentManager({ localRepository, syncedRepository });
   return (
     <DocumentManagerContext.Provider value={manager}>
       {children}

--- a/packages/app/src/documents/api-repository.ts
+++ b/packages/app/src/documents/api-repository.ts
@@ -16,6 +16,7 @@ function rowToMeta(row: DocumentRow): DocumentMeta {
     order: row.order,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+    origin: "synced",
   };
 }
 

--- a/packages/app/src/documents/idb-repository.ts
+++ b/packages/app/src/documents/idb-repository.ts
@@ -4,14 +4,22 @@ import type { DocumentData, DocumentMeta } from "./types";
 
 const store = createStore("anipres-documents", "documents");
 
+function stampLocal(meta: DocumentMeta): DocumentMeta {
+  return { ...meta, origin: "local" };
+}
+
 export class IdbDocumentRepository implements DocumentRepository {
   async list(): Promise<DocumentMeta[]> {
     const all = await entries<string, DocumentData>(store);
-    return all.map(([, data]) => data.meta).sort((a, b) => a.order - b.order);
+    return all
+      .map(([, data]) => stampLocal(data.meta))
+      .sort((a, b) => a.order - b.order);
   }
 
   async get(id: string): Promise<DocumentData | undefined> {
-    return get<DocumentData>(id, store);
+    const data = await get<DocumentData>(id, store);
+    if (!data) return undefined;
+    return { ...data, meta: stampLocal(data.meta) };
   }
 
   async save(data: DocumentData): Promise<void> {

--- a/packages/app/src/documents/reconnect.ts
+++ b/packages/app/src/documents/reconnect.ts
@@ -172,6 +172,7 @@ export async function reconcileOfflineEdits(params: {
       createdAt: now,
       updatedAt: now,
       order: serverDoc.meta.order + 0.001,
+      origin: "synced",
     },
     snapshot: null,
   });

--- a/packages/app/src/documents/types.ts
+++ b/packages/app/src/documents/types.ts
@@ -1,11 +1,14 @@
 import type { TLStoreSnapshot } from "tldraw";
 
+export type DocumentOrigin = "local" | "synced";
+
 export interface DocumentMeta {
   id: string;
   title: string;
   createdAt: number;
   updatedAt: number;
   order: number;
+  origin: DocumentOrigin;
 }
 
 export interface DocumentData {

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -49,28 +49,41 @@ export function useDocumentManager(params: {
   const [loading, setLoading] = useState(true);
 
   const editorRef = useRef<Editor | null>(null);
-  const activeDocumentIdRef = useRef<string | null>(null);
-  useEffect(() => {
-    activeDocumentIdRef.current = activeDocumentId;
-  }, [activeDocumentId]);
 
-  // Keep a ref in sync with documents state so actions that run immediately
-  // after a refresh (e.g. selecting a freshly-forked doc) can resolve its
-  // repository before React commits the next render.
+  // Keep refs in sync with state via a pair of commit helpers so actions
+  // that run immediately after a state change (e.g. selecting a
+  // freshly-forked doc after refreshDocuments, or reading the active
+  // doc's origin from a store listener right after a doc switch) can see
+  // the updated values before React commits the next render.
   const documentsRef = useRef<DocumentMeta[]>(documents);
+  const activeDocumentIdRef = useRef<string | null>(null);
+  const activeDocumentOriginRef = useRef<DocumentOrigin | null>(null);
+
+  const syncActiveOriginRef = (
+    nextDocs: DocumentMeta[],
+    activeId: string | null,
+  ) => {
+    activeDocumentOriginRef.current = activeId
+      ? (nextDocs.find((d) => d.id === activeId)?.origin ?? null)
+      : null;
+  };
+
   const commitDocuments = useCallback((next: DocumentMeta[]) => {
     documentsRef.current = next;
+    syncActiveOriginRef(next, activeDocumentIdRef.current);
     setDocuments(next);
+  }, []);
+
+  const commitActiveDocumentId = useCallback((next: string | null) => {
+    activeDocumentIdRef.current = next;
+    syncActiveOriginRef(documentsRef.current, next);
+    setActiveDocumentId(next);
   }, []);
 
   const activeDocument = useMemo(
     () => documents.find((d) => d.id === activeDocumentId) ?? null,
     [documents, activeDocumentId],
   );
-  const activeDocumentOriginRef = useRef<DocumentOrigin | null>(null);
-  useEffect(() => {
-    activeDocumentOriginRef.current = activeDocument?.origin ?? null;
-  }, [activeDocument]);
 
   // Resolve which repository owns a given document id by consulting the
   // latest merged list. Falls back to the implicit "local only" repo when
@@ -152,7 +165,7 @@ export function useDocumentManager(params: {
         await repo.save(doc);
         if (cancelled) return;
         commitDocuments([doc.meta]);
-        setActiveDocumentId(doc.meta.id);
+        commitActiveDocumentId(doc.meta.id);
         setActiveSnapshot(null);
       } else {
         commitDocuments(metas);
@@ -160,7 +173,7 @@ export function useDocumentManager(params: {
         const repo = getRepository(firstMeta.origin);
         const data = repo ? await repo.get(firstMeta.id) : undefined;
         if (cancelled) return;
-        setActiveDocumentId(firstMeta.id);
+        commitActiveDocumentId(firstMeta.id);
         setActiveSnapshot(data?.snapshot ?? null);
       }
       setLoading(false);
@@ -168,7 +181,13 @@ export function useDocumentManager(params: {
     return () => {
       cancelled = true;
     };
-  }, [commitDocuments, getRepository, listAllDocuments, syncedRepository]);
+  }, [
+    commitActiveDocumentId,
+    commitDocuments,
+    getRepository,
+    listAllDocuments,
+    syncedRepository,
+  ]);
 
   const refreshDocuments = useCallback(async () => {
     const metas = await listAllDocuments();
@@ -189,10 +208,10 @@ export function useDocumentManager(params: {
       if (!data) return;
 
       editorRef.current = null;
-      setActiveDocumentId(id);
+      commitActiveDocumentId(id);
       setActiveSnapshot(data.snapshot);
     },
-    [findRepositoryForId, saveCurrentEditor],
+    [commitActiveDocumentId, findRepositoryForId, saveCurrentEditor],
   );
 
   const createDocument = useCallback(
@@ -205,18 +224,30 @@ export function useDocumentManager(params: {
       if (!repo) return;
 
       // Compute order against just this repo's docs so each group stays
-      // independently ordered.
-      const existing = await repo.list();
-      const maxOrder = existing.reduce((max, d) => Math.max(max, d.order), 0);
-      const doc = createNewDocument(maxOrder + 1, origin);
-      await repo.save(doc);
+      // independently ordered. Catch repository failures (e.g. synced
+      // server unreachable) so the button click doesn't end in an
+      // unhandled rejection with no user-visible change.
+      try {
+        const existing = await repo.list();
+        const maxOrder = existing.reduce((max, d) => Math.max(max, d.order), 0);
+        const doc = createNewDocument(maxOrder + 1, origin);
+        await repo.save(doc);
 
-      editorRef.current = null;
-      setActiveDocumentId(doc.meta.id);
-      setActiveSnapshot(null);
-      await refreshDocuments();
+        editorRef.current = null;
+        commitActiveDocumentId(doc.meta.id);
+        setActiveSnapshot(null);
+        await refreshDocuments();
+      } catch (error) {
+        console.error(`Failed to create ${origin} document`, error);
+      }
     },
-    [getRepository, refreshDocuments, saveCurrentEditor, syncedRepository],
+    [
+      commitActiveDocumentId,
+      getRepository,
+      refreshDocuments,
+      saveCurrentEditor,
+      syncedRepository,
+    ],
   );
 
   const deleteDocument = useCallback(
@@ -229,17 +260,41 @@ export function useDocumentManager(params: {
 
       if (remaining.length === 0) {
         // Create a new document if we deleted the last one; use the
-        // current default origin.
+        // current default origin. Fall back to local creation if the
+        // preferred (synced) save fails so the user is not left with an
+        // empty sidebar after a successful delete.
         const defaultOrigin: DocumentOrigin = syncedRepository
           ? "synced"
           : "local";
         const defaultRepo = getRepository(defaultOrigin);
         if (!defaultRepo) return;
         const doc = createNewDocument(1, defaultOrigin);
-        await defaultRepo.save(doc);
+        try {
+          await defaultRepo.save(doc);
+        } catch (error) {
+          console.error(
+            `Failed to create replacement ${defaultOrigin} document; falling back to local`,
+            error,
+          );
+          if (defaultOrigin === "synced") {
+            const localDoc = createNewDocument(1, "local");
+            try {
+              await localRepository.save(localDoc);
+              doc.meta = localDoc.meta;
+            } catch (localError) {
+              console.error(
+                "Failed to create replacement local document",
+                localError,
+              );
+              return;
+            }
+          } else {
+            return;
+          }
+        }
         commitDocuments([doc.meta]);
         editorRef.current = null;
-        setActiveDocumentId(doc.meta.id);
+        commitActiveDocumentId(doc.meta.id);
         setActiveSnapshot(null);
         return;
       }
@@ -252,15 +307,17 @@ export function useDocumentManager(params: {
         const nextRepo = getRepository(nextMeta.origin);
         const data = nextRepo ? await nextRepo.get(nextMeta.id) : undefined;
         editorRef.current = null;
-        setActiveDocumentId(nextMeta.id);
+        commitActiveDocumentId(nextMeta.id);
         setActiveSnapshot(data?.snapshot ?? null);
       }
     },
     [
+      commitActiveDocumentId,
       commitDocuments,
       findRepositoryForId,
       getRepository,
       listAllDocuments,
+      localRepository,
       syncedRepository,
     ],
   );

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -91,15 +91,19 @@ export function useDocumentManager(params: {
   );
 
   const listAllDocuments = useCallback(async (): Promise<DocumentMeta[]> => {
-    // Load both lists in parallel and tolerate a synced-list failure (e.g.
-    // server unavailable, offline after auth) by falling back to an empty
-    // synced group. A local-list failure still propagates because it means
-    // IndexedDB itself is broken, which the caller needs to know about.
+    // Load both lists in parallel. On synced-list failure (server down,
+    // offline after auth) fall back to the last known synced docs from
+    // documentsRef, so a transient failure during a post-operation
+    // refresh does not silently drop synced documents from the sidebar
+    // and unmount the active synced editor. On initial load the ref is
+    // still empty, so that case degrades to an empty synced group as
+    // before. A local-list failure still propagates because it signals
+    // an IndexedDB-level problem that the caller needs to surface.
     const [syncedList, localList] = await Promise.all([
       syncedRepository
         ? syncedRepository.list().catch((error) => {
             console.error("Failed to list synced documents", error);
-            return [] as DocumentMeta[];
+            return documentsRef.current.filter((d) => d.origin === "synced");
           })
         : Promise.resolve([] as DocumentMeta[]),
       localRepository.list(),

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -1,9 +1,12 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { getSnapshot, type Editor, type TLStoreSnapshot } from "tldraw";
 import type { DocumentRepository } from "./repository";
-import type { DocumentData, DocumentMeta } from "./types";
+import type { DocumentData, DocumentMeta, DocumentOrigin } from "./types";
 
-function createNewDocument(order: number): DocumentData {
+function createNewDocument(
+  order: number,
+  origin: DocumentOrigin,
+): DocumentData {
   return {
     meta: {
       id: crypto.randomUUID(),
@@ -11,6 +14,7 @@ function createNewDocument(order: number): DocumentData {
       createdAt: Date.now(),
       updatedAt: Date.now(),
       order,
+      origin,
     },
     snapshot: null,
   };
@@ -18,12 +22,12 @@ function createNewDocument(order: number): DocumentData {
 
 export interface DocumentManager {
   documents: DocumentMeta[];
+  activeDocument: DocumentMeta | null;
   activeDocumentId: string | null;
   activeSnapshot: TLStoreSnapshot | null;
   loading: boolean;
-  synced: boolean;
   selectDocument: (id: string) => Promise<void>;
-  createDocument: () => Promise<void>;
+  createDocument: (options?: { origin?: DocumentOrigin }) => Promise<void>;
   deleteDocument: (id: string) => Promise<void>;
   renameDocument: (id: string, title: string) => Promise<void>;
   reorderDocument: (id: string, newOrder: number) => Promise<void>;
@@ -31,11 +35,12 @@ export interface DocumentManager {
   refreshDocuments: () => Promise<void>;
 }
 
-export function useDocumentManager(
-  repository: DocumentRepository,
-  options?: { synced?: boolean },
-): DocumentManager {
-  const synced = options?.synced ?? false;
+export function useDocumentManager(params: {
+  localRepository: DocumentRepository;
+  syncedRepository?: DocumentRepository;
+}): DocumentManager {
+  const { localRepository, syncedRepository } = params;
+
   const [documents, setDocuments] = useState<DocumentMeta[]>([]);
   const [activeDocumentId, setActiveDocumentId] = useState<string | null>(null);
   const [activeSnapshot, setActiveSnapshot] = useState<TLStoreSnapshot | null>(
@@ -49,44 +54,96 @@ export function useDocumentManager(
     activeDocumentIdRef.current = activeDocumentId;
   }, [activeDocumentId]);
 
+  const documentsRef = useRef<DocumentMeta[]>(documents);
+  useEffect(() => {
+    documentsRef.current = documents;
+  }, [documents]);
+
+  const activeDocument = useMemo(
+    () => documents.find((d) => d.id === activeDocumentId) ?? null,
+    [documents, activeDocumentId],
+  );
+  const activeDocumentOriginRef = useRef<DocumentOrigin | null>(null);
+  useEffect(() => {
+    activeDocumentOriginRef.current = activeDocument?.origin ?? null;
+  }, [activeDocument]);
+
+  // Resolve which repository owns a given document id by consulting the
+  // latest merged list. Falls back to the implicit "local only" repo when
+  // called before the first load settles.
+  const getRepository = useCallback(
+    (origin: DocumentOrigin | undefined): DocumentRepository | null => {
+      if (origin === "synced") return syncedRepository ?? null;
+      return localRepository;
+    },
+    [localRepository, syncedRepository],
+  );
+  const findRepositoryForId = useCallback(
+    (id: string): DocumentRepository | null => {
+      const meta = documentsRef.current.find((d) => d.id === id);
+      return getRepository(meta?.origin);
+    },
+    [getRepository],
+  );
+
+  const listAllDocuments = useCallback(async (): Promise<DocumentMeta[]> => {
+    const syncedList = syncedRepository
+      ? await syncedRepository.list()
+      : ([] as DocumentMeta[]);
+    const localList = await localRepository.list();
+    // Synced first, then local. Each group is already ordered by `order`
+    // from its repository.
+    return [...syncedList, ...localList];
+  }, [localRepository, syncedRepository]);
+
   const saveCurrentEditor = useCallback(async () => {
-    if (synced) return;
+    // Only local-origin documents are persisted via this hook — synced
+    // documents are persisted by useSync over WebSocket.
+    if (activeDocumentOriginRef.current !== "local") return;
 
     const editor = editorRef.current;
     const docId = activeDocumentIdRef.current;
     if (!editor || !docId) return;
 
-    const existing = await repository.get(docId);
+    const existing = await localRepository.get(docId);
     if (!existing) return;
 
     const { document } = getSnapshot(editor.store);
-    await repository.save({
+    await localRepository.save({
       ...existing,
       meta: { ...existing.meta, updatedAt: Date.now() },
       snapshot: document,
     });
-  }, [repository, synced]);
+  }, [localRepository]);
 
   // Initialize: load documents or create first one
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const metas = await repository.list();
+      const metas = await listAllDocuments();
       if (cancelled) return;
 
       if (metas.length === 0) {
-        const doc = createNewDocument(1);
-        await repository.save(doc);
+        // Prefer creating the first document in the synced repo when the
+        // user is logged in; otherwise create it locally.
+        const defaultOrigin: DocumentOrigin = syncedRepository
+          ? "synced"
+          : "local";
+        const repo = getRepository(defaultOrigin);
+        if (!repo) return;
+        const doc = createNewDocument(1, defaultOrigin);
+        await repo.save(doc);
         if (cancelled) return;
         setDocuments([doc.meta]);
         setActiveDocumentId(doc.meta.id);
         setActiveSnapshot(null);
       } else {
         setDocuments(metas);
-        const firstId = metas[0].id;
-        const data = await repository.get(firstId);
+        const firstMeta = metas[0];
+        const repo = getRepository(firstMeta.origin);
+        const data = repo ? await repo.get(firstMeta.id) : undefined;
         if (cancelled) return;
-        setActiveDocumentId(firstId);
+        setActiveDocumentId(firstMeta.id);
         setActiveSnapshot(data?.snapshot ?? null);
       }
       setLoading(false);
@@ -94,12 +151,12 @@ export function useDocumentManager(
     return () => {
       cancelled = true;
     };
-  }, [repository]);
+  }, [getRepository, listAllDocuments, syncedRepository]);
 
   const refreshDocuments = useCallback(async () => {
-    const metas = await repository.list();
+    const metas = await listAllDocuments();
     setDocuments(metas);
-  }, [repository]);
+  }, [listAllDocuments]);
 
   const selectDocument = useCallback(
     async (id: string) => {
@@ -108,39 +165,61 @@ export function useDocumentManager(
       // Save current before switching
       await saveCurrentEditor();
 
-      const data = await repository.get(id);
+      const repo = findRepositoryForId(id);
+      if (!repo) return;
+
+      const data = await repo.get(id);
       if (!data) return;
 
       editorRef.current = null;
       setActiveDocumentId(id);
       setActiveSnapshot(data.snapshot);
     },
-    [repository, saveCurrentEditor],
+    [findRepositoryForId, saveCurrentEditor],
   );
 
-  const createDocument = useCallback(async () => {
-    await saveCurrentEditor();
+  const createDocument = useCallback(
+    async (options?: { origin?: DocumentOrigin }) => {
+      await saveCurrentEditor();
 
-    const metas = await repository.list();
-    const maxOrder = metas.reduce((max, d) => Math.max(max, d.order), 0);
-    const doc = createNewDocument(maxOrder + 1);
-    await repository.save(doc);
+      const origin: DocumentOrigin =
+        options?.origin ?? (syncedRepository ? "synced" : "local");
+      const repo = getRepository(origin);
+      if (!repo) return;
 
-    editorRef.current = null;
-    setActiveDocumentId(doc.meta.id);
-    setActiveSnapshot(null);
-    await refreshDocuments();
-  }, [repository, saveCurrentEditor, refreshDocuments]);
+      // Compute order against just this repo's docs so each group stays
+      // independently ordered.
+      const existing = await repo.list();
+      const maxOrder = existing.reduce((max, d) => Math.max(max, d.order), 0);
+      const doc = createNewDocument(maxOrder + 1, origin);
+      await repo.save(doc);
+
+      editorRef.current = null;
+      setActiveDocumentId(doc.meta.id);
+      setActiveSnapshot(null);
+      await refreshDocuments();
+    },
+    [getRepository, refreshDocuments, saveCurrentEditor, syncedRepository],
+  );
 
   const deleteDocument = useCallback(
     async (id: string) => {
-      await repository.delete(id);
-      const remaining = await repository.list();
+      const repo = findRepositoryForId(id);
+      if (!repo) return;
+
+      await repo.delete(id);
+      const remaining = await listAllDocuments();
 
       if (remaining.length === 0) {
-        // Create a new document if we deleted the last one
-        const doc = createNewDocument(1);
-        await repository.save(doc);
+        // Create a new document if we deleted the last one; use the
+        // current default origin.
+        const defaultOrigin: DocumentOrigin = syncedRepository
+          ? "synced"
+          : "local";
+        const defaultRepo = getRepository(defaultOrigin);
+        if (!defaultRepo) return;
+        const doc = createNewDocument(1, defaultOrigin);
+        await defaultRepo.save(doc);
         setDocuments([doc.meta]);
         editorRef.current = null;
         setActiveDocumentId(doc.meta.id);
@@ -152,14 +231,15 @@ export function useDocumentManager(
 
       if (id === activeDocumentIdRef.current) {
         // Switch to the first remaining document
-        const nextDoc = remaining[0];
-        const data = await repository.get(nextDoc.id);
+        const nextMeta = remaining[0];
+        const nextRepo = getRepository(nextMeta.origin);
+        const data = nextRepo ? await nextRepo.get(nextMeta.id) : undefined;
         editorRef.current = null;
-        setActiveDocumentId(nextDoc.id);
+        setActiveDocumentId(nextMeta.id);
         setActiveSnapshot(data?.snapshot ?? null);
       }
     },
-    [repository],
+    [findRepositoryForId, getRepository, listAllDocuments, syncedRepository],
   );
 
   const renameDocument = useCallback(
@@ -167,15 +247,17 @@ export function useDocumentManager(
       if (id === activeDocumentIdRef.current) {
         await saveCurrentEditor();
       }
-      const data = await repository.get(id);
+      const repo = findRepositoryForId(id);
+      if (!repo) return;
+      const data = await repo.get(id);
       if (!data) return;
-      await repository.save({
+      await repo.save({
         ...data,
         meta: { ...data.meta, title, updatedAt: Date.now() },
       });
       await refreshDocuments();
     },
-    [repository, refreshDocuments, saveCurrentEditor],
+    [findRepositoryForId, refreshDocuments, saveCurrentEditor],
   );
 
   const reorderDocument = useCallback(
@@ -183,31 +265,31 @@ export function useDocumentManager(
       if (id === activeDocumentIdRef.current) {
         await saveCurrentEditor();
       }
-      const data = await repository.get(id);
+      const repo = findRepositoryForId(id);
+      if (!repo) return;
+      const data = await repo.get(id);
       if (!data) return;
-      await repository.save({
+      await repo.save({
         ...data,
         meta: { ...data.meta, order: newOrder, updatedAt: Date.now() },
       });
       await refreshDocuments();
     },
-    [repository, refreshDocuments, saveCurrentEditor],
+    [findRepositoryForId, refreshDocuments, saveCurrentEditor],
   );
 
   const registerEditor = useCallback(
     (editor: Editor) => {
       editorRef.current = editor;
 
-      if (synced) {
-        return () => {
-          // No auto-save listener to clean up in synced mode
-        };
-      }
-
-      // Auto-save on user changes, debounced
+      // Synced documents are persisted by useSync; this auto-save path is
+      // only for local-origin docs. The check is re-evaluated on every
+      // store event below so switching the active doc takes effect without
+      // re-registering.
       let timer: ReturnType<typeof setTimeout> | undefined;
       const stopListening = editor.store.listen(
         () => {
+          if (activeDocumentOriginRef.current !== "local") return;
           clearTimeout(timer);
           timer = setTimeout(() => {
             saveCurrentEditor();
@@ -221,7 +303,7 @@ export function useDocumentManager(
         stopListening();
       };
     },
-    [saveCurrentEditor, synced],
+    [saveCurrentEditor],
   );
 
   // Best-effort save when the user leaves the page.
@@ -230,20 +312,21 @@ export function useDocumentManager(
   // navigation/close. None of these can await the async save, but firing it
   // initiates the IndexedDB transaction which browsers typically allow to
   // complete during page teardown.
-  // Skipped in synced mode — content is persisted by useSync.
+  // No-op for synced docs — content is persisted by useSync.
   useEffect(() => {
-    if (synced) return;
-
     const handleVisibilityChange = () => {
-      if (document.visibilityState === "hidden") {
+      if (
+        activeDocumentOriginRef.current === "local" &&
+        document.visibilityState === "hidden"
+      ) {
         saveCurrentEditor();
       }
     };
     const handlePageHide = () => {
-      saveCurrentEditor();
+      if (activeDocumentOriginRef.current === "local") saveCurrentEditor();
     };
     const handleBeforeUnload = () => {
-      saveCurrentEditor();
+      if (activeDocumentOriginRef.current === "local") saveCurrentEditor();
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
     window.addEventListener("pagehide", handlePageHide);
@@ -253,14 +336,14 @@ export function useDocumentManager(
       window.removeEventListener("pagehide", handlePageHide);
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
-  }, [saveCurrentEditor, synced]);
+  }, [saveCurrentEditor]);
 
   return {
     documents,
+    activeDocument,
     activeDocumentId,
     activeSnapshot,
     loading,
-    synced,
     selectDocument,
     createDocument,
     deleteDocument,

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -91,10 +91,19 @@ export function useDocumentManager(params: {
   );
 
   const listAllDocuments = useCallback(async (): Promise<DocumentMeta[]> => {
-    const syncedList = syncedRepository
-      ? await syncedRepository.list()
-      : ([] as DocumentMeta[]);
-    const localList = await localRepository.list();
+    // Load both lists in parallel and tolerate a synced-list failure (e.g.
+    // server unavailable, offline after auth) by falling back to an empty
+    // synced group. A local-list failure still propagates because it means
+    // IndexedDB itself is broken, which the caller needs to know about.
+    const [syncedList, localList] = await Promise.all([
+      syncedRepository
+        ? syncedRepository.list().catch((error) => {
+            console.error("Failed to list synced documents", error);
+            return [] as DocumentMeta[];
+          })
+        : Promise.resolve([] as DocumentMeta[]),
+      localRepository.list(),
+    ]);
     // Synced first, then local. Each group is already ordered by `order`
     // from its repository.
     return [...syncedList, ...localList];

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -54,10 +54,14 @@ export function useDocumentManager(params: {
     activeDocumentIdRef.current = activeDocumentId;
   }, [activeDocumentId]);
 
+  // Keep a ref in sync with documents state so actions that run immediately
+  // after a refresh (e.g. selecting a freshly-forked doc) can resolve its
+  // repository before React commits the next render.
   const documentsRef = useRef<DocumentMeta[]>(documents);
-  useEffect(() => {
-    documentsRef.current = documents;
-  }, [documents]);
+  const commitDocuments = useCallback((next: DocumentMeta[]) => {
+    documentsRef.current = next;
+    setDocuments(next);
+  }, []);
 
   const activeDocument = useMemo(
     () => documents.find((d) => d.id === activeDocumentId) ?? null,
@@ -134,11 +138,11 @@ export function useDocumentManager(params: {
         const doc = createNewDocument(1, defaultOrigin);
         await repo.save(doc);
         if (cancelled) return;
-        setDocuments([doc.meta]);
+        commitDocuments([doc.meta]);
         setActiveDocumentId(doc.meta.id);
         setActiveSnapshot(null);
       } else {
-        setDocuments(metas);
+        commitDocuments(metas);
         const firstMeta = metas[0];
         const repo = getRepository(firstMeta.origin);
         const data = repo ? await repo.get(firstMeta.id) : undefined;
@@ -151,12 +155,12 @@ export function useDocumentManager(params: {
     return () => {
       cancelled = true;
     };
-  }, [getRepository, listAllDocuments, syncedRepository]);
+  }, [commitDocuments, getRepository, listAllDocuments, syncedRepository]);
 
   const refreshDocuments = useCallback(async () => {
     const metas = await listAllDocuments();
-    setDocuments(metas);
-  }, [listAllDocuments]);
+    commitDocuments(metas);
+  }, [commitDocuments, listAllDocuments]);
 
   const selectDocument = useCallback(
     async (id: string) => {
@@ -220,14 +224,14 @@ export function useDocumentManager(params: {
         if (!defaultRepo) return;
         const doc = createNewDocument(1, defaultOrigin);
         await defaultRepo.save(doc);
-        setDocuments([doc.meta]);
+        commitDocuments([doc.meta]);
         editorRef.current = null;
         setActiveDocumentId(doc.meta.id);
         setActiveSnapshot(null);
         return;
       }
 
-      setDocuments(remaining);
+      commitDocuments(remaining);
 
       if (id === activeDocumentIdRef.current) {
         // Switch to the first remaining document
@@ -239,7 +243,13 @@ export function useDocumentManager(params: {
         setActiveSnapshot(data?.snapshot ?? null);
       }
     },
-    [findRepositoryForId, getRepository, listAllDocuments, syncedRepository],
+    [
+      commitDocuments,
+      findRepositoryForId,
+      getRepository,
+      listAllDocuments,
+      syncedRepository,
+    ],
   );
 
   const renameDocument = useCallback(


### PR DESCRIPTION
## Summary

- Keep both `IdbDocumentRepository` and `ApiDocumentRepository` active when the user is logged in instead of swapping one out for the other. Logging in no longer hides local IDB documents.
- `DocumentMeta` gains `origin: "local" | "synced"` stamped by each repo on `list()` / `get()`. The per-doc editor container (`AppContent.tsx`), auto-save path, and page-lifecycle listeners all branch on the active document's origin instead of a global `synced` flag.
- Sidebar groups docs under **Synced** / **Local** headers when both groups are non-empty; otherwise it stays flat to match today's look.
- First of two PRs for the dual-mode documents work. The follow-up will add a per-doc "Convert to synced" action that migrates inline data-URL assets to R2.

## Test plan

- [x] `pnpm -F app typecheck` — clean.
- [x] `pnpm -F app exec vitest run` — 19 existing tests still pass. Hook-level tests deferred: the app has no `@testing-library/react` / DOM env today, and pulling them in felt out of scope for this PR.
- [x] Logged out: create 2 local docs → flat sidebar, same as before.
- [x] Log in with pre-existing local docs → local docs stay visible under **Local**; server docs appear under **Synced**.
- [x] Create new doc when logged in → lands in the Synced group by default.
- [x] Switch between local and synced docs → correct container renders (`AnipresContainer` vs `OfflineAwareSyncedContainer`); auto-save only fires for local docs.
- [x] Delete a synced doc → the synced repo is hit; next doc auto-selected.
- [x] Log out while a synced doc is active → transitions back to a local doc (or a fresh empty one if none existed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)