### PR TITLE
feat(app): network status indicator and in-place reconnecting banner

### DIFF
--- a/packages/app/src/components/DocumentSidebar.tsx
+++ b/packages/app/src/components/DocumentSidebar.tsx
@@ -13,6 +13,7 @@ import type { DocumentMeta } from "../documents/types";
 import type { ColorSchemePreference } from "../hooks/useColorScheme";
 import { ColorSchemeSwitcher } from "./ColorSchemeSwitcher";
 import { DocumentListItem } from "./DocumentListItem";
+import { NetworkStatus } from "./NetworkStatus";
 import styles from "./DocumentSidebar.module.css";
 
 interface DocumentSidebarProps {
@@ -118,6 +119,7 @@ export function DocumentSidebar({
         {renderGroup(localDocs)}
       </div>
       <div className={styles.footer}>
+        <NetworkStatus />
         {user ? (
           <button type="button" className={styles.authButton} onClick={logout}>
             <LogOut size={14} /> Log out

--- a/packages/app/src/components/NetworkStatus.module.css
+++ b/packages/app/src/components/NetworkStatus.module.css
@@ -1,0 +1,19 @@
+.pill {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: rgba(245, 158, 11, 0.12);
+  color: #b45309;
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+:global([data-color-scheme="dark"]) .pill {
+  background: rgba(245, 158, 11, 0.15);
+  color: #fbbf24;
+  border-color: rgba(245, 158, 11, 0.35);
+}

--- a/packages/app/src/components/NetworkStatus.test.tsx
+++ b/packages/app/src/components/NetworkStatus.test.tsx
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { NetworkStatus } from "./NetworkStatus";
+
+function setNavigatorOnline(value: boolean) {
+  Object.defineProperty(navigator, "onLine", {
+    value,
+    configurable: true,
+  });
+}
+
+function fireNetworkEvent(type: "online" | "offline") {
+  window.dispatchEvent(new Event(type));
+}
+
+describe("NetworkStatus", () => {
+  afterEach(() => {
+    // Unmount prior render so subsequent `screen` / role queries don't
+    // see stale DOM nodes. testing-library does not auto-cleanup under
+    // vitest without a setup file.
+    cleanup();
+    // Reset to the default "online" state so tests don't leak navigator
+    // state across each other.
+    setNavigatorOnline(true);
+    vi.restoreAllMocks();
+  });
+
+  it("renders nothing when navigator reports online", () => {
+    setNavigatorOnline(true);
+    const { container } = render(<NetworkStatus />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders an Offline pill when navigator reports offline on mount", () => {
+    setNavigatorOnline(false);
+    render(<NetworkStatus />);
+    expect(screen.getByRole("status").textContent).toContain("Offline");
+  });
+
+  it("shows the pill when an offline event fires after mount", () => {
+    setNavigatorOnline(true);
+    const { queryByRole } = render(<NetworkStatus />);
+    expect(queryByRole("status")).toBeNull();
+
+    act(() => {
+      setNavigatorOnline(false);
+      fireNetworkEvent("offline");
+    });
+
+    expect(screen.getByRole("status").textContent).toContain("Offline");
+  });
+
+  it("hides the pill when an online event fires after going offline", () => {
+    setNavigatorOnline(false);
+    const { queryByRole } = render(<NetworkStatus />);
+    expect(queryByRole("status")?.textContent).toContain("Offline");
+
+    act(() => {
+      setNavigatorOnline(true);
+      fireNetworkEvent("online");
+    });
+
+    expect(queryByRole("status")).toBeNull();
+  });
+});

--- a/packages/app/src/components/NetworkStatus.tsx
+++ b/packages/app/src/components/NetworkStatus.tsx
@@ -1,0 +1,39 @@
+import { WifiOff } from "lucide-react";
+import { useEffect, useState } from "react";
+import styles from "./NetworkStatus.module.css";
+
+/**
+ * Shows an "Offline" pill when the browser reports no network connection.
+ * Renders nothing when online — the expected state is signaled by absence
+ * of the indicator rather than a persistent green dot, to keep the sidebar
+ * footer quiet when nothing is wrong.
+ *
+ * This reflects the browser's `navigator.onLine` state, not sync-room
+ * connectivity. The sync-room reconnect banner lives inside
+ * OfflineAwareSyncedContainer because it is per-document state.
+ */
+export function NetworkStatus() {
+  const [online, setOnline] = useState(() =>
+    typeof navigator !== "undefined" ? navigator.onLine : true,
+  );
+
+  useEffect(() => {
+    const handleOnline = () => setOnline(true);
+    const handleOffline = () => setOnline(false);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  if (online) return null;
+
+  return (
+    <div className={styles.pill} role="status" aria-live="polite">
+      <WifiOff size={14} aria-hidden="true" />
+      <span>Offline</span>
+    </div>
+  );
+}

--- a/packages/app/src/components/OfflineAwareSyncedContainer.tsx
+++ b/packages/app/src/components/OfflineAwareSyncedContainer.tsx
@@ -475,20 +475,38 @@ export function OfflineAwareSyncedContainer({
   }
 
   if (mode.type === "reconnecting") {
+    // Keep the snapshot-backed editor visible so the user does not
+    // stare at a blank "Reconnecting..." screen. The editor is mounted
+    // with the pre-reconnect snapshot; any interaction during the
+    // reconnect window is ephemeral (the store is not connected), which
+    // matches the banner's intent of "hold tight, we're re-syncing".
     return (
-      <div
-        role="status"
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          height: "100%",
-          fontSize: 14,
-          color: "#666",
-        }}
-      >
-        Reconnecting...
-      </div>
+      <>
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            position: "fixed",
+            top: 0,
+            left: "50%",
+            transform: "translateX(-50%)",
+            zIndex: 1000,
+            background: "#3b82f6",
+            color: "#fff",
+            padding: "4px 16px",
+            borderRadius: "0 0 6px 6px",
+            fontSize: 13,
+            fontWeight: 500,
+          }}
+        >
+          Reconnecting…
+        </div>
+        <Anipres
+          key={`reconnecting-${documentId}`}
+          snapshot={mode.snapshot}
+          colorScheme={colorScheme}
+        />
+      </>
     );
   }
 


### PR DESCRIPTION
## Summary

Two Phase-6 polish items that share the "surface network state to the user" concern.

**`NetworkStatus` component (new)**
- Renders an "Offline" pill in the sidebar footer when `navigator.onLine` flips false, driven by the browser's `online` / `offline` events.
- Renders nothing when online — the sidebar stays quiet by default; absence of the indicator is how "everything's fine" is signaled.
- `role="status"` + `aria-live="polite"` so screen readers announce the transition.
- Reflects browser network state only, not sync-room connectivity. The sync-room reconnect state is per-document and lives inside `OfflineAwareSyncedContainer` (see the next item).

**In-place reconnecting banner in `OfflineAwareSyncedContainer`**
- Previously, `mode.type === "reconnecting"` replaced the entire editor area with a centered "Reconnecting…" text. Users lost sight of their own document while the reconnect handshake ran.
- Now renders the snapshot-backed `<Anipres>` together with a fixed banner at the top of the viewport (blue, same placement/shape as the existing orange offline banner). Users see their content throughout the reconnect window; any interaction during that window is ephemeral by design (the store is snapshot-only, not connected), which matches the banner's intent.

## Test plan

- [x] `pnpm -F app typecheck` — clean.
- [x] `pnpm -F app exec vitest run` — 64 tests across 6 files pass (+4 new `NetworkStatus` tests covering mount/unmount with and without connectivity, and the `online` / `offline` event transitions). `cleanup()` wired into `afterEach` since testing-library doesn't auto-cleanup under vitest without a setup file.
- [x] `pnpm -F app lint` — clean.
- [x] `pnpm -F app format --check` — clean.
- [ ] Manual: toggle DevTools → Network → Offline; the sidebar footer shows the "Offline" pill. Toggle back to Online; pill disappears.
- [ ] Manual: open a synced doc, toggle Offline so it transitions to `mode.type === "offline"` (orange banner), toggle Online back. While the reconnect is in flight, confirm the editor stays visible with the new blue "Reconnecting…" banner rather than a blank centered text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)