### PR TITLE
fix(app): clear stale convert-to-synced state on delete and logout

### DIFF
--- a/packages/app/src/documents/migration.ts
+++ b/packages/app/src/documents/migration.ts
@@ -215,6 +215,15 @@ export async function convertLocalDocToSynced(
 
   // Compute an order value against the synced repo so the migrated doc
   // does not collide with an existing server doc's order.
+  //
+  // Known limitation: when multiple convertLocalDocToSynced calls run
+  // in parallel they can each read the same maxOrder and write the
+  // same order+1 to their respective new docs. The sidebar's stable
+  // sort still shows both, just in a non-deterministic order between
+  // them, and any user reorder heals the collision. Fixing this cleanly
+  // would require threading an atomic allocator through this function
+  // — deliberately deferred until convert-to-synced is commonly used
+  // with enough docs for the cosmetic ambiguity to matter.
   const syncedList = await syncedRepository.list();
   const maxOrder = syncedList.reduce((max, d) => Math.max(max, d.order), 0);
 

--- a/packages/app/src/documents/useDocumentManager.test.tsx
+++ b/packages/app/src/documents/useDocumentManager.test.tsx
@@ -516,6 +516,78 @@ describe("useDocumentManager", () => {
     expect(result.current.activeDocument?.origin).toBe("synced");
   });
 
+  it("clears conversionErrors for a doc when it is deleted", async () => {
+    const localRepo = makeFakeRepo("local", [
+      makeLocalDocWithSnapshot("doc-1"),
+      makeLocalDocWithSnapshot("doc-2"),
+    ]);
+    const syncedRepo = makeFakeRepo("synced");
+
+    const pushSnapshot = vi
+      .fn<(documentId: string, snapshot: TLStoreSnapshot) => Promise<void>>()
+      .mockRejectedValue(new Error("Snapshot push failed: 500"));
+    const uploadAsset = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDocumentManager({
+        localRepository: localRepo.repo,
+        syncedRepository: syncedRepo.repo,
+        migrationOverrides: { uploadAsset, pushSnapshot },
+      }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.convertToSynced("doc-1");
+    });
+    expect(result.current.conversionErrors.has("doc-1")).toBe(true);
+
+    await act(async () => {
+      await result.current.deleteDocument("doc-1");
+    });
+
+    expect(result.current.conversionErrors.has("doc-1")).toBe(false);
+  });
+
+  it("resets converting and conversionErrors when the synced repository identity changes (logout)", async () => {
+    const localRepo = makeFakeRepo("local", [
+      makeLocalDocWithSnapshot("doc-1"),
+    ]);
+    const syncedRepo = makeFakeRepo("synced");
+
+    const pushSnapshot = vi
+      .fn<(documentId: string, snapshot: TLStoreSnapshot) => Promise<void>>()
+      .mockRejectedValue(new Error("Snapshot push failed: 500"));
+    const uploadAsset = vi.fn();
+
+    const initialProps: {
+      syncedRepository: DocumentRepository | undefined;
+    } = { syncedRepository: syncedRepo.repo };
+    const { result, rerender } = renderHook(
+      (props: { syncedRepository: DocumentRepository | undefined }) =>
+        useDocumentManager({
+          localRepository: localRepo.repo,
+          syncedRepository: props.syncedRepository,
+          migrationOverrides: { uploadAsset, pushSnapshot },
+        }),
+      { initialProps },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.convertToSynced("doc-1");
+    });
+    expect(result.current.conversionErrors.has("doc-1")).toBe(true);
+
+    // Simulate a logout by swapping syncedRepository to undefined.
+    rerender({ syncedRepository: undefined });
+
+    await waitFor(() => expect(result.current.conversionErrors.size).toBe(0));
+    expect(result.current.converting.size).toBe(0);
+  });
+
   it("convertToSynced is a no-op when no synced repository is configured", async () => {
     const localRepo = makeFakeRepo("local", [makeDoc("doc-1", 1, "local")]);
 

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -228,6 +228,21 @@ export function useDocumentManager(params: {
     commitDocuments(metas);
   }, [commitDocuments, listAllDocuments]);
 
+  // When the syncedRepository identity changes — login, logout, or a
+  // logout-then-login cycle — any in-flight migration state is about to
+  // become meaningless. Reset so no row inherits a ghost spinner or
+  // stale error from the prior repository pair.
+  const prevSyncedRepoRef = useRef<DocumentRepository | undefined>(
+    syncedRepository,
+  );
+  useEffect(() => {
+    if (prevSyncedRepoRef.current === syncedRepository) return;
+    prevSyncedRepoRef.current = syncedRepository;
+    convertingRef.current = new Set();
+    setConverting(new Set());
+    setConversionErrors(new Map());
+  }, [syncedRepository]);
+
   const selectDocument = useCallback(
     async (id: string) => {
       if (id === activeDocumentIdRef.current) return;
@@ -290,6 +305,25 @@ export function useDocumentManager(params: {
       if (!repo) return;
 
       await repo.delete(id);
+
+      // Drop any stale convert-to-synced state for this id. An entry in
+      // conversionErrors would otherwise linger in memory with no row to
+      // render against; an in-flight converting entry (possible only if
+      // delete races a migration) is abandoned intentionally — the
+      // migration will still try to complete but its id is already gone.
+      setConversionErrors((prev) => {
+        if (!prev.has(id)) return prev;
+        const next = new Map(prev);
+        next.delete(id);
+        return next;
+      });
+      if (convertingRef.current.has(id)) {
+        const next = new Set(convertingRef.current);
+        next.delete(id);
+        convertingRef.current = next;
+        setConverting(next);
+      }
+
       const remaining = await listAllDocuments();
 
       if (remaining.length === 0) {


### PR DESCRIPTION
## Summary

Addresses two state-lifecycle follow-ups surfaced during PR #432 review that were never actioned:

- **Delete clears the doc's entry.** When a document is deleted, drop any `conversionErrors.get(id)` entry for it and remove the id from `converting` if it is present. Previously the entry lingered in the hook's memory pointing to a ghost id — invisible (no row to render against) but sticky.
- **Logout resets migration state.** When `syncedRepository` identity changes (login, logout, or a logout-then-login cycle), reset both `converting` and `conversionErrors`. Previously these would carry over from the prior session and could surface on a newly-rendered row that happened to share an id. Uses a `prevSyncedRepoRef` pattern so the reset runs on actual repository changes, not on the initial mount, avoiding an unnecessary re-render at startup.
- **Design comment on parallel-order collision.** Documents the deliberately-deferred order-allocation design choice as an inline comment in `convertLocalDocToSynced`. The collision is cosmetic — sidebar's stable sort resolves ties, any user reorder heals it — and fixing cleanly requires threading an atomic allocator through the function, which is not worth the API churn until the migration flow sees enough real use for the ambiguity to matter.

No public-API change. No behavioral change on the happy path.

## Test plan

- [x] `pnpm -F app typecheck` — clean.
- [x] `pnpm -F app exec vitest run` — 56 tests across 5 files pass (2 new `renderHook` cases: delete-clears-error and logout-resets-state).
- [x] `pnpm -F app lint` — clean (four pre-existing warnings in files this PR does not touch).
- [x] `pnpm -F app format --check` — clean.
- [ ] Manual: trigger a convert failure on a local doc (throttle network or seed >10 MB asset), see the red error state on the row, click the **X** delete button, confirm the row disappears and no stale state lingers.
- [ ] Manual: trigger a convert failure as above, then log out — confirm the local doc comes back under **Local** with no spinner or error icon on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)