### PR TITLE
fix(app): abort in-flight convert-to-synced when the doc is deleted

### DIFF
--- a/packages/app/src/documents/migration.test.ts
+++ b/packages/app/src/documents/migration.test.ts
@@ -370,6 +370,66 @@ describe("convertLocalDocToSynced", () => {
     expect(syncedRepo.save).not.toHaveBeenCalled();
   });
 
+  it("throws immediately without touching the repos when the abortSignal is already aborted", async () => {
+    const snapshot = snapshotWith({});
+    const localRepo = makeFakeRepo("local", [makeLocalDoc("doc-1", snapshot)]);
+    const syncedRepo = makeFakeRepo("synced");
+    const uploadAsset = vi.fn();
+    const pushSnapshot = vi.fn();
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      convertLocalDocToSynced({
+        documentId: "doc-1",
+        localRepository: localRepo.repo,
+        syncedRepository: syncedRepo.repo,
+        uploadAsset,
+        pushSnapshot,
+        abortSignal: controller.signal,
+      }),
+    ).rejects.toThrow();
+
+    expect(localRepo.get).not.toHaveBeenCalled();
+    expect(syncedRepo.save).not.toHaveBeenCalled();
+    expect(uploadAsset).not.toHaveBeenCalled();
+    expect(pushSnapshot).not.toHaveBeenCalled();
+    expect(localRepo.delete).not.toHaveBeenCalled();
+  });
+
+  it("aborts mid-migration when the abortSignal fires after the synced save", async () => {
+    const snapshot = snapshotWith({});
+    const localRepo = makeFakeRepo("local", [makeLocalDoc("doc-1", snapshot)]);
+    const syncedRepo = makeFakeRepo("synced");
+
+    const controller = new AbortController();
+    // Abort mid-migration, right after syncedRepository.save runs.
+    syncedRepo.repo.save = vi.fn(async (d: DocumentData) => {
+      syncedRepo.store.set(d.meta.id, d);
+      controller.abort();
+    });
+
+    const pushSnapshot = vi.fn();
+
+    await expect(
+      convertLocalDocToSynced({
+        documentId: "doc-1",
+        localRepository: localRepo.repo,
+        syncedRepository: syncedRepo.repo,
+        uploadAsset: vi.fn(),
+        pushSnapshot,
+        abortSignal: controller.signal,
+      }),
+    ).rejects.toThrow();
+
+    // Metadata save completed before the abort; the later snapshot push
+    // was skipped and local copy was not deleted.
+    expect(syncedRepo.repo.save).toHaveBeenCalledTimes(1);
+    expect(pushSnapshot).not.toHaveBeenCalled();
+    expect(localRepo.delete).not.toHaveBeenCalled();
+  });
+
   it("throws when the document is already synced", async () => {
     const syncedDoc: DocumentData = {
       ...makeLocalDoc("doc-1"),

--- a/packages/app/src/documents/migration.ts
+++ b/packages/app/src/documents/migration.ts
@@ -121,9 +121,17 @@ export async function uploadAssetDataUrls(
 // surface as a visible failure rather than an indefinite spinner.
 const MIGRATION_FETCH_TIMEOUT_MS = 60_000;
 
+function composeWithTimeout(userSignal?: AbortSignal): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(MIGRATION_FETCH_TIMEOUT_MS);
+  return userSignal
+    ? AbortSignal.any([userSignal, timeoutSignal])
+    : timeoutSignal;
+}
+
 async function defaultUploadAsset(
   documentId: string,
   file: File,
+  abortSignal?: AbortSignal,
 ): Promise<{ src: string }> {
   const formData = new FormData();
   formData.append("file", file);
@@ -132,7 +140,7 @@ async function defaultUploadAsset(
     {
       method: "POST",
       body: formData,
-      signal: AbortSignal.timeout(MIGRATION_FETCH_TIMEOUT_MS),
+      signal: composeWithTimeout(abortSignal),
     },
   );
   if (!res.ok) {
@@ -144,6 +152,7 @@ async function defaultUploadAsset(
 async function defaultPushSnapshot(
   documentId: string,
   snapshot: TLStoreSnapshot,
+  abortSignal?: AbortSignal,
 ): Promise<void> {
   const res = await fetch(
     `/api/documents/${encodeURIComponent(documentId)}/snapshot`,
@@ -154,7 +163,7 @@ async function defaultPushSnapshot(
         snapshot,
         expectedSnapshotVersion: 0,
       }),
-      signal: AbortSignal.timeout(MIGRATION_FETCH_TIMEOUT_MS),
+      signal: composeWithTimeout(abortSignal),
     },
   );
   if (!res.ok) {
@@ -166,11 +175,23 @@ export interface ConvertLocalDocToSyncedParams {
   documentId: string;
   localRepository: DocumentRepository;
   syncedRepository: DocumentRepository;
-  uploadAsset?: (documentId: string, file: File) => Promise<{ src: string }>;
+  uploadAsset?: (
+    documentId: string,
+    file: File,
+    abortSignal?: AbortSignal,
+  ) => Promise<{ src: string }>;
   pushSnapshot?: (
     documentId: string,
     snapshot: TLStoreSnapshot,
+    abortSignal?: AbortSignal,
   ) => Promise<void>;
+  /**
+   * When provided, the migration checks the signal's aborted state at
+   * each between-step boundary and throws its `reason` (an AbortError
+   * by default). Fetch-backed steps also pass the signal through to
+   * the HTTP layer so in-flight requests cancel eagerly.
+   */
+  abortSignal?: AbortSignal;
 }
 
 /**
@@ -201,7 +222,10 @@ export async function convertLocalDocToSynced(
     syncedRepository,
     uploadAsset = defaultUploadAsset,
     pushSnapshot = defaultPushSnapshot,
+    abortSignal,
   } = params;
+
+  abortSignal?.throwIfAborted();
 
   const local = await localRepository.get(documentId);
   if (!local) {
@@ -212,6 +236,8 @@ export async function convertLocalDocToSynced(
       `Document ${documentId} is not a local document (origin: ${local.meta.origin})`,
     );
   }
+
+  abortSignal?.throwIfAborted();
 
   // Compute an order value against the synced repo so the migrated doc
   // does not collide with an existing server doc's order.
@@ -227,6 +253,8 @@ export async function convertLocalDocToSynced(
   const syncedList = await syncedRepository.list();
   const maxOrder = syncedList.reduce((max, d) => Math.max(max, d.order), 0);
 
+  abortSignal?.throwIfAborted();
+
   // createdAt is preserved from the local doc so migrated docs keep
   // their original creation time; only updatedAt advances.
   await syncedRepository.save({
@@ -240,11 +268,15 @@ export async function convertLocalDocToSynced(
   });
 
   if (local.snapshot) {
+    abortSignal?.throwIfAborted();
     const rewritten = await uploadAssetDataUrls(local.snapshot, (file) =>
-      uploadAsset(documentId, file),
+      uploadAsset(documentId, file, abortSignal),
     );
-    await pushSnapshot(documentId, rewritten);
+    abortSignal?.throwIfAborted();
+    await pushSnapshot(documentId, rewritten, abortSignal);
   }
+
+  abortSignal?.throwIfAborted();
 
   await localRepository.delete(documentId);
 }

--- a/packages/app/src/documents/useDocumentManager.test.tsx
+++ b/packages/app/src/documents/useDocumentManager.test.tsx
@@ -550,6 +550,82 @@ describe("useDocumentManager", () => {
     expect(result.current.conversionErrors.has("doc-1")).toBe(false);
   });
 
+  it("aborts an in-flight migration and cleans up synced metadata when the doc is deleted", async () => {
+    const localRepo = makeFakeRepo("local", [
+      makeLocalDocWithSnapshot("doc-1"),
+      makeLocalDocWithSnapshot("doc-2"),
+    ]);
+    const syncedRepo = makeFakeRepo("synced");
+
+    let resolvePush!: () => void;
+    const pushPromise = new Promise<void>((resolve) => {
+      resolvePush = resolve;
+    });
+    const pushSnapshot = vi
+      .fn<
+        (
+          documentId: string,
+          snapshot: TLStoreSnapshot,
+          abortSignal?: AbortSignal,
+        ) => Promise<void>
+      >()
+      .mockImplementation(
+        (_docId, _snap, abortSignal) =>
+          new Promise<void>((resolve, reject) => {
+            // Reject with an AbortError if/when the signal fires.
+            abortSignal?.addEventListener("abort", () =>
+              reject(new DOMException("Aborted via test signal", "AbortError")),
+            );
+            // Otherwise wait for the explicit resolve.
+            pushPromise.then(resolve, reject);
+          }),
+      );
+    const uploadAsset = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDocumentManager({
+        localRepository: localRepo.repo,
+        syncedRepository: syncedRepo.repo,
+        migrationOverrides: { uploadAsset, pushSnapshot },
+      }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let convertPromise!: Promise<void>;
+    act(() => {
+      convertPromise = result.current.convertToSynced("doc-1");
+    });
+
+    // Wait until the synced metadata save has landed so we know the
+    // deletion has something to clean up.
+    await waitFor(() => {
+      expect(result.current.converting.has("doc-1")).toBe(true);
+      expect(syncedRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      await result.current.deleteDocument("doc-1");
+      await convertPromise;
+    });
+
+    // The aborted migration should not have surfaced as an error and
+    // the in-flight state is gone.
+    expect(result.current.converting.has("doc-1")).toBe(false);
+    expect(result.current.conversionErrors.has("doc-1")).toBe(false);
+
+    // The orphan synced metadata that the aborted migration left behind
+    // was cleaned up by deleteDocument.
+    expect(syncedRepo.delete).toHaveBeenCalledWith("doc-1");
+    expect(syncedRepo.store.has("doc-1")).toBe(false);
+
+    // doc-1 is gone, doc-2 remains active.
+    expect(result.current.documents.map((d) => d.id)).toEqual(["doc-2"]);
+
+    // Drain the mocked push so no pending promise leaks between tests.
+    resolvePush();
+  });
+
   it("resets converting and conversionErrors when the synced repository identity changes (logout)", async () => {
     const localRepo = makeFakeRepo("local", [
       makeLocalDocWithSnapshot("doc-1"),
@@ -561,6 +637,11 @@ describe("useDocumentManager", () => {
       .mockRejectedValue(new Error("Snapshot push failed: 500"));
     const uploadAsset = vi.fn();
 
+    // The explicit type annotation widens `initialProps.syncedRepository`
+    // to `DocumentRepository | undefined`; without it, renderHook's
+    // generic inference narrows Props to `DocumentRepository` based on
+    // the concrete initial value and the later `rerender(undefined)`
+    // call would be a TS error.
     const initialProps: {
       syncedRepository: DocumentRepository | undefined;
     } = { syncedRepository: syncedRepo.repo };
@@ -586,6 +667,51 @@ describe("useDocumentManager", () => {
 
     await waitFor(() => expect(result.current.conversionErrors.size).toBe(0));
     expect(result.current.converting.size).toBe(0);
+  });
+
+  it("resets migration state across a logout → login cycle", async () => {
+    const localRepo = makeFakeRepo("local", [
+      makeLocalDocWithSnapshot("doc-1"),
+    ]);
+    const syncedRepo = makeFakeRepo("synced");
+
+    const pushSnapshot = vi
+      .fn<(documentId: string, snapshot: TLStoreSnapshot) => Promise<void>>()
+      .mockRejectedValue(new Error("Snapshot push failed: 500"));
+    const uploadAsset = vi.fn();
+
+    const initialProps: {
+      syncedRepository: DocumentRepository | undefined;
+    } = { syncedRepository: syncedRepo.repo };
+    const { result, rerender } = renderHook(
+      (props: { syncedRepository: DocumentRepository | undefined }) =>
+        useDocumentManager({
+          localRepository: localRepo.repo,
+          syncedRepository: props.syncedRepository,
+          migrationOverrides: { uploadAsset, pushSnapshot },
+        }),
+      { initialProps },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Seed an error while logged in.
+    await act(async () => {
+      await result.current.convertToSynced("doc-1");
+    });
+    expect(result.current.conversionErrors.has("doc-1")).toBe(true);
+
+    // Logout clears state.
+    rerender({ syncedRepository: undefined });
+    await waitFor(() => expect(result.current.conversionErrors.size).toBe(0));
+
+    // Login again with the same repo identity — the reset effect fires
+    // on every repo change, so the state must stay clean. This is the
+    // symmetric counterpart to the logout test above.
+    rerender({ syncedRepository: syncedRepo.repo });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.converting.size).toBe(0);
+    expect(result.current.conversionErrors.size).toBe(0);
   });
 
   it("convertToSynced is a no-op when no synced repository is configured", async () => {

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -83,6 +83,12 @@ export function useDocumentManager(params: {
   // so a per-id gate can reject a second call on the same doc without the
   // stale-closure trap of reading React state.
   const convertingRef = useRef<ReadonlySet<string>>(converting);
+  // AbortController per in-flight convert-to-synced migration. Populated
+  // in convertToSynced, consumed by deleteDocument to cancel a migration
+  // when the local doc it is operating on is deleted mid-flight.
+  const migrationAbortControllersRef = useRef<Map<string, AbortController>>(
+    new Map(),
+  );
 
   // Keep refs in sync with state via a pair of commit helpers so actions
   // that run immediately after a state change (e.g. selecting a
@@ -304,13 +310,40 @@ export function useDocumentManager(params: {
       const repo = findRepositoryForId(id);
       if (!repo) return;
 
+      // Cancel any in-flight convert-to-synced migration for this id
+      // before touching storage. The migration's catch handler will see
+      // controller.signal.aborted and exit silently; its half-done state
+      // is cleaned up below.
+      const migrationController = migrationAbortControllersRef.current.get(id);
+      const wasMigrating = migrationController !== undefined;
+      if (migrationController) {
+        migrationController.abort();
+        migrationAbortControllersRef.current.delete(id);
+      }
+
       await repo.delete(id);
+
+      // If the migration had already persisted metadata to the synced
+      // repo before we aborted (step 2 of convertLocalDocToSynced), a
+      // ghost synced copy of the deleted doc would otherwise appear on
+      // the next refresh. Best-effort cleanup — a 404 is fine, it just
+      // means the migration hadn't reached that step yet.
+      if (wasMigrating && syncedRepository) {
+        try {
+          await syncedRepository.delete(id);
+        } catch (error) {
+          console.error(
+            `Failed to clean up synced metadata after aborting migration of ${id}`,
+            error,
+          );
+        }
+      }
 
       // Drop any stale convert-to-synced state for this id. An entry in
       // conversionErrors would otherwise linger in memory with no row to
-      // render against; an in-flight converting entry (possible only if
-      // delete races a migration) is abandoned intentionally — the
-      // migration will still try to complete but its id is already gone.
+      // render against; an in-flight converting entry is also removed
+      // immediately so the spinner disappears without waiting for the
+      // migration to respond to the abort.
       setConversionErrors((prev) => {
         if (!prev.has(id)) return prev;
         const next = new Map(prev);
@@ -463,7 +496,13 @@ export function useDocumentManager(params: {
         return next;
       });
 
+      // Register an AbortController for this migration so deleteDocument
+      // can cancel it if the user deletes the doc mid-flight.
+      const controller = new AbortController();
+      migrationAbortControllersRef.current.set(id, controller);
+
       const clearInFlight = () => {
+        migrationAbortControllersRef.current.delete(id);
         const next = new Set(convertingRef.current);
         next.delete(id);
         convertingRef.current = next;
@@ -476,10 +515,18 @@ export function useDocumentManager(params: {
           localRepository,
           syncedRepository,
           ...migrationOverrides,
+          abortSignal: controller.signal,
         });
       } catch (error) {
-        console.error("Failed to convert document to synced", error);
         clearInFlight();
+        if (controller.signal.aborted) {
+          // The migration was cancelled from deleteDocument. That path
+          // has already run its own cleanup (local delete, synced
+          // metadata cleanup, listAllDocuments), so don't double-log,
+          // surface an error, or refresh again.
+          return;
+        }
+        console.error("Failed to convert document to synced", error);
         setConversionErrors((prev) => {
           const next = new Map(prev);
           next.set(


### PR DESCRIPTION
## Summary

Previously, if a user clicked **Upload to cloud** on a local doc and then clicked **Delete** before the migration finished, `repo.delete(id)` removed the local copy but any synced metadata already persisted by step 2 of `convertLocalDocToSynced` survived. When the migration's `refreshDocuments()` landed, a ghost synced version of the deleted doc appeared in the sidebar — surprising the user who had just deleted it.

Thread an `AbortSignal` end-to-end through the migration:

- **`migration.ts`** — `ConvertLocalDocToSyncedParams` gains an optional `abortSignal`. The function calls `throwIfAborted()` at each between-step boundary, and the default fetch helpers compose it with the existing 60s timeout via `AbortSignal.any` so in-flight HTTP cancels eagerly. Custom `uploadAsset` / `pushSnapshot` callback signatures gain an optional signal parameter too.
- **`useDocumentManager`** — tracks one `AbortController` per in-flight migration in `migrationAbortControllersRef`. `convertToSynced` creates a controller, passes its signal through, and in the catch branch checks `controller.signal.aborted` — if set, the error was the user's own cancellation and is not logged or surfaced as `conversionErrors`.
- **`deleteDocument`** — looks up the controller for the id being deleted, aborts it before `repo.delete` runs, and follows with a best-effort `syncedRepository.delete(id)` to clean up any orphan metadata the migration may have already persisted. A 404 from that cleanup is fine — it just means the migration hadn't reached step 2 yet.

### Drive-bys

- Symmetric logout → login cycle reset test, covering the repo-identity-change effect in both directions.
- One-line comment above the `initialProps` type-widening in the logout test explaining the `renderHook` generic-inference quirk.

## Test plan

- [x] `pnpm -F app typecheck` — clean.
- [x] `pnpm -F app exec vitest run` — 60 tests across 5 files pass (+4 new: two migration-level abort cases, two hook-level integration cases).
- [x] `pnpm -F app lint` — clean (four pre-existing warnings in files this PR does not touch).
- [x] `pnpm -F app format --check` — clean.
- [ ] Manual: upload-to-cloud a local doc with a large inline image (to keep the asset upload in flight for a while); before it completes, click the **X** delete button. Confirm the row disappears, no ghost synced copy shows up on the next refresh, and no error toast/log.
- [ ] Manual regression: normal convert-to-synced completes correctly (no false abort path triggered by the 60s timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)