### PR TITLE
feat(worker): tighten input validation schemas + add worker test pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,36 @@ jobs:
       - name: Format check
         run: pnpm format --check
 
+  test-worker:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/worker
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          version: latest
+          run_install: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: .nvmrc
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
       - name: Test
         run: pnpm test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,9 +220,6 @@ jobs:
       - name: Test
         run: pnpm test
 
-      - name: Test
-        run: pnpm test
-
   build-app:
     needs: [build-anipres, lint-app]
 

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -8,7 +8,8 @@
     "deploy": "pnpm run migrate:remote && wrangler deploy",
     "migrate:local": "wrangler d1 migrations apply DB --local",
     "migrate:remote": "wrangler d1 migrations apply DB --remote",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest"
   },
   "dependencies": {
     "@hono/oauth-providers": "^0.8.5",

--- a/packages/worker/src/schemas.test.ts
+++ b/packages/worker/src/schemas.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import * as v from "valibot";
+import {
+  documentIdParamSchema,
+  documentMetadataSchema,
+  snapshotPushBodySchema,
+} from "./schemas";
+
+describe("documentIdParamSchema", () => {
+  it("accepts a UUID id", () => {
+    const result = v.safeParse(documentIdParamSchema, {
+      id: "8d6f4d3e-3c8f-4a8a-9c9d-1e2f3a4b5c6d",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a non-UUID id", () => {
+    const result = v.safeParse(documentIdParamSchema, { id: "not-a-uuid" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a missing id", () => {
+    const result = v.safeParse(documentIdParamSchema, {});
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("documentMetadataSchema", () => {
+  const validMetadata = {
+    title: "My Document",
+    order: 1,
+    created_at: 1700000000000,
+    updated_at: 1700000000001,
+  };
+
+  it("accepts well-formed metadata", () => {
+    const result = v.safeParse(documentMetadataSchema, validMetadata);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a title longer than 256 characters", () => {
+    const result = v.safeParse(documentMetadataSchema, {
+      ...validMetadata,
+      title: "x".repeat(257),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a title at the 256-character limit", () => {
+    const result = v.safeParse(documentMetadataSchema, {
+      ...validMetadata,
+      title: "x".repeat(256),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a title with a null byte", () => {
+    const result = v.safeParse(documentMetadataSchema, {
+      ...validMetadata,
+      title: "hello\u0000world",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a non-finite order (NaN)", () => {
+    const result = v.safeParse(documentMetadataSchema, {
+      ...validMetadata,
+      order: Number.NaN,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a non-finite order (Infinity)", () => {
+    const result = v.safeParse(documentMetadataSchema, {
+      ...validMetadata,
+      order: Number.POSITIVE_INFINITY,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an order below the lower bound", () => {
+    const result = v.safeParse(documentMetadataSchema, {
+      ...validMetadata,
+      order: -1e10,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an order above the upper bound", () => {
+    const result = v.safeParse(documentMetadataSchema, {
+      ...validMetadata,
+      order: 1e10,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a fractional order (used by reorder logic)", () => {
+    const result = v.safeParse(documentMetadataSchema, {
+      ...validMetadata,
+      order: 1.5,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a negative timestamp", () => {
+    const result = v.safeParse(documentMetadataSchema, {
+      ...validMetadata,
+      created_at: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a non-integer timestamp", () => {
+    const result = v.safeParse(documentMetadataSchema, {
+      ...validMetadata,
+      updated_at: 1700000000000.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects NaN timestamps", () => {
+    const result = v.safeParse(documentMetadataSchema, {
+      ...validMetadata,
+      created_at: Number.NaN,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("snapshotPushBodySchema", () => {
+  const validBody = {
+    snapshot: { "shape:abc": { id: "shape:abc", typeName: "shape" } },
+    expectedSnapshotVersion: 0,
+  };
+
+  it("accepts a well-formed body", () => {
+    const result = v.safeParse(snapshotPushBodySchema, validBody);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an empty snapshot record", () => {
+    const result = v.safeParse(snapshotPushBodySchema, {
+      ...validBody,
+      snapshot: {},
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a negative expectedSnapshotVersion", () => {
+    const result = v.safeParse(snapshotPushBodySchema, {
+      ...validBody,
+      expectedSnapshotVersion: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a non-integer expectedSnapshotVersion", () => {
+    const result = v.safeParse(snapshotPushBodySchema, {
+      ...validBody,
+      expectedSnapshotVersion: 1.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a NaN expectedSnapshotVersion", () => {
+    const result = v.safeParse(snapshotPushBodySchema, {
+      ...validBody,
+      expectedSnapshotVersion: Number.NaN,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a non-object snapshot", () => {
+    const result = v.safeParse(snapshotPushBodySchema, {
+      snapshot: "not an object",
+      expectedSnapshotVersion: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/worker/src/schemas.ts
+++ b/packages/worker/src/schemas.ts
@@ -1,0 +1,64 @@
+import * as v from "valibot";
+
+// Document title bounds: long enough to be useful, short enough to keep
+// rows compact in D1. Reject null bytes — D1's TEXT column tolerates
+// them but they break grep, leak through raw logs, and have no place in
+// a user-facing label.
+const DOCUMENT_TITLE_MAX_LENGTH = 256;
+
+// Order is stored as REAL in D1 for fractional reordering. Bound it to
+// a sane range so a malicious or confused client cannot push values that
+// would clutter the sidebar's display formatter (and reject NaN /
+// Infinity which JSON would otherwise pass through as `null`).
+const DOCUMENT_ORDER_MIN = -1e9;
+const DOCUMENT_ORDER_MAX = 1e9;
+
+// Maximum snapshot push body size. tldraw snapshots are usually well
+// under 1 MB; even the largest realistic doc with embedded references
+// rarely exceeds a few MB. 5 MB gives plenty of headroom while
+// preventing a runaway client from streaming arbitrary blobs at the DO.
+export const MAX_SNAPSHOT_BODY_BYTES = 5 * 1024 * 1024;
+
+const finiteNumber = v.pipe(v.number(), v.finite());
+
+const nonNegativeFiniteInteger = v.pipe(
+  v.number(),
+  v.integer(),
+  v.minValue(0),
+);
+
+// Title: bounded length and no null bytes. Whitespace-only strings are
+// allowed by valibot here; the client commits "Untitled" for empty
+// titles in createNewDocument, so an explicit minLength would just push
+// edge-case behavior to the request layer.
+const documentTitleSchema = v.pipe(
+  v.string(),
+  v.maxLength(DOCUMENT_TITLE_MAX_LENGTH),
+  v.regex(/^[^\u0000]*$/u, "Title contains a null byte"),
+);
+
+const documentOrderSchema = v.pipe(
+  finiteNumber,
+  v.minValue(DOCUMENT_ORDER_MIN),
+  v.maxValue(DOCUMENT_ORDER_MAX),
+);
+
+export const documentIdParamSchema = v.object({
+  id: v.pipe(v.string(), v.uuid()),
+});
+
+export const documentConnectParamSchema = v.object({
+  documentId: v.pipe(v.string(), v.uuid()),
+});
+
+export const documentMetadataSchema = v.object({
+  title: documentTitleSchema,
+  order: documentOrderSchema,
+  created_at: nonNegativeFiniteInteger,
+  updated_at: nonNegativeFiniteInteger,
+});
+
+export const snapshotPushBodySchema = v.object({
+  snapshot: v.record(v.string(), v.unknown()),
+  expectedSnapshotVersion: nonNegativeFiniteInteger,
+});

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -2,31 +2,18 @@ import { Hono } from "hono";
 import * as v from "valibot";
 import { registerAssetRoutes, startDocumentDeletion } from "./assets";
 import { registerApiAuth, registerAuthRoutes } from "./auth";
+import {
+  documentConnectParamSchema,
+  documentIdParamSchema,
+  documentMetadataSchema,
+  MAX_SNAPSHOT_BODY_BYTES,
+  snapshotPushBodySchema,
+} from "./schemas";
 import type { AppBindings } from "./types";
 
 export { DocumentSyncRoom } from "./DocumentSyncRoom";
 
 const app = new Hono<AppBindings>();
-
-const documentIdParamSchema = v.object({
-  id: v.pipe(v.string(), v.uuid()),
-});
-
-const documentConnectParamSchema = v.object({
-  documentId: v.pipe(v.string(), v.uuid()),
-});
-
-const documentMetadataSchema = v.object({
-  title: v.string(),
-  order: v.number(),
-  created_at: v.number(),
-  updated_at: v.number(),
-});
-
-const snapshotPushBodySchema = v.object({
-  snapshot: v.record(v.string(), v.unknown()),
-  expectedSnapshotVersion: v.number(),
-});
 
 registerAuthRoutes(app);
 registerApiAuth(app);
@@ -167,6 +154,17 @@ app.put("/api/documents/:id/snapshot", async (c) => {
       { error: "Invalid document id", details: paramsResult.issues },
       400,
     );
+  }
+
+  // Cap the body size before reading. Cloudflare's default request
+  // limit is generous; this stops a runaway client from streaming
+  // arbitrary blobs at the DO snapshot store.
+  const declaredLength = Number(c.req.header("content-length"));
+  if (
+    Number.isFinite(declaredLength) &&
+    declaredLength > MAX_SNAPSHOT_BODY_BYTES
+  ) {
+    return c.json({ error: "Snapshot body too large" }, 413);
   }
 
   let json: unknown;


### PR DESCRIPTION
## Summary

First half of the Phase-6 hardening work — focused on input validation bounds in the worker. Pre-existing valibot schemas were loose around constraints that don't matter often but matter when they do; this lays the ground rules so a malicious or buggy client cannot push pathological values into D1 / R2 / the DO. Rate limiting follows in a separate PR.

### Schema tightenings

- **Document title**: max 256 characters; reject null bytes. Long titles bloat D1 rows and clutter the sidebar; null bytes leak through raw logs and grep output.
- **Document order**: must be finite (rejects `NaN` / `Infinity`, which `JSON.stringify` passes through as the string `null` and which would otherwise corrupt sort order) and bounded to ±1e9.
- **Document timestamps** (`created_at` / `updated_at`): non-negative finite integers.
- **`expectedSnapshotVersion`** on snapshot push: non-negative finite integer (was just `v.number()`).

### Snapshot push body-size guard

`PUT /api/documents/:id/snapshot` now rejects a body whose `Content-Length` exceeds **5 MB** with a `413` before the JSON parse runs. Cloudflare's default request body limit is generous; this is the app-level brake on a runaway client.

### Schema extraction

The four inline schemas in `worker.ts` move into a new `packages/worker/src/schemas.ts` so they can be unit-tested in isolation without standing up Hono and the auth middleware. `worker.ts` imports from `./schemas`; behavior unchanged for valid inputs.

### Worker test pipeline (new)

The worker package had no test setup. Adds `test: "vitest"` to its `package.json`, plus a 21-test `schemas.test.ts` covering each tightened constraint and a few sanity cases (UUID acceptance, empty snapshot record, fractional order). New `test-worker` CI job alongside `lint-app` runs `pnpm typecheck` and `pnpm test` from `packages/worker` — without it the schema tests would only run locally.

## Test plan

- [x] `pnpm -F anipres-worker typecheck` — clean.
- [x] `pnpm -F anipres-worker test --run` — 21/21 pass.
- [x] `pnpm -F app typecheck` — clean.
- [x] `pnpm -F app exec vitest run` — 64/64 pass (no app regression).
- [x] `actionlint .github/workflows/ci.yml` — clean.
- [ ] Manual regression: drag → drop a normal-sized image into a synced doc; image uploads, doc syncs. (Validation should not affect happy-path traffic.)
- [ ] Manual rejection: send a `PUT /api/documents/:id/snapshot` with a 6 MB body via `curl`; expect a 413 response without the DO being touched.

## Follow-up

Phase-6 rate limiting (per-user via Workers Rate Limiting API, applied to the top-cost endpoints — asset upload, snapshot push, doc creation) is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)