### PR TITLE
feat(anipres): share MAX_ASSET_SIZE between client editor and worker

### DIFF
--- a/.changeset/shared-max-asset-size.md
+++ b/.changeset/shared-max-asset-size.md
@@ -1,0 +1,5 @@
+---
+"anipres": minor
+---
+
+Export `MAX_ASSET_SIZE` from `anipres/schema` and pass it through to the underlying `<Tldraw>` component as the `maxAssetSize` prop, so the editor rejects oversized files at drag/drop time with a friendly toast. The constant is shared with the anipres worker's asset upload endpoint to keep the client and server caps in sync.

--- a/packages/anipres/src/Anipres.tsx
+++ b/packages/anipres/src/Anipres.tsx
@@ -35,6 +35,7 @@ import type {
 } from "tldraw";
 import "tldraw/tldraw.css";
 
+import { MAX_ASSET_SIZE } from "./schema";
 import { SlideShapeType } from "./shapes/slide/SlideShape";
 import { SlideShapeTool } from "./shapes/slide/SlideShapeTool";
 import { ThemeImageShapeTool } from "./shapes/theme-image/ThemeImageShapeTool";
@@ -530,6 +531,7 @@ const Inner = (props: InnerProps) => {
       shapeUtils={customShapeUtils}
       tools={customTools}
       getShapeVisibility={determineShapeVisibility}
+      maxAssetSize={MAX_ASSET_SIZE}
       options={{
         maxPages: 1,
       }}

--- a/packages/anipres/src/schema.ts
+++ b/packages/anipres/src/schema.ts
@@ -1,7 +1,8 @@
 // This file is a separate ESM entry point ("anipres/schema") that only
-// re-exports pure-TS shape props and type constants — no React, no ShapeUtils.
-// This allows non-React consumers like the Cloudflare Worker to import shape
-// schemas without pulling in the React component tree from the main entry.
+// exposes pure-TS shape props, type constants, and shared policy values
+// used by both the client and server — no React, no ShapeUtils. This
+// allows non-React consumers like the Cloudflare Worker to import them
+// without pulling in the React component tree from the main entry.
 export { slideShapeProps, SlideShapeType } from "./shapes/slide/SlideShape.ts";
 export {
   themeImageShapeProps,

--- a/packages/anipres/src/schema.ts
+++ b/packages/anipres/src/schema.ts
@@ -7,3 +7,16 @@ export {
   themeImageShapeProps,
   ThemeImageShapeType,
 } from "./shapes/theme-image/ThemeImageShape.ts";
+
+/**
+ * Maximum size in bytes for a single uploaded asset (image or video).
+ *
+ * Used by both the client (passed to tldraw as `maxAssetSize` on
+ * `<Tldraw>` so the editor rejects oversized files at drag/drop time)
+ * and the anipres worker (as the cap for `POST /api/documents/:id/assets`).
+ *
+ * Keeping the constant in this shared non-React module ensures the two
+ * sides stay in sync — a bump on one side would require a bump here
+ * first, and the worker's typecheck would catch drift.
+ */
+export const MAX_ASSET_SIZE = 10 * 1024 * 1024;

--- a/packages/worker/src/assets.ts
+++ b/packages/worker/src/assets.ts
@@ -1,5 +1,9 @@
 import type { Hono } from "hono";
 import * as v from "valibot";
+// Single source of truth for the per-asset size cap, shared with the
+// client (passed into tldraw's `maxAssetSize` prop via the Anipres
+// component) so the two sides cannot drift.
+import { MAX_ASSET_SIZE } from "anipres/schema";
 import type { AppBindings, AppContext } from "./types";
 
 const SUPPORTED_ASSET_CONTENT_TYPES = [
@@ -31,7 +35,6 @@ const ASSET_EXTENSION_BY_CONTENT_TYPE = {
   string
 >;
 
-const MAX_ASSET_SIZE = 10 * 1024 * 1024; // 10 MB
 const MAX_ASSET_MULTIPART_OVERHEAD = 256 * 1024; // 256 KB
 const MAX_ASSET_REQUEST_BODY_SIZE =
   MAX_ASSET_SIZE + MAX_ASSET_MULTIPART_OVERHEAD;


### PR DESCRIPTION
## Summary

- tldraw ships a built-in client-side asset-size guard (default `DEFAULT_MAX_ASSET_SIZE = 10 MB`, configurable via the `maxAssetSize` prop on `<Tldraw>`). The anipres worker also caps `POST /api/documents/:id/assets` at 10 MB. Today these two constants are defined independently and could drift — a bump on one side would silently let files through one gate and not the other.
- Exports a single `MAX_ASSET_SIZE` constant from `anipres/schema` (the shared non-React entry the worker already consumes for shape schemas), passes it into tldraw via `maxAssetSize` in the Anipres component, and has the worker import it instead of defining a local literal.
- Future bumps update both sides automatically, and the worker's typecheck fails if the export is ever removed.

## Test plan

- [x] `pnpm -F anipres typecheck` clean; `pnpm -F anipres build` produces `dist/schema.{js,d.ts}` exporting `MAX_ASSET_SIZE`.
- [x] `pnpm -F anipres-worker typecheck` clean (imports from `anipres/schema`).
- [x] `pnpm -F app typecheck` clean.
- [x] `pnpm -F anipres exec vitest run` — 21 tests pass.
- [x] `pnpm -F app exec vitest run` — 48 tests pass.
- [x] Lint + format clean across all three packages.
- [ ] Manual: try dragging a >10 MB image into the editor — tldraw's toast *"File size is too big"* appears and the upload is rejected before reaching the server.
- [ ] Manual: confirm a normal image (<10 MB) drag still uploads cleanly.

## Notes

- Branch is based on `feature/sync-server` *before* the unmerged PR #432 (convert-progress-ux). The packages touched here don't overlap with #432's scope, so no conflicts expected after both merge — but worth a quick rebase check.
- Ships a minor version bump for `anipres` via a new changeset entry (`MAX_ASSET_SIZE` is a new public export on the `/schema` subpath).

🤖 Generated with [Claude Code](https://claude.com/claude-code)