### PR TITLE
chore(app): resolve residual ESLint warnings + track convert-to-synced follow-ups

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11,3 +11,12 @@ Tasks deferred during development that should be addressed before production rel
 ## Phases Not Yet Implemented
 
 - **Phase 6 — Anonymous mode + polish**: Online/offline indicator, reconnection UX, user profile/settings, rate limiting, input validation.
+
+## Convert-to-synced polish
+
+Follow-ups deferred from the convert-to-synced PRs (#431–#435). None are blocking; group here so they surface during a Phase 6 polish pass.
+
+- **Friendly error-message mapping**: `conversionError.message` flows directly to the button's `title` / `aria-label` today, surfacing strings like `"Asset upload failed: 413"` or `"signal timed out"`. Map to user-friendly text (413 → "This file is too large", `AbortError` → "Upload timed out — check your connection and try again", other 4xx/5xx → "Couldn't reach the server. Try again.").
+- **`aria-live` region for screen readers**: Convert state changes only announce when the button is re-focused. A `<div aria-live="polite">` near the sidebar footer would announce success/failure passively. Needs a small design pass on when/what to announce.
+- **Asset-upload concurrency cap**: `uploadAssetDataUrls` runs every data-URL asset upload in parallel via `Promise.all`. A legacy doc with many inline images will fire N simultaneous requests. Add a small pool (4–6 in flight) to be kinder to the browser connection pool and the worker.
+- **Tighten internal `composeWithTimeout` / default-helper signatures**: The internal `composeWithTimeout(userSignal?: AbortSignal)` helper and the `abortSignal?: AbortSignal` params on `defaultUploadAsset` / `defaultPushSnapshot` read like they can be called without an argument, but every call site passes the value. Change those internals to `AbortSignal | undefined` for an honest signature. The public `ConvertLocalDocToSyncedParams` interface keeps `?` for consumer ergonomics.

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -5,7 +5,8 @@ import { IdbDocumentRepository } from "./documents/idb-repository";
 import { ApiDocumentRepository } from "./documents/api-repository";
 import { DocumentManagerProvider } from "./documents/DocumentManagerContext";
 import { AppContent } from "./AppContent";
-import { AuthProvider, useAuth } from "./auth/AuthContext";
+import { AuthProvider } from "./auth/AuthContext";
+import { useAuth } from "./auth/useAuth";
 
 function AuthenticatedApp() {
   const { user, loading: authLoading } = useAuth();

--- a/packages/app/src/auth/AuthContext.tsx
+++ b/packages/app/src/auth/AuthContext.tsx
@@ -1,21 +1,6 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-} from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { User } from "./types";
-
-interface AuthContextValue {
-  user: User | null;
-  loading: boolean;
-  loginWithGitHub: () => void;
-  loginWithGoogle: () => void;
-  logout: () => void;
-}
-
-const AuthContext = createContext<AuthContextValue | null>(null);
+import { AuthContext } from "./useAuth";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
@@ -61,12 +46,4 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       {children}
     </AuthContext.Provider>
   );
-}
-
-export function useAuth(): AuthContextValue {
-  const ctx = useContext(AuthContext);
-  if (!ctx) {
-    throw new Error("useAuth must be used within an AuthProvider");
-  }
-  return ctx;
 }

--- a/packages/app/src/auth/useAuth.ts
+++ b/packages/app/src/auth/useAuth.ts
@@ -1,0 +1,20 @@
+import { createContext, useContext } from "react";
+import type { User } from "./types";
+
+export interface AuthContextValue {
+  user: User | null;
+  loading: boolean;
+  loginWithGitHub: () => void;
+  loginWithGoogle: () => void;
+  logout: () => void;
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return ctx;
+}

--- a/packages/app/src/components/DocumentSidebar.tsx
+++ b/packages/app/src/components/DocumentSidebar.tsx
@@ -7,7 +7,7 @@ import {
   Plus,
 } from "lucide-react";
 import { useMemo, useState } from "react";
