### PR TITLE
fix(app): preserve editor across offline/reconnecting + race-free network sub

### DIFF
--- a/packages/app/src/components/NetworkStatus.tsx
+++ b/packages/app/src/components/NetworkStatus.tsx
@@ -1,6 +1,26 @@
 import { WifiOff } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import styles from "./NetworkStatus.module.css";
+
+function subscribeToNetworkStatus(notify: () => void) {
+  window.addEventListener("online", notify);
+  window.addEventListener("offline", notify);
+  return () => {
+    window.removeEventListener("online", notify);
+    window.removeEventListener("offline", notify);
+  };
+}
+
+function getNetworkStatusSnapshot() {
+  return navigator.onLine;
+}
+
+// Server snapshot: assume online when there is no navigator (SSR or
+// pre-hydration). The app is currently a Vite SPA so this branch is
+// effectively unreachable, but useSyncExternalStore requires it.
+function getNetworkStatusServerSnapshot() {
+  return true;
+}
 
 /**
  * Shows an "Offline" pill when the browser reports no network connection.
@@ -8,25 +28,20 @@ import styles from "./NetworkStatus.module.css";
  * of the indicator rather than a persistent green dot, to keep the sidebar
  * footer quiet when nothing is wrong.
  *
+ * Uses useSyncExternalStore to avoid a stale-state race between the
+ * initial render and the listener subscription that would otherwise
+ * affect the manual useState/useEffect pattern.
+ *
  * This reflects the browser's `navigator.onLine` state, not sync-room
  * connectivity. The sync-room reconnect banner lives inside
  * OfflineAwareSyncedContainer because it is per-document state.
  */
 export function NetworkStatus() {
-  const [online, setOnline] = useState(() =>
-    typeof navigator !== "undefined" ? navigator.onLine : true,
+  const online = useSyncExternalStore(
+    subscribeToNetworkStatus,
+    getNetworkStatusSnapshot,
+    getNetworkStatusServerSnapshot,
   );
-
-  useEffect(() => {
-    const handleOnline = () => setOnline(true);
-    const handleOffline = () => setOnline(false);
-    window.addEventListener("online", handleOnline);
-    window.addEventListener("offline", handleOffline);
-    return () => {
-      window.removeEventListener("online", handleOnline);
-      window.removeEventListener("offline", handleOffline);
-    };
-  }, []);
 
   if (online) return null;
 

--- a/packages/app/src/components/OfflineAwareSyncedContainer.tsx
+++ b/packages/app/src/components/OfflineAwareSyncedContainer.tsx
@@ -443,43 +443,15 @@ export function OfflineAwareSyncedContainer({
     );
   }
 
-  if (mode.type === "offline") {
-    return (
-      <>
-        <div
-          role="status"
-          style={{
-            position: "fixed",
-            top: 0,
-            left: "50%",
-            transform: "translateX(-50%)",
-            zIndex: 1000,
-            background: "#f59e0b",
-            color: "#000",
-            padding: "4px 16px",
-            borderRadius: "0 0 6px 6px",
-            fontSize: 13,
-            fontWeight: 500,
-          }}
-        >
-          Offline — changes saved locally
-        </div>
-        <Anipres
-          key={`offline-${documentId}`}
-          snapshot={mode.snapshot}
-          onMount={handleOfflineMount}
-          colorScheme={colorScheme}
-        />
-      </>
-    );
-  }
-
-  if (mode.type === "reconnecting") {
-    // Keep the snapshot-backed editor visible so the user does not
-    // stare at a blank "Reconnecting..." screen. The editor is mounted
-    // with the pre-reconnect snapshot; any interaction during the
-    // reconnect window is ephemeral (the store is not connected), which
-    // matches the banner's intent of "hold tight, we're re-syncing".
+  if (mode.type === "offline" || mode.type === "reconnecting") {
+    const isReconnecting = mode.type === "reconnecting";
+    // Use the document id alone as the React key so the same Anipres /
+    // tldraw instance persists across offline ↔ reconnecting transitions.
+    // Without this the editor would unmount/remount on every transition,
+    // discarding camera position, selection, and any open dropdowns.
+    // handleOfflineMount stays attached in both modes so the offline
+    // editor ref is populated regardless of which mode mounted first
+    // (e.g., the startup branch can land directly in "reconnecting").
     return (
       <>
         <div
@@ -491,19 +463,20 @@ export function OfflineAwareSyncedContainer({
             left: "50%",
             transform: "translateX(-50%)",
             zIndex: 1000,
-            background: "#3b82f6",
-            color: "#fff",
+            background: isReconnecting ? "#3b82f6" : "#f59e0b",
+            color: isReconnecting ? "#fff" : "#000",
             padding: "4px 16px",
             borderRadius: "0 0 6px 6px",
             fontSize: 13,
             fontWeight: 500,
           }}
         >
-          Reconnecting…
+          {isReconnecting ? "Reconnecting…" : "Offline — changes saved locally"}
         </div>
         <Anipres
-          key={`reconnecting-${documentId}`}
+          key={documentId}
           snapshot={mode.snapshot}
+          onMount={handleOfflineMount}
           colorScheme={colorScheme}
         />
       </>


### PR DESCRIPTION
## Summary

Two follow-ups from the PR #437 review.

**`NetworkStatus` initial-state race**
- The previous `useState` + `useEffect` pattern read `navigator.onLine` once at the lazy initializer and attached the `online`/`offline` listener in a separate effect. An event firing in the microsecond window between those two phases would be missed, leaving the pill stuck on the wrong state until the next transition.
- Switch to `useSyncExternalStore`. React re-reads `getSnapshot` after the subscribe callback runs, so the resync happens automatically with no manual `setState`-in-effect (which ESLint correctly objects to). Bonus: tear resistance under concurrent rendering and a documented SSR fallback (`getServerSnapshot` returns `true` when `navigator` is absent — currently unreachable but required by the API).
- The four existing tests still pass against the new implementation; they exercise the public contract (renders pill on `offline` event, hides on `online`), not the internals.

**Editor instance preservation across offline ↔ reconnecting**
- Previously the offline branch keyed `<Anipres>` as `offline-${id}` and the reconnecting branch as `reconnecting-${id}`. Different keys forced a full unmount/remount on every transition, discarding camera position, selection, and any open dropdowns.
- Merge the two branches into a single conditional, key `<Anipres>` as `${documentId}` alone, and pass `onMount={handleOfflineMount}` in both modes. React keeps the same Anipres / tldraw instance across offline ↔ reconnecting transitions. `handleOfflineMount` only fires once on first mount, so the offline editor ref is populated regardless of which mode mounted first — including the `resolveStartupState` → `"reconnecting"` direct startup path. `handleOnline` reads the ref only when `mode.type === "offline"`, so reconnecting-mode holding the ref is harmless.
- Banner color and copy still differ per mode (orange / dark text for offline, blue / white for reconnecting), so the visual signal is preserved.

## Test plan

- [x] `pnpm -F app typecheck` — clean.
- [x] `pnpm -F app exec vitest run` — 64 tests pass (NetworkStatus tests unchanged against the new internal implementation).
- [x] `pnpm -F app lint` — clean (the previous race-fix attempt with manual `setState`-in-effect was rejected by `react-hooks/set-state-in-effect`; `useSyncExternalStore` is the idiomatic resolution).
- [x] `pnpm -F app format --check` — clean.
- [ ] Manual: open a synced doc, scroll/zoom to a non-default position, devtools → Network → Offline. Confirm offline orange banner appears with the camera state preserved. Devtools → Online. While the reconnect handshake runs, the blue "Reconnecting…" banner appears and the camera state remains preserved (was previously reset). On reconnect success, the synced editor mounts fresh as expected.
- [ ] Manual regression: load the page initially while offline (devtools throttled before reload). The "Offline" pill in the sidebar footer should appear immediately, not flicker through "online" first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)