### PR TITLE
chore(worker): add prod routes for anipres.app and flag D1 id TODO

### DIFF
--- a/packages/worker/wrangler.toml
+++ b/packages/worker/wrangler.toml
@@ -8,9 +8,24 @@ bindings = [
   { name = "DOCUMENT_SYNC_ROOM", class_name = "DocumentSyncRoom" }
 ]
 
+# Frontend is served from anipres.app, so the worker handles same-origin
+# /api/* (data routes) and /auth/* (OAuth start/callback, /auth/me,
+# /auth/logout) under the same zone. Both are required — splitting them
+# would break the OAuth round-trip.
+[[routes]]
+pattern = "anipres.app/api/*"
+zone_name = "anipres.app"
+
+[[routes]]
+pattern = "anipres.app/auth/*"
+zone_name = "anipres.app"
+
 [[d1_databases]]
 binding = "DB"
 database_name = "anipres-db"
+# TODO: replace with the production D1 id from `wrangler d1 list`
+# (or the result of `wrangler d1 create anipres-db`) before the first
+# `wrangler deploy`. The literal "local" only works under `wrangler dev`.
 database_id = "local"
 
 [[migrations]]


### PR DESCRIPTION
## Summary

Pre-deploy hygiene for the worker before PR #409 merges.

- **Routes (`anipres.app/api/*` and `anipres.app/auth/*`)** — the deployed frontend lives at `anipres.app/`, and both prefixes are needed. `/api/*` covers data routes (documents, snapshots, assets, sync upgrade); `/auth/*` covers the OAuth round-trip endpoints (`/auth/github`, `/auth/google`, `/auth/google/callback`, `/auth/me`, `/auth/logout`). Routing only one would break OAuth.
- **D1 `database_id = "local"` placeholder TODO** — the literal `"local"` is the convention for `wrangler dev`. `wrangler deploy` (called from `pnpm deploy` after `wrangler d1 migrations apply DB --remote`) needs the real production UUID. Surfacing it as an inline TODO so the first deploy fails loudly rather than silently targeting the wrong DB.

## Pre-deploy checklist (separate from this PR — for the operator)

- [ ] `wrangler d1 list` (or `wrangler d1 create anipres-db`) → paste the resulting id into `wrangler.toml`.
- [ ] `wrangler r2 bucket create anipres-assets` and `wrangler r2 bucket create anipres-assets-preview`.
- [ ] `wrangler secret put` for: `GITHUB_ID`, `GITHUB_SECRET`, `GOOGLE_ID`, `GOOGLE_SECRET`, `JWT_SECRET`.
- [ ] OAuth provider apps: callback URLs registered as `https://anipres.app/auth/github` and `https://anipres.app/auth/google/callback`.
- [ ] Cloudflare zone `anipres.app` is on the same account that runs `wrangler deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)