### PR TITLE
chore: add changesets for unannounced anipres API changes

### DIFF
--- a/.changeset/expose-shape-building-blocks.md
+++ b/.changeset/expose-shape-building-blocks.md
@@ -1,0 +1,8 @@
+---
+"anipres": minor
+---
+
+Expose anipres' shape building blocks for advanced consumers:
+
+- The `anipres/schema` subpath now also exports `slideShapeProps`, `SlideShapeType`, `themeImageShapeProps`, and `ThemeImageShapeType` — pure-TS values usable outside React (e.g. validating snapshots on a server).
+- The main entry now exports `customShapeUtils`, `allShapeUtils`, and `allBindingUtils` for embedders that build a tldraw editor with anipres' shapes plus their own.

--- a/.changeset/pin-tldraw-peer.md
+++ b/.changeset/pin-tldraw-peer.md
@@ -1,0 +1,5 @@
+---
+"anipres": patch
+---
+
+Tighten the `tldraw` peer dependency from `^3.15.5` to exact `3.15.5`. Anipres' shape schemas are now shared across the editor and the new `anipres/schema` subpath; minor tldraw versions can change shape internals, so pinning keeps the contract stable. Consumers should align their own `tldraw` install to the same exact version.


### PR DESCRIPTION
## Summary

Two existing changeset fragments (`shared-max-asset-size.md` and `slide-shape-extract-types.md`) cover part of the `anipres` package's PR #409 surface, but a few public-API changes ship without changelog notes. Adding the missing fragments before #409 merges so the published changelog accurately reflects the bump.

| Change | Fragment | Bump |
|---|---|---|
| `anipres/schema` ships shape props/types (`slideShapeProps`, `SlideShapeType`, `themeImageShapeProps`, `ThemeImageShapeType`) | `expose-shape-building-blocks.md` | minor |
| Top-level exports `customShapeUtils`, `allShapeUtils`, `allBindingUtils` | (same fragment) | minor |
| `tldraw` peer dep tightened from `^3.15.5` to exact `3.15.5` | `pin-tldraw-peer.md` | patch |

The CJS file rename (`anipres.umd.cjs` → `anipres.cjs`) is transparent via the exports map and doesn't need a changelog note. `slidev-addon-anipres` is unchanged on this branch; `app` and `anipres-worker` are private.

## Test plan

- [x] `pnpm changeset status` — `anipres` queues for minor, internal deps queue for patch via `updateInternalDependencies` config

🤖 Generated with [Claude Code](https://claude.com/claude-code)