-import { useAuth } from "../auth/AuthContext";
+import { useAuth } from "../auth/useAuth";
 import { useDocumentManagerContext } from "../documents/useDocumentManagerContext";
 import type { DocumentMeta } from "../documents/types";
 import type { ColorSchemePreference } from "../hooks/useColorScheme";

--- a/packages/app/src/components/OfflineAwareSyncedContainer.tsx
+++ b/packages/app/src/components/OfflineAwareSyncedContainer.tsx
@@ -230,7 +230,7 @@ export function OfflineAwareSyncedContainer({
         recovery,
       });
     }
-  }, [mode, documentId, refreshDocuments, selectDocument]);
+  }, [mode, documentId, currentSessionId, refreshDocuments, selectDocument]);
 
   useEffect(() => {
     retryHandleOnlineRef.current = () => {
@@ -368,12 +368,13 @@ export function OfflineAwareSyncedContainer({
     setOfflineEditor(editor);
   }, []);
 
-  useEffect(() => {
-    if (mode.type !== "offline") {
-      return;
-    }
+  // Extract the offline recovery state so the effect's dep array can
+  // reference a flat variable instead of a conditional expression —
+  // required by react-hooks/exhaustive-deps.
+  const offlineRecovery = mode.type === "offline" ? mode.recovery : undefined;
 
-    if (!offlineEditor) {
+  useEffect(() => {
+    if (!offlineEditor || !offlineRecovery) {
       return;
     }
 
@@ -385,7 +386,7 @@ export function OfflineAwareSyncedContainer({
           snapshot,
           snapshotVersion: snapshotVersionRef.current,
           recovery: createRecoveryState({
-            ...mode.recovery,
+            ...offlineRecovery,
             hasPendingOfflineChanges: true,
           }),
         },
@@ -427,13 +428,7 @@ export function OfflineAwareSyncedContainer({
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       window.removeEventListener("pagehide", handlePageHide);
     };
-  }, [
-    currentSessionId,
-    documentId,
-    mode.type === "offline" ? mode.recovery : undefined,
-    mode.type,
-    offlineEditor,
-  ]);
+  }, [currentSessionId, documentId, offlineRecovery, offlineEditor]);
 
   if (mode.type === "synced") {
     return (


### PR DESCRIPTION
## Summary

Two independent small items that were easier to bundle than split:

- **Track convert-to-synced follow-ups in `docs/TODO.md`.** Captures the four items flagged across the #431–#435 review cycle (friendly error messages, `aria-live` region, asset-upload concurrency cap, tightened internal `composeWithTimeout` / default-helper signatures) so they surface during a future polish pass instead of living in PR discussion history.
- **Resolve residual ESLint warnings** — four had accumulated; app package is now at zero.
  - `react-refresh/only-export-components` on `AuthContext.tsx`: split into `AuthContext.tsx` (provider) and a new `useAuth.ts` (hook + context + value type), matching the existing `DocumentManagerContext` / `useDocumentManagerContext` pattern. Updates the two importers.
  - `react-hooks/exhaustive-deps` on `handleOnline` in `OfflineAwareSyncedContainer.tsx`: added the missing `currentSessionId` dep.
  - `react-hooks/exhaustive-deps` + "complex expression in dep array" on the offline-flush effect in `OfflineAwareSyncedContainer.tsx`: extract `offlineRecovery = mode.type === "offline" ? mode.recovery : undefined` to a flat variable, use it inside the effect body, and reference it as a plain dep. Drops the redundant `mode.type` dep and inner guard since `offlineRecovery` truthiness already captures the "only run when offline" condition.

No behavior change in either piece.

## Test plan

- [x] `pnpm -F app typecheck` — clean.
- [x] `pnpm -F app exec vitest run` — 60 tests across 5 files pass.
- [x] `pnpm -F app lint` — **zero warnings** (was 4).
- [x] `pnpm -F app format --check` — clean.
- [ ] Manual regression: the offline-flush effect still fires when transitioning to offline mode and cleans up correctly on mode change (check the offline recovery write in `idb-sync-cache` while editing an offline-cached doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)