### PR TITLE
feat(app): adapt document flows to the new server contract

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -20,7 +20,8 @@
     "lucide-react": "^0.577.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "tldraw": "3.15.5"
+    "tldraw": "3.15.5",
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@tldraw/sync": "3.15.5",
     "anipres": "workspace:*",
+    "fractional-indexing": "^3.2.0",
     "idb-keyval": "^6.2.1",
     "lucide-react": "^0.577.0",
     "react": "^18.3.1",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -16,6 +16,15 @@ interface Workspace {
   updated_at: number;
 }
 
+// Result of a workspace-discovery fetch. The fetched value is tagged
+// with the user id it was fetched for, so derived state can treat
+// stale entries (after a user-A → user-B transition) as "loading"
+// instead of synchronously clearing state from the effect (which the
+// React lint rule discourages — it causes a cascading re-render).
+type WorkspaceFetchResult =
+  | { userId: number; id: string }
+  | { userId: number; error: string };
+
 function AuthenticatedApp() {
   const { user, loading: authLoading } = useAuth();
   const localRepository = useMemo(() => new IdbDocumentRepository(), []);
@@ -24,35 +33,53 @@ function AuthenticatedApp() {
   // the user's workspaces via `GET /api/workspaces` and bind the synced
   // repo to the (Phase 1: only) workspace returned. Extension A will
   // surface the list to the user; for now we just take the first row.
-  //
-  // The fetched value is tagged with the user id it was fetched for,
-  // so when the auth subject changes we can derive `null` until the
-  // new fetch lands instead of synchronously clearing in the effect
-  // (which the React lint rule discourages — it causes a cascading
-  // re-render).
-  const [fetchedWorkspace, setFetchedWorkspace] = useState<{
-    userId: number;
-    id: string;
-  } | null>(null);
+  const [fetchedWorkspace, setFetchedWorkspace] =
+    useState<WorkspaceFetchResult | null>(null);
   useEffect(() => {
     if (!user) return;
+    const userId = user.id;
     let cancelled = false;
     fetch("/api/workspaces")
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data: Workspace[] | null) => {
-        if (cancelled) return;
-        if (data && data.length > 0) {
-          setFetchedWorkspace({ userId: user.id, id: data[0].id });
+      .then(async (res): Promise<WorkspaceFetchResult> => {
+        if (!res.ok) {
+          return { userId, error: `request failed (${res.status})` };
         }
+        const data: Workspace[] = await res.json();
+        if (data.length === 0) {
+          return { userId, error: "no workspace found for this account" };
+        }
+        return { userId, id: data[0].id };
       })
-      .catch(() => {});
+      .catch(
+        (err: unknown): WorkspaceFetchResult => ({
+          userId,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      )
+      .then((next) => {
+        if (cancelled) return;
+        if ("error" in next) {
+          console.error(
+            `Workspace discovery failed: ${next.error}. The app cannot reach the server-backed document store.`,
+          );
+        }
+        setFetchedWorkspace(next);
+      });
     return () => {
       cancelled = true;
     };
   }, [user]);
 
+  // Derived: treat a fetched value belonging to a different user (or no
+  // value at all) as "still loading" without touching state.
+  const currentWorkspace =
+    user && fetchedWorkspace?.userId === user.id ? fetchedWorkspace : null;
   const workspaceId =
-    user && fetchedWorkspace?.userId === user.id ? fetchedWorkspace.id : null;
+    currentWorkspace && "id" in currentWorkspace ? currentWorkspace.id : null;
+  const workspaceError =
+    currentWorkspace && "error" in currentWorkspace
+      ? currentWorkspace.error
+      : null;
 
   const syncedRepository = useMemo(
     () =>
@@ -62,11 +89,29 @@ function AuthenticatedApp() {
     [user, workspaceId],
   );
 
+  if (authLoading) {
+    return null;
+  }
+
+  // Logged in but workspace discovery failed — Phase 1 invariant says
+  // login always provisions exactly one workspace, so this path is
+  // genuinely broken state (server unreachable, account in a bad
+  // shape, etc.). Surface a message instead of hanging on a blank
+  // screen.
+  if (user !== null && workspaceError !== null) {
+    return (
+      <div role="alert" style={{ padding: "1rem", textAlign: "center" }}>
+        <p>Could not load your workspace: {workspaceError}.</p>
+        <p>Please try refreshing the page.</p>
+      </div>
+    );
+  }
+
   // Wait for both auth resolution and (when logged in) workspace
   // discovery before rendering. Without this, a logged-in user would
   // briefly see the local-only experience while the workspace fetch
   // is in flight.
-  if (authLoading || (user !== null && workspaceId === null)) {
+  if (user !== null && workspaceId === null) {
     return null;
   }
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,22 +1,72 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import * as xiaolai from "./fonts/XiaolaiSC-Regular.ttf";
 import "anipres/anipres.css";
 import { IdbDocumentRepository } from "./documents/idb-repository";
 import { ApiDocumentRepository } from "./documents/api-repository";
 import { DocumentManagerProvider } from "./documents/DocumentManagerContext";
+import { SyncedRepositoryProvider } from "./documents/SyncedRepositoryContext";
 import { AppContent } from "./AppContent";
 import { AuthProvider } from "./auth/AuthContext";
 import { useAuth } from "./auth/useAuth";
 
+interface Workspace {
+  id: string;
+  name: string;
+  created_at: number;
+  updated_at: number;
+}
+
 function AuthenticatedApp() {
   const { user, loading: authLoading } = useAuth();
   const localRepository = useMemo(() => new IdbDocumentRepository(), []);
+
+  // Server-side documents are workspace-owned. After login we discover
+  // the user's workspaces via `GET /api/workspaces` and bind the synced
+  // repo to the (Phase 1: only) workspace returned. Extension A will
+  // surface the list to the user; for now we just take the first row.
+  //
+  // The fetched value is tagged with the user id it was fetched for,
+  // so when the auth subject changes we can derive `null` until the
+  // new fetch lands instead of synchronously clearing in the effect
+  // (which the React lint rule discourages — it causes a cascading
+  // re-render).
+  const [fetchedWorkspace, setFetchedWorkspace] = useState<{
+    userId: number;
+    id: string;
+  } | null>(null);
+  useEffect(() => {
+    if (!user) return;
+    let cancelled = false;
+    fetch("/api/workspaces")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: Workspace[] | null) => {
+        if (cancelled) return;
+        if (data && data.length > 0) {
+          setFetchedWorkspace({ userId: user.id, id: data[0].id });
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  const workspaceId =
+    user && fetchedWorkspace?.userId === user.id ? fetchedWorkspace.id : null;
+
   const syncedRepository = useMemo(
-    () => (user !== null ? new ApiDocumentRepository() : undefined),
-    [user],
+    () =>
+      user !== null && workspaceId !== null
+        ? new ApiDocumentRepository(workspaceId)
+        : undefined,
+    [user, workspaceId],
   );
 
-  if (authLoading) {
+  // Wait for both auth resolution and (when logged in) workspace
+  // discovery before rendering. Without this, a logged-in user would
+  // briefly see the local-only experience while the workspace fetch
+  // is in flight.
+  if (authLoading || (user !== null && workspaceId === null)) {
     return null;
   }
 
@@ -34,12 +84,14 @@ function AuthenticatedApp() {
           --tl-font-draw: Excalifont-Regular, '${xiaolai.css.family}', ${xiaolai.fontFamilyFallback}, 'tldraw_draw';
         }
       `}</style>
-      <DocumentManagerProvider
-        localRepository={localRepository}
-        syncedRepository={syncedRepository}
-      >
-        <AppContent />
-      </DocumentManagerProvider>
+      <SyncedRepositoryProvider repository={syncedRepository ?? null}>
+        <DocumentManagerProvider
+          localRepository={localRepository}
+          syncedRepository={syncedRepository}
+        >
+          <AppContent />
+        </DocumentManagerProvider>
+      </SyncedRepositoryProvider>
     </>
   );
 }

--- a/packages/app/src/AppContent.tsx
+++ b/packages/app/src/AppContent.tsx
@@ -25,7 +25,7 @@ export function AppContent() {
       }
     >
       {activeDocument &&
-        (activeDocument.origin === "synced" ? (
+        (activeDocument.source === "synced" ? (
           <OfflineAwareSyncedContainer
             key={activeDocument.id}
             documentId={activeDocument.id}

--- a/packages/app/src/components/DocumentListItem.tsx
+++ b/packages/app/src/components/DocumentListItem.tsx
@@ -10,7 +10,7 @@ interface DocumentListItemProps {
   onRename: (id: string, title: string) => void;
   onDelete: (id: string) => void;
   /**
-   * When provided and `doc.origin === "local"`, the item renders a
+   * When provided and `doc.source === "local"`, the item renders a
    * "Upload to cloud" affordance that triggers migration to the synced
    * repository. Absent when the user is logged out (no synced
    * destination) or when the doc is already synced.
@@ -56,7 +56,7 @@ export function DocumentListItem({
     setEditing(false);
   };
 
-  const canConvert = onConvert !== undefined && doc.origin === "local";
+  const canConvert = onConvert !== undefined && doc.source === "local";
   const convertTitle = isConverting
     ? "Uploading…"
     : conversionError

--- a/packages/app/src/components/DocumentSidebar.tsx
+++ b/packages/app/src/components/DocumentSidebar.tsx
@@ -45,7 +45,7 @@ export function DocumentSidebar({
     const synced: DocumentMeta[] = [];
     const local: DocumentMeta[] = [];
     for (const doc of documents) {
-      (doc.origin === "synced" ? synced : local).push(doc);
+      (doc.source === "synced" ? synced : local).push(doc);
     }
     return { syncedDocs: synced, localDocs: local };
   }, [documents]);

--- a/packages/app/src/components/OfflineAwareSyncedContainer.tsx
+++ b/packages/app/src/components/OfflineAwareSyncedContainer.tsx
@@ -19,7 +19,7 @@ import {
   reconcileOfflineEdits,
   type ReconnectResult,
 } from "../documents/reconnect";
-import { ApiDocumentRepository } from "../documents/api-repository";
+import { useSyncedRepository } from "../documents/useSyncedRepository";
 import { useDocumentManagerContext } from "../documents/useDocumentManagerContext";
 
 type Mode =
@@ -42,8 +42,6 @@ interface OfflineAwareSyncedContainerProps {
   colorScheme?: "light" | "dark" | "system";
 }
 
-const repository = new ApiDocumentRepository();
-
 // Owns the sync editor lifecycle: startup cache restore, offline fallback,
 // reconnect reconciliation, and switching to a forked document on conflict.
 // The live WebSocket-backed editor itself stays inside SyncedAnipresContainer.
@@ -53,6 +51,7 @@ export function OfflineAwareSyncedContainer({
 }: OfflineAwareSyncedContainerProps) {
   const [mode, setMode] = useState<Mode>({ type: "loading" });
   const { refreshDocuments, selectDocument } = useDocumentManagerContext();
+  const repository = useSyncedRepository();
   const currentSessionId = getSyncCacheSessionId();
 
   // Track the offline editor so we can grab its snapshot for reconciliation.
@@ -139,6 +138,12 @@ export function OfflineAwareSyncedContainer({
       return;
     }
     if (mode.type !== "offline" && mode.type !== "reconnecting") return;
+
+    // The synced repo is bound to a workspace at login. If somehow we
+    // got here without one (logged out mid-flow, race during workspace
+    // discovery), there's no server to reconcile against — stay
+    // offline and let a future reconnect retry the path.
+    if (!repository) return;
 
     const recovery = mode.recovery;
     let snapshot: TLStoreSnapshot = mode.snapshot;
@@ -230,7 +235,14 @@ export function OfflineAwareSyncedContainer({
         recovery,
       });
     }
-  }, [mode, documentId, currentSessionId, refreshDocuments, selectDocument]);
+  }, [
+    mode,
+    documentId,
+    currentSessionId,
+    refreshDocuments,
+    selectDocument,
+    repository,
+  ]);
 
   useEffect(() => {
     retryHandleOnlineRef.current = () => {

--- a/packages/app/src/documents/SyncedRepositoryContext.tsx
+++ b/packages/app/src/documents/SyncedRepositoryContext.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+import type { ApiDocumentRepository } from "./api-repository";
+import { SyncedRepositoryContext } from "./useSyncedRepository";
+
+export function SyncedRepositoryProvider({
+  repository,
+  children,
+}: {
+  repository: ApiDocumentRepository | null;
+  children: ReactNode;
+}) {
+  return (
+    <SyncedRepositoryContext.Provider value={repository}>
+      {children}
+    </SyncedRepositoryContext.Provider>
+  );
+}

--- a/packages/app/src/documents/api-repository.test.ts
+++ b/packages/app/src/documents/api-repository.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiDocumentRepository } from "./api-repository";
+import type { DocumentData } from "./types";
 
 function jsonResponse(body: unknown, status = 200): Response {
   return {
@@ -94,7 +95,7 @@ describe("ApiDocumentRepository", () => {
       }),
     );
 
-    const result = await repo.create({
+    const result = await repo.save({
       meta: {
         id: docId,
         title: "Title",
@@ -105,35 +106,35 @@ describe("ApiDocumentRepository", () => {
       snapshot: null,
     });
 
-    // The id is the same one the caller minted; slug and updated_at
-    // come from the server.
+    // The id is the same one the caller minted; slug, created_at,
+    // and updated_at come from the server response.
     expect(result.meta.id).toBe(docId);
     expect(result.meta.slug).toBe("server-slug");
     expect(result.meta.sortOrder).toBe("a0");
     expect(result.meta.updatedAt).toBe(20);
 
-    // The wire body sends:
-    //   - id: from the draft (client-allocated UUID v7)
+    // PUT goes to /api/documents/:id (id in URL, not body). The body
+    // sends:
     //   - workspace_id: from the repo's binding
     //   - title, sort_order: from the draft
     //   - created_at: only when the caller set it (migration use case)
     // updated_at and slug never appear — the server stamps both.
     const [url, init] = vi.mocked(fetch).mock.calls[0];
-    expect(url).toBe("/api/documents");
-    expect(init?.method).toBe("POST");
+    expect(url).toBe(`/api/documents/${docId}`);
+    expect(init?.method).toBe("PUT");
     const sent = JSON.parse((init?.body as string) ?? "{}");
     expect(sent).toEqual({
-      id: docId,
       workspace_id: TEST_WORKSPACE_ID,
       title: "Title",
       sort_order: "a0",
       created_at: 10,
     });
+    expect(sent).not.toHaveProperty("id");
     expect(sent).not.toHaveProperty("slug");
     expect(sent).not.toHaveProperty("updated_at");
   });
 
-  it("create omits created_at when the caller doesn't supply one", async () => {
+  it("save omits created_at when the caller doesn't supply one", async () => {
     const docId = "0190e7c0-9c52-7000-9d4f-1a2b3c4d5e6f";
     vi.mocked(fetch).mockResolvedValueOnce(
       jsonResponse({
@@ -146,7 +147,7 @@ describe("ApiDocumentRepository", () => {
       }),
     );
 
-    await repo.create({
+    await repo.save({
       meta: {
         id: docId,
         title: "Fresh",
@@ -159,7 +160,6 @@ describe("ApiDocumentRepository", () => {
     const [, init] = vi.mocked(fetch).mock.calls[0];
     const sent = JSON.parse((init?.body as string) ?? "{}");
     expect(sent).toEqual({
-      id: docId,
       workspace_id: TEST_WORKSPACE_ID,
       title: "Fresh",
       sort_order: "a0",
@@ -167,33 +167,55 @@ describe("ApiDocumentRepository", () => {
     expect(sent).not.toHaveProperty("created_at");
   });
 
-  it("update PUTs to /api/documents/:id with snake_case body", async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ ok: true }));
+  it("save accepts a full DocumentData (re-save / update path)", async () => {
+    const docId = "0190e7c0-9c52-7000-9d4f-1a2b3c4d5e6f";
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({
+        id: docId,
+        slug: "doc-slug",
+        title: "Renamed",
+        sort_order: "a1",
+        created_at: 1,
+        updated_at: 999,
+      }),
+    );
 
-    await repo.update({
+    // Pass a full DocumentData (with all timestamps and slug). The
+    // repo only forwards the meaningful fields to the wire; extras
+    // are dropped. DocumentData is structurally a superset of
+    // DocumentDraft, so the call is valid; the local-variable typing
+    // hop avoids TS's excess-property check on object literals.
+    const data: DocumentData = {
       meta: {
-        id: "42",
-        slug: "ignored-on-update",
-        title: "New Title",
+        id: docId,
+        slug: "ignored",
+        title: "Renamed",
         sortOrder: "a1",
-        createdAt: 0,
+        createdAt: 1,
         updatedAt: 99,
         origin: "synced",
       },
       snapshot: null,
-    });
+    };
+    await repo.save(data);
 
     const [url, init] = vi.mocked(fetch).mock.calls[0];
-    expect(url).toBe("/api/documents/42");
+    expect(url).toBe(`/api/documents/${docId}`);
     expect(init?.method).toBe("PUT");
     const sent = JSON.parse((init?.body as string) ?? "{}");
-    // updated_at is not sent: the server's updated_at trigger refreshes
-    // the row's timestamp on any UPDATE that doesn't already set it.
+    // The wire body has no updated_at (server's trigger handles it),
+    // no slug (server-allocated on insert; ignored on update), and no
+    // id (it's in the URL). created_at is forwarded because the
+    // caller's draft had it set.
     expect(sent).toEqual({
-      title: "New Title",
+      workspace_id: TEST_WORKSPACE_ID,
+      title: "Renamed",
       sort_order: "a1",
+      created_at: 1,
     });
     expect(sent).not.toHaveProperty("updated_at");
+    expect(sent).not.toHaveProperty("slug");
+    expect(sent).not.toHaveProperty("id");
   });
 
   it("delete sends DELETE to /api/documents/:id", async () => {

--- a/packages/app/src/documents/api-repository.test.ts
+++ b/packages/app/src/documents/api-repository.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiDocumentRepository } from "./api-repository";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+describe("ApiDocumentRepository", () => {
+  let repo: ApiDocumentRepository;
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    repo = new ApiDocumentRepository();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("list maps server rows to DocumentMeta and preserves slug", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse([
+        {
+          id: "42",
+          slug: "hello-world",
+          title: "Hello",
+          sort_order: "a0",
+          created_at: 1,
+          updated_at: 2,
+        },
+      ]),
+    );
+
+    const list = await repo.list();
+
+    expect(list).toEqual([
+      {
+        id: "42",
+        slug: "hello-world",
+        title: "Hello",
+        sortOrder: "a0",
+        createdAt: 1,
+        updatedAt: 2,
+        origin: "synced",
+      },
+    ]);
+    expect(vi.mocked(fetch).mock.calls[0][0]).toBe("/api/documents");
+  });
+
+  it("get returns the document shape with slug propagated", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({
+        meta: {
+          id: "42",
+          slug: "hello-world",
+          title: "Hello",
+          sort_order: "a0",
+          created_at: 1,
+          updated_at: 2,
+        },
+        snapshot: null,
+      }),
+    );
+
+    const result = await repo.get("42");
+
+    expect(result?.meta.slug).toBe("hello-world");
+    expect(result?.meta.sortOrder).toBe("a0");
+    expect(result?.snapshot).toBeNull();
+  });
+
+  it("get returns undefined on 404", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse(null, 404));
+    expect(await repo.get("missing")).toBeUndefined();
+  });
+
+  it("create POSTs metadata-only body and returns server-allocated id and slug", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({
+        id: "100",
+        slug: "server-slug",
+        title: "Title",
+        sort_order: "a0",
+        created_at: 10,
+        updated_at: 20,
+      }),
+    );
+
+    const result = await repo.create({
+      meta: {
+        // The client-provided id is ignored by the server. We pass a
+        // placeholder UUID; the returned doc carries the canonical id.
+        id: "client-placeholder",
+        title: "Title",
+        sortOrder: "a0",
+        createdAt: 10,
+        updatedAt: 20,
+        origin: "synced",
+      },
+      snapshot: null,
+    });
+
+    // Server-allocated id and slug surface in the result.
+    expect(result.meta.id).toBe("100");
+    expect(result.meta.slug).toBe("server-slug");
+    expect(result.meta.sortOrder).toBe("a0");
+
+    // The wire body uses snake_case field names and excludes the id.
+    const [url, init] = vi.mocked(fetch).mock.calls[0];
+    expect(url).toBe("/api/documents");
+    expect(init?.method).toBe("POST");
+    const sent = JSON.parse((init?.body as string) ?? "{}");
+    expect(sent).toEqual({
+      title: "Title",
+      sort_order: "a0",
+      created_at: 10,
+      updated_at: 20,
+    });
+    expect(sent).not.toHaveProperty("id");
+    expect(sent).not.toHaveProperty("slug");
+  });
+
+  it("update PUTs to /api/documents/:id with snake_case body", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    await repo.update({
+      meta: {
+        id: "42",
+        slug: "ignored-on-update",
+        title: "New Title",
+        sortOrder: "a1",
+        createdAt: 0,
+        updatedAt: 99,
+        origin: "synced",
+      },
+      snapshot: null,
+    });
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0];
+    expect(url).toBe("/api/documents/42");
+    expect(init?.method).toBe("PUT");
+    const sent = JSON.parse((init?.body as string) ?? "{}");
+    expect(sent).toEqual({
+      title: "New Title",
+      sort_order: "a1",
+      updated_at: 99,
+    });
+  });
+
+  it("delete sends DELETE to /api/documents/:id", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(jsonResponse({ ok: true }));
+    await repo.delete("42");
+    const [url, init] = vi.mocked(fetch).mock.calls[0];
+    expect(url).toBe("/api/documents/42");
+    expect(init?.method).toBe("DELETE");
+  });
+});

--- a/packages/app/src/documents/api-repository.test.ts
+++ b/packages/app/src/documents/api-repository.test.ts
@@ -92,24 +92,24 @@ describe("ApiDocumentRepository", () => {
 
     const result = await repo.create({
       meta: {
-        // The client-provided id is ignored by the server. We pass a
-        // placeholder UUID; the returned doc carries the canonical id.
-        id: "client-placeholder",
         title: "Title",
         sortOrder: "a0",
         createdAt: 10,
-        updatedAt: 20,
         origin: "synced",
       },
       snapshot: null,
     });
 
-    // Server-allocated id and slug surface in the result.
+    // Server-allocated id, slug, and updated_at surface in the result.
     expect(result.meta.id).toBe("100");
     expect(result.meta.slug).toBe("server-slug");
     expect(result.meta.sortOrder).toBe("a0");
+    expect(result.meta.updatedAt).toBe(20);
 
-    // The wire body uses snake_case field names and excludes the id.
+    // The wire body sends only the fields the caller actually supplied:
+    // title, sort_order, and (because the caller set it explicitly here
+    // for the migration use case) created_at. updated_at and id never
+    // appear — the server stamps the former and allocates the latter.
     const [url, init] = vi.mocked(fetch).mock.calls[0];
     expect(url).toBe("/api/documents");
     expect(init?.method).toBe("POST");
@@ -118,10 +118,37 @@ describe("ApiDocumentRepository", () => {
       title: "Title",
       sort_order: "a0",
       created_at: 10,
-      updated_at: 20,
     });
     expect(sent).not.toHaveProperty("id");
     expect(sent).not.toHaveProperty("slug");
+    expect(sent).not.toHaveProperty("updated_at");
+  });
+
+  it("create omits created_at when the caller doesn't supply one", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({
+        id: "101",
+        slug: "fresh-doc",
+        title: "Fresh",
+        sort_order: "a0",
+        created_at: 50,
+        updated_at: 50,
+      }),
+    );
+
+    await repo.create({
+      meta: {
+        title: "Fresh",
+        sortOrder: "a0",
+        origin: "synced",
+      },
+      snapshot: null,
+    });
+
+    const [, init] = vi.mocked(fetch).mock.calls[0];
+    const sent = JSON.parse((init?.body as string) ?? "{}");
+    expect(sent).toEqual({ title: "Fresh", sort_order: "a0" });
+    expect(sent).not.toHaveProperty("created_at");
   });
 
   it("update PUTs to /api/documents/:id with snake_case body", async () => {
@@ -144,11 +171,13 @@ describe("ApiDocumentRepository", () => {
     expect(url).toBe("/api/documents/42");
     expect(init?.method).toBe("PUT");
     const sent = JSON.parse((init?.body as string) ?? "{}");
+    // updated_at is not sent: the server's updated_at trigger refreshes
+    // the row's timestamp on any UPDATE that doesn't already set it.
     expect(sent).toEqual({
       title: "New Title",
       sort_order: "a1",
-      updated_at: 99,
     });
+    expect(sent).not.toHaveProperty("updated_at");
   });
 
   it("delete sends DELETE to /api/documents/:id", async () => {

--- a/packages/app/src/documents/api-repository.test.ts
+++ b/packages/app/src/documents/api-repository.test.ts
@@ -81,10 +81,11 @@ describe("ApiDocumentRepository", () => {
     expect(await repo.get("missing")).toBeUndefined();
   });
 
-  it("create POSTs metadata-only body and returns server-allocated id and slug", async () => {
+  it("create POSTs the client-supplied id and returns server-stamped fields", async () => {
+    const docId = "0190e7c0-9c52-7000-9d4f-1a2b3c4d5e6f";
     vi.mocked(fetch).mockResolvedValueOnce(
       jsonResponse({
-        id: "100",
+        id: docId,
         slug: "server-slug",
         title: "Title",
         sort_order: "a0",
@@ -95,6 +96,7 @@ describe("ApiDocumentRepository", () => {
 
     const result = await repo.create({
       meta: {
+        id: docId,
         title: "Title",
         sortOrder: "a0",
         createdAt: 10,
@@ -103,37 +105,39 @@ describe("ApiDocumentRepository", () => {
       snapshot: null,
     });
 
-    // Server-allocated id, slug, and updated_at surface in the result.
-    expect(result.meta.id).toBe("100");
+    // The id is the same one the caller minted; slug and updated_at
+    // come from the server.
+    expect(result.meta.id).toBe(docId);
     expect(result.meta.slug).toBe("server-slug");
     expect(result.meta.sortOrder).toBe("a0");
     expect(result.meta.updatedAt).toBe(20);
 
     // The wire body sends:
+    //   - id: from the draft (client-allocated UUID v7)
     //   - workspace_id: from the repo's binding
     //   - title, sort_order: from the draft
     //   - created_at: only when the caller set it (migration use case)
-    // updated_at and id never appear — the server stamps the former
-    // and allocates the latter.
+    // updated_at and slug never appear — the server stamps both.
     const [url, init] = vi.mocked(fetch).mock.calls[0];
     expect(url).toBe("/api/documents");
     expect(init?.method).toBe("POST");
     const sent = JSON.parse((init?.body as string) ?? "{}");
     expect(sent).toEqual({
+      id: docId,
       workspace_id: TEST_WORKSPACE_ID,
       title: "Title",
       sort_order: "a0",
       created_at: 10,
     });
-    expect(sent).not.toHaveProperty("id");
     expect(sent).not.toHaveProperty("slug");
     expect(sent).not.toHaveProperty("updated_at");
   });
 
   it("create omits created_at when the caller doesn't supply one", async () => {
+    const docId = "0190e7c0-9c52-7000-9d4f-1a2b3c4d5e6f";
     vi.mocked(fetch).mockResolvedValueOnce(
       jsonResponse({
-        id: "101",
+        id: docId,
         slug: "fresh-doc",
         title: "Fresh",
         sort_order: "a0",
@@ -144,6 +148,7 @@ describe("ApiDocumentRepository", () => {
 
     await repo.create({
       meta: {
+        id: docId,
         title: "Fresh",
         sortOrder: "a0",
         origin: "synced",
@@ -154,6 +159,7 @@ describe("ApiDocumentRepository", () => {
     const [, init] = vi.mocked(fetch).mock.calls[0];
     const sent = JSON.parse((init?.body as string) ?? "{}");
     expect(sent).toEqual({
+      id: docId,
       workspace_id: TEST_WORKSPACE_ID,
       title: "Fresh",
       sort_order: "a0",

--- a/packages/app/src/documents/api-repository.test.ts
+++ b/packages/app/src/documents/api-repository.test.ts
@@ -11,10 +11,11 @@ function jsonResponse(body: unknown, status = 200): Response {
 
 describe("ApiDocumentRepository", () => {
   let repo: ApiDocumentRepository;
+  const TEST_WORKSPACE_ID = "5";
 
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
-    repo = new ApiDocumentRepository();
+    repo = new ApiDocumentRepository(TEST_WORKSPACE_ID);
   });
 
   afterEach(() => {
@@ -48,7 +49,9 @@ describe("ApiDocumentRepository", () => {
         origin: "synced",
       },
     ]);
-    expect(vi.mocked(fetch).mock.calls[0][0]).toBe("/api/documents");
+    expect(vi.mocked(fetch).mock.calls[0][0]).toBe(
+      `/api/documents?workspace_id=${TEST_WORKSPACE_ID}`,
+    );
   });
 
   it("get returns the document shape with slug propagated", async () => {
@@ -106,15 +109,18 @@ describe("ApiDocumentRepository", () => {
     expect(result.meta.sortOrder).toBe("a0");
     expect(result.meta.updatedAt).toBe(20);
 
-    // The wire body sends only the fields the caller actually supplied:
-    // title, sort_order, and (because the caller set it explicitly here
-    // for the migration use case) created_at. updated_at and id never
-    // appear — the server stamps the former and allocates the latter.
+    // The wire body sends:
+    //   - workspace_id: from the repo's binding
+    //   - title, sort_order: from the draft
+    //   - created_at: only when the caller set it (migration use case)
+    // updated_at and id never appear — the server stamps the former
+    // and allocates the latter.
     const [url, init] = vi.mocked(fetch).mock.calls[0];
     expect(url).toBe("/api/documents");
     expect(init?.method).toBe("POST");
     const sent = JSON.parse((init?.body as string) ?? "{}");
     expect(sent).toEqual({
+      workspace_id: TEST_WORKSPACE_ID,
       title: "Title",
       sort_order: "a0",
       created_at: 10,
@@ -147,7 +153,11 @@ describe("ApiDocumentRepository", () => {
 
     const [, init] = vi.mocked(fetch).mock.calls[0];
     const sent = JSON.parse((init?.body as string) ?? "{}");
-    expect(sent).toEqual({ title: "Fresh", sort_order: "a0" });
+    expect(sent).toEqual({
+      workspace_id: TEST_WORKSPACE_ID,
+      title: "Fresh",
+      sort_order: "a0",
+    });
     expect(sent).not.toHaveProperty("created_at");
   });
 

--- a/packages/app/src/documents/api-repository.test.ts
+++ b/packages/app/src/documents/api-repository.test.ts
@@ -47,7 +47,7 @@ describe("ApiDocumentRepository", () => {
         sortOrder: "a0",
         createdAt: 1,
         updatedAt: 2,
-        origin: "synced",
+        source: "synced",
       },
     ]);
     expect(vi.mocked(fetch).mock.calls[0][0]).toBe(
@@ -101,7 +101,7 @@ describe("ApiDocumentRepository", () => {
         title: "Title",
         sortOrder: "a0",
         createdAt: 10,
-        origin: "synced",
+        source: "synced",
       },
       snapshot: null,
     });
@@ -116,7 +116,7 @@ describe("ApiDocumentRepository", () => {
     // PUT goes to /api/documents/:id (id in URL, not body). The body
     // sends:
     //   - workspace_id: from the repo's binding
-    //   - title, sort_order: from the draft
+    //   - title, sort_order: from the input
     //   - created_at: only when the caller set it (migration use case)
     // updated_at and slug never appear — the server stamps both.
     const [url, init] = vi.mocked(fetch).mock.calls[0];
@@ -152,7 +152,7 @@ describe("ApiDocumentRepository", () => {
         id: docId,
         title: "Fresh",
         sortOrder: "a0",
-        origin: "synced",
+        source: "synced",
       },
       snapshot: null,
     });
@@ -183,7 +183,7 @@ describe("ApiDocumentRepository", () => {
     // Pass a full DocumentData (with all timestamps and slug). The
     // repo only forwards the meaningful fields to the wire; extras
     // are dropped. DocumentData is structurally a superset of
-    // DocumentDraft, so the call is valid; the local-variable typing
+    // DocumentInput, so the call is valid; the local-variable typing
     // hop avoids TS's excess-property check on object literals.
     const data: DocumentData = {
       meta: {
@@ -193,7 +193,7 @@ describe("ApiDocumentRepository", () => {
         sortOrder: "a1",
         createdAt: 1,
         updatedAt: 99,
-        origin: "synced",
+        source: "synced",
       },
       snapshot: null,
     };
@@ -206,7 +206,7 @@ describe("ApiDocumentRepository", () => {
     // The wire body has no updated_at (server's trigger handles it),
     // no slug (server-allocated on insert; ignored on update), and no
     // id (it's in the URL). created_at is forwarded because the
-    // caller's draft had it set.
+    // caller's input had it set.
     expect(sent).toEqual({
       workspace_id: TEST_WORKSPACE_ID,
       title: "Renamed",

--- a/packages/app/src/documents/api-repository.ts
+++ b/packages/app/src/documents/api-repository.ts
@@ -1,5 +1,5 @@
 import type { DocumentRepository } from "./repository";
-import type { DocumentData, DocumentDraft, DocumentMeta } from "./types";
+import type { DocumentData, DocumentInput, DocumentMeta } from "./types";
 
 // Document ids are client-allocated UUID v7 strings (see
 // `packages/worker/migrations/0001_initial_schema.sql` design note).
@@ -22,7 +22,7 @@ function rowToMeta(row: DocumentRow): DocumentMeta {
     sortOrder: row.sort_order,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
-    origin: "synced",
+    source: "synced",
   };
 }
 
@@ -71,7 +71,7 @@ export class ApiDocumentRepository implements DocumentRepository {
    *
    * The id is in the URL path; it's not duplicated in the body.
    */
-  async save(draft: DocumentDraft): Promise<DocumentData> {
+  async save(input: DocumentInput): Promise<DocumentData> {
     const body: {
       workspace_id: string;
       title: string;
@@ -79,14 +79,14 @@ export class ApiDocumentRepository implements DocumentRepository {
       created_at?: number;
     } = {
       workspace_id: this.workspaceId,
-      title: draft.meta.title,
-      sort_order: draft.meta.sortOrder,
+      title: input.meta.title,
+      sort_order: input.meta.sortOrder,
     };
-    if (draft.meta.createdAt !== undefined) {
-      body.created_at = draft.meta.createdAt;
+    if (input.meta.createdAt !== undefined) {
+      body.created_at = input.meta.createdAt;
     }
     const res = await fetch(
-      `/api/documents/${encodeURIComponent(draft.meta.id)}`,
+      `/api/documents/${encodeURIComponent(input.meta.id)}`,
       {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -101,7 +101,7 @@ export class ApiDocumentRepository implements DocumentRepository {
       meta: rowToMeta(row),
       // Snapshot is uploaded separately (PUT /api/documents/:id/snapshot);
       // the save response only carries metadata.
-      snapshot: draft.snapshot,
+      snapshot: input.snapshot,
     };
   }
 

--- a/packages/app/src/documents/api-repository.ts
+++ b/packages/app/src/documents/api-repository.ts
@@ -25,9 +25,25 @@ function rowToMeta(row: DocumentRow): DocumentMeta {
   };
 }
 
+/**
+ * Documents are workspace-owned on the server. Every list/create call
+ * has to name the workspace it's targeting; an `ApiDocumentRepository`
+ * instance is bound to one workspace for its lifetime. App-level code
+ * is responsible for resolving the user's workspace_id (via
+ * `GET /api/workspaces`) and constructing the repo with it.
+ *
+ * Per-document operations (`get`, `update`, `delete`) take a doc id
+ * which already implicitly identifies a workspace, so they don't need
+ * the workspace_id at the wire layer — the server still verifies that
+ * the doc lives in a workspace the requesting user owns.
+ */
 export class ApiDocumentRepository implements DocumentRepository {
+  constructor(private readonly workspaceId: string) {}
+
   async list(): Promise<DocumentMeta[]> {
-    const res = await fetch("/api/documents");
+    const res = await fetch(
+      `/api/documents?workspace_id=${encodeURIComponent(this.workspaceId)}`,
+    );
     if (!res.ok) throw new Error(`Failed to list documents: ${res.status}`);
     const rows: DocumentRow[] = await res.json();
     return rows.map(rowToMeta);
@@ -46,18 +62,22 @@ export class ApiDocumentRepository implements DocumentRepository {
 
   /**
    * POST /api/documents — server allocates id, slug, and `updated_at`.
-   * `created_at` is sent only when the caller explicitly supplies it
-   * (the local→synced migration uses this to preserve the on-device
-   * creation time); otherwise the server stamps it. Any caller-
-   * supplied `id` on the draft is silently dropped — the returned
-   * doc carries the canonical id (a stringified INTEGER from the server).
+   * The body carries the workspace_id (server enforces ownership) and
+   * the user-meaningful fields. `created_at` is sent only when the
+   * caller explicitly supplies it (the local→synced migration uses
+   * this to preserve the on-device creation time); otherwise the
+   * server stamps it. Any caller-supplied `id` on the draft is
+   * silently dropped — the returned doc carries the canonical id (a
+   * stringified INTEGER from the server).
    */
   async create(draft: DocumentDraft): Promise<DocumentData> {
     const body: {
+      workspace_id: string;
       title: string;
       sort_order: string;
       created_at?: number;
     } = {
+      workspace_id: this.workspaceId,
       title: draft.meta.title,
       sort_order: draft.meta.sortOrder,
     };

--- a/packages/app/src/documents/api-repository.ts
+++ b/packages/app/src/documents/api-repository.ts
@@ -1,5 +1,5 @@
 import type { DocumentRepository } from "./repository";
-import type { DocumentData, DocumentMeta } from "./types";
+import type { DocumentData, DocumentDraft, DocumentMeta } from "./types";
 
 // Server serializes documents.id as a string (decimal-of-INTEGER) so
 // the client can keep an opaque-string id type without worrying about
@@ -45,19 +45,19 @@ export class ApiDocumentRepository implements DocumentRepository {
   }
 
   /**
-   * POST /api/documents — server allocates id and slug. Caller's
-   * `data.meta.id` is ignored; the returned doc carries the
-   * canonical id (a stringified INTEGER from the server).
+   * POST /api/documents — server allocates id and slug. Any caller-
+   * supplied `id` on the draft is silently dropped; the returned doc
+   * carries the canonical id (a stringified INTEGER from the server).
    */
-  async create(data: DocumentData): Promise<DocumentData> {
+  async create(draft: DocumentDraft): Promise<DocumentData> {
     const res = await fetch("/api/documents", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        title: data.meta.title,
-        sort_order: data.meta.sortOrder,
-        created_at: data.meta.createdAt,
-        updated_at: data.meta.updatedAt,
+        title: draft.meta.title,
+        sort_order: draft.meta.sortOrder,
+        created_at: draft.meta.createdAt,
+        updated_at: draft.meta.updatedAt,
       }),
     });
     if (!res.ok) {
@@ -68,7 +68,7 @@ export class ApiDocumentRepository implements DocumentRepository {
       meta: rowToMeta(row),
       // Snapshot is uploaded separately (PUT /api/documents/:id/snapshot);
       // the create response only carries metadata.
-      snapshot: data.snapshot,
+      snapshot: draft.snapshot,
     };
   }
 

--- a/packages/app/src/documents/api-repository.ts
+++ b/packages/app/src/documents/api-repository.ts
@@ -1,10 +1,14 @@
 import type { DocumentRepository } from "./repository";
 import type { DocumentData, DocumentMeta } from "./types";
 
+// Server serializes documents.id as a string (decimal-of-INTEGER) so
+// the client can keep an opaque-string id type without worrying about
+// JSON number precision.
 interface DocumentRow {
   id: string;
+  slug: string;
   title: string;
-  order: number;
+  sort_order: string;
   created_at: number;
   updated_at: number;
 }
@@ -12,8 +16,9 @@ interface DocumentRow {
 function rowToMeta(row: DocumentRow): DocumentMeta {
   return {
     id: row.id,
+    slug: row.slug,
     title: row.title,
-    order: row.order,
+    sortOrder: row.sort_order,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     origin: "synced",
@@ -39,7 +44,35 @@ export class ApiDocumentRepository implements DocumentRepository {
     };
   }
 
-  async save(data: DocumentData): Promise<void> {
+  /**
+   * POST /api/documents — server allocates id and slug. Caller's
+   * `data.meta.id` is ignored; the returned doc carries the
+   * canonical id (a stringified INTEGER from the server).
+   */
+  async create(data: DocumentData): Promise<DocumentData> {
+    const res = await fetch("/api/documents", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: data.meta.title,
+        sort_order: data.meta.sortOrder,
+        created_at: data.meta.createdAt,
+        updated_at: data.meta.updatedAt,
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to create document: ${res.status}`);
+    }
+    const row: DocumentRow = await res.json();
+    return {
+      meta: rowToMeta(row),
+      // Snapshot is uploaded separately (PUT /api/documents/:id/snapshot);
+      // the create response only carries metadata.
+      snapshot: data.snapshot,
+    };
+  }
+
+  async update(data: DocumentData): Promise<void> {
     const res = await fetch(
       `/api/documents/${encodeURIComponent(data.meta.id)}`,
       {
@@ -47,13 +80,12 @@ export class ApiDocumentRepository implements DocumentRepository {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           title: data.meta.title,
-          order: data.meta.order,
-          created_at: data.meta.createdAt,
+          sort_order: data.meta.sortOrder,
           updated_at: data.meta.updatedAt,
         }),
       },
     );
-    if (!res.ok) throw new Error(`Failed to save document: ${res.status}`);
+    if (!res.ok) throw new Error(`Failed to update document: ${res.status}`);
   }
 
   async delete(id: string): Promise<void> {

--- a/packages/app/src/documents/api-repository.ts
+++ b/packages/app/src/documents/api-repository.ts
@@ -45,20 +45,29 @@ export class ApiDocumentRepository implements DocumentRepository {
   }
 
   /**
-   * POST /api/documents — server allocates id and slug. Any caller-
-   * supplied `id` on the draft is silently dropped; the returned doc
-   * carries the canonical id (a stringified INTEGER from the server).
+   * POST /api/documents — server allocates id, slug, and `updated_at`.
+   * `created_at` is sent only when the caller explicitly supplies it
+   * (the local→synced migration uses this to preserve the on-device
+   * creation time); otherwise the server stamps it. Any caller-
+   * supplied `id` on the draft is silently dropped — the returned
+   * doc carries the canonical id (a stringified INTEGER from the server).
    */
   async create(draft: DocumentDraft): Promise<DocumentData> {
+    const body: {
+      title: string;
+      sort_order: string;
+      created_at?: number;
+    } = {
+      title: draft.meta.title,
+      sort_order: draft.meta.sortOrder,
+    };
+    if (draft.meta.createdAt !== undefined) {
+      body.created_at = draft.meta.createdAt;
+    }
     const res = await fetch("/api/documents", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        title: draft.meta.title,
-        sort_order: draft.meta.sortOrder,
-        created_at: draft.meta.createdAt,
-        updated_at: draft.meta.updatedAt,
-      }),
+      body: JSON.stringify(body),
     });
     if (!res.ok) {
       throw new Error(`Failed to create document: ${res.status}`);
@@ -72,6 +81,8 @@ export class ApiDocumentRepository implements DocumentRepository {
     };
   }
 
+  // PUT /api/documents/:id — caller's `updatedAt` is not sent; the
+  // server's updated_at trigger refreshes the row's timestamp.
   async update(data: DocumentData): Promise<void> {
     const res = await fetch(
       `/api/documents/${encodeURIComponent(data.meta.id)}`,
@@ -81,7 +92,6 @@ export class ApiDocumentRepository implements DocumentRepository {
         body: JSON.stringify({
           title: data.meta.title,
           sort_order: data.meta.sortOrder,
-          updated_at: data.meta.updatedAt,
         }),
       },
     );

--- a/packages/app/src/documents/api-repository.ts
+++ b/packages/app/src/documents/api-repository.ts
@@ -1,9 +1,10 @@
 import type { DocumentRepository } from "./repository";
 import type { DocumentData, DocumentDraft, DocumentMeta } from "./types";
 
-// Server serializes documents.id as a string (decimal-of-INTEGER) so
-// the client can keep an opaque-string id type without worrying about
-// JSON number precision.
+// Document ids are client-allocated UUID v7 strings (see
+// `packages/worker/migrations/0001_initial_schema.sql` design note).
+// The wire shape mirrors the D1 row directly — no per-field coercion
+// needed.
 interface DocumentRow {
   id: string;
   slug: string;
@@ -61,22 +62,23 @@ export class ApiDocumentRepository implements DocumentRepository {
   }
 
   /**
-   * POST /api/documents — server allocates id, slug, and `updated_at`.
-   * The body carries the workspace_id (server enforces ownership) and
-   * the user-meaningful fields. `created_at` is sent only when the
-   * caller explicitly supplies it (the local→synced migration uses
-   * this to preserve the on-device creation time); otherwise the
-   * server stamps it. Any caller-supplied `id` on the draft is
-   * silently dropped — the returned doc carries the canonical id (a
-   * stringified INTEGER from the server).
+   * POST /api/documents — caller supplies the document id (UUID v7);
+   * the server validates it, allocates the slug, and stamps
+   * `updated_at`. The body carries the workspace_id (server enforces
+   * ownership) and the user-meaningful fields. `created_at` is sent
+   * only when the caller explicitly supplies it (the local→synced
+   * migration uses this to preserve the on-device creation time);
+   * otherwise the server stamps it.
    */
   async create(draft: DocumentDraft): Promise<DocumentData> {
     const body: {
+      id: string;
       workspace_id: string;
       title: string;
       sort_order: string;
       created_at?: number;
     } = {
+      id: draft.meta.id,
       workspace_id: this.workspaceId,
       title: draft.meta.title,
       sort_order: draft.meta.sortOrder,

--- a/packages/app/src/documents/api-repository.ts
+++ b/packages/app/src/documents/api-repository.ts
@@ -27,15 +27,15 @@ function rowToMeta(row: DocumentRow): DocumentMeta {
 }
 
 /**
- * Documents are workspace-owned on the server. Every list/create call
+ * Documents are workspace-owned on the server. Every list/save call
  * has to name the workspace it's targeting; an `ApiDocumentRepository`
  * instance is bound to one workspace for its lifetime. App-level code
  * is responsible for resolving the user's workspace_id (via
  * `GET /api/workspaces`) and constructing the repo with it.
  *
- * Per-document operations (`get`, `update`, `delete`) take a doc id
- * which already implicitly identifies a workspace, so they don't need
- * the workspace_id at the wire layer — the server still verifies that
+ * Per-document operations (`get`, `delete`) take a doc id which
+ * already implicitly identifies a workspace, so they don't need the
+ * workspace_id at the wire layer — the server still verifies that
  * the doc lives in a workspace the requesting user owns.
  */
 export class ApiDocumentRepository implements DocumentRepository {
@@ -62,23 +62,22 @@ export class ApiDocumentRepository implements DocumentRepository {
   }
 
   /**
-   * POST /api/documents — caller supplies the document id (UUID v7);
-   * the server validates it, allocates the slug, and stamps
-   * `updated_at`. The body carries the workspace_id (server enforces
-   * ownership) and the user-meaningful fields. `created_at` is sent
+   * PUT /api/documents/:id — server-side upsert. The body always
+   * carries workspace_id, title, and sort_order; `created_at` is sent
    * only when the caller explicitly supplies it (the local→synced
-   * migration uses this to preserve the on-device creation time);
-   * otherwise the server stamps it.
+   * migration uses this to preserve the on-device creation time).
+   * The server stamps `updated_at` (via trigger) and the slug (on
+   * insert only) and returns the canonical row.
+   *
+   * The id is in the URL path; it's not duplicated in the body.
    */
-  async create(draft: DocumentDraft): Promise<DocumentData> {
+  async save(draft: DocumentDraft): Promise<DocumentData> {
     const body: {
-      id: string;
       workspace_id: string;
       title: string;
       sort_order: string;
       created_at?: number;
     } = {
-      id: draft.meta.id,
       workspace_id: this.workspaceId,
       title: draft.meta.title,
       sort_order: draft.meta.sortOrder,
@@ -86,38 +85,24 @@ export class ApiDocumentRepository implements DocumentRepository {
     if (draft.meta.createdAt !== undefined) {
       body.created_at = draft.meta.createdAt;
     }
-    const res = await fetch("/api/documents", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
+    const res = await fetch(
+      `/api/documents/${encodeURIComponent(draft.meta.id)}`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
     if (!res.ok) {
-      throw new Error(`Failed to create document: ${res.status}`);
+      throw new Error(`Failed to save document: ${res.status}`);
     }
     const row: DocumentRow = await res.json();
     return {
       meta: rowToMeta(row),
       // Snapshot is uploaded separately (PUT /api/documents/:id/snapshot);
-      // the create response only carries metadata.
+      // the save response only carries metadata.
       snapshot: draft.snapshot,
     };
-  }
-
-  // PUT /api/documents/:id — caller's `updatedAt` is not sent; the
-  // server's updated_at trigger refreshes the row's timestamp.
-  async update(data: DocumentData): Promise<void> {
-    const res = await fetch(
-      `/api/documents/${encodeURIComponent(data.meta.id)}`,
-      {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          title: data.meta.title,
-          sort_order: data.meta.sortOrder,
-        }),
-      },
-    );
-    if (!res.ok) throw new Error(`Failed to update document: ${res.status}`);
   }
 
   async delete(id: string): Promise<void> {

--- a/packages/app/src/documents/idb-repository.ts
+++ b/packages/app/src/documents/idb-repository.ts
@@ -1,6 +1,6 @@
 import { createStore, get, set, del, entries } from "idb-keyval";
 import type { DocumentRepository } from "./repository";
-import type { DocumentData, DocumentMeta } from "./types";
+import type { DocumentData, DocumentDraft, DocumentMeta } from "./types";
 
 const store = createStore("anipres-documents", "documents");
 
@@ -25,8 +25,10 @@ export class IdbDocumentRepository implements DocumentRepository {
   // Create and update collapse to the same `set()` call here — IDB
   // doesn't distinguish — but the interface keeps them separate so
   // the API repo can split POST (create) from PUT (update).
-  async create(data: DocumentData): Promise<DocumentData> {
-    await set(data.meta.id, data, store);
+  async create(draft: DocumentDraft): Promise<DocumentData> {
+    const id = draft.meta.id ?? crypto.randomUUID();
+    const data: DocumentData = { ...draft, meta: { ...draft.meta, id } };
+    await set(id, data, store);
     return { ...data, meta: stampLocal(data.meta) };
   }
 

--- a/packages/app/src/documents/idb-repository.ts
+++ b/packages/app/src/documents/idb-repository.ts
@@ -27,17 +27,15 @@ export class IdbDocumentRepository implements DocumentRepository {
   // the API repo can split POST (create) from PUT (update).
   async create(draft: DocumentDraft): Promise<DocumentData> {
     const now = Date.now();
-    const id = draft.meta.id ?? crypto.randomUUID();
     const data: DocumentData = {
       snapshot: draft.snapshot,
       meta: {
         ...draft.meta,
-        id,
         createdAt: draft.meta.createdAt ?? now,
         updatedAt: now,
       },
     };
-    await set(id, data, store);
+    await set(data.meta.id, data, store);
     return { ...data, meta: stampLocal(data.meta) };
   }
 

--- a/packages/app/src/documents/idb-repository.ts
+++ b/packages/app/src/documents/idb-repository.ts
@@ -1,11 +1,11 @@
 import { createStore, get, set, del, entries } from "idb-keyval";
 import type { DocumentRepository } from "./repository";
-import type { DocumentData, DocumentDraft, DocumentMeta } from "./types";
+import type { DocumentData, DocumentInput, DocumentMeta } from "./types";
 
 const store = createStore("anipres-documents", "documents");
 
 function stampLocal(meta: DocumentMeta): DocumentMeta {
-  return { ...meta, origin: "local" };
+  return { ...meta, source: "local" };
 }
 
 export class IdbDocumentRepository implements DocumentRepository {
@@ -23,21 +23,21 @@ export class IdbDocumentRepository implements DocumentRepository {
   }
 
   /**
-   * Insert or update the row at `draft.meta.id`. On insert, stamps
+   * Insert or update the row at `input.meta.id`. On insert, stamps
    * `createdAt` (honoring the optional override) and `updatedAt`. On
    * update, bumps `updatedAt` and preserves the existing `createdAt`
-   * — even if a different value is in `draft.meta.createdAt`, the
+   * — even if a different value is in `input.meta.createdAt`, the
    * stored row's createdAt wins, since it represents the actual
    * on-device creation moment.
    */
-  async save(draft: DocumentDraft): Promise<DocumentData> {
+  async save(input: DocumentInput): Promise<DocumentData> {
     const now = Date.now();
-    const existing = await get<DocumentData>(draft.meta.id, store);
+    const existing = await get<DocumentData>(input.meta.id, store);
     const data: DocumentData = {
-      snapshot: draft.snapshot,
+      snapshot: input.snapshot,
       meta: {
-        ...draft.meta,
-        createdAt: existing?.meta.createdAt ?? draft.meta.createdAt ?? now,
+        ...input.meta,
+        createdAt: existing?.meta.createdAt ?? input.meta.createdAt ?? now,
         updatedAt: now,
       },
     };

--- a/packages/app/src/documents/idb-repository.ts
+++ b/packages/app/src/documents/idb-repository.ts
@@ -26,14 +26,27 @@ export class IdbDocumentRepository implements DocumentRepository {
   // doesn't distinguish — but the interface keeps them separate so
   // the API repo can split POST (create) from PUT (update).
   async create(draft: DocumentDraft): Promise<DocumentData> {
+    const now = Date.now();
     const id = draft.meta.id ?? crypto.randomUUID();
-    const data: DocumentData = { ...draft, meta: { ...draft.meta, id } };
+    const data: DocumentData = {
+      snapshot: draft.snapshot,
+      meta: {
+        ...draft.meta,
+        id,
+        createdAt: draft.meta.createdAt ?? now,
+        updatedAt: now,
+      },
+    };
     await set(id, data, store);
     return { ...data, meta: stampLocal(data.meta) };
   }
 
   async update(data: DocumentData): Promise<void> {
-    await set(data.meta.id, data, store);
+    const stamped: DocumentData = {
+      ...data,
+      meta: { ...data.meta, updatedAt: Date.now() },
+    };
+    await set(stamped.meta.id, stamped, store);
   }
 
   async delete(id: string): Promise<void> {

--- a/packages/app/src/documents/idb-repository.ts
+++ b/packages/app/src/documents/idb-repository.ts
@@ -13,7 +13,7 @@ export class IdbDocumentRepository implements DocumentRepository {
     const all = await entries<string, DocumentData>(store);
     return all
       .map(([, data]) => stampLocal(data.meta))
-      .sort((a, b) => a.order - b.order);
+      .sort((a, b) => a.sortOrder.localeCompare(b.sortOrder));
   }
 
   async get(id: string): Promise<DocumentData | undefined> {
@@ -22,7 +22,15 @@ export class IdbDocumentRepository implements DocumentRepository {
     return { ...data, meta: stampLocal(data.meta) };
   }
 
-  async save(data: DocumentData): Promise<void> {
+  // Create and update collapse to the same `set()` call here — IDB
+  // doesn't distinguish — but the interface keeps them separate so
+  // the API repo can split POST (create) from PUT (update).
+  async create(data: DocumentData): Promise<DocumentData> {
+    await set(data.meta.id, data, store);
+    return { ...data, meta: stampLocal(data.meta) };
+  }
+
+  async update(data: DocumentData): Promise<void> {
     await set(data.meta.id, data, store);
   }
 

--- a/packages/app/src/documents/idb-repository.ts
+++ b/packages/app/src/documents/idb-repository.ts
@@ -22,29 +22,27 @@ export class IdbDocumentRepository implements DocumentRepository {
     return { ...data, meta: stampLocal(data.meta) };
   }
 
-  // Create and update collapse to the same `set()` call here — IDB
-  // doesn't distinguish — but the interface keeps them separate so
-  // the API repo can split POST (create) from PUT (update).
-  async create(draft: DocumentDraft): Promise<DocumentData> {
+  /**
+   * Insert or update the row at `draft.meta.id`. On insert, stamps
+   * `createdAt` (honoring the optional override) and `updatedAt`. On
+   * update, bumps `updatedAt` and preserves the existing `createdAt`
+   * — even if a different value is in `draft.meta.createdAt`, the
+   * stored row's createdAt wins, since it represents the actual
+   * on-device creation moment.
+   */
+  async save(draft: DocumentDraft): Promise<DocumentData> {
     const now = Date.now();
+    const existing = await get<DocumentData>(draft.meta.id, store);
     const data: DocumentData = {
       snapshot: draft.snapshot,
       meta: {
         ...draft.meta,
-        createdAt: draft.meta.createdAt ?? now,
+        createdAt: existing?.meta.createdAt ?? draft.meta.createdAt ?? now,
         updatedAt: now,
       },
     };
     await set(data.meta.id, data, store);
     return { ...data, meta: stampLocal(data.meta) };
-  }
-
-  async update(data: DocumentData): Promise<void> {
-    const stamped: DocumentData = {
-      ...data,
-      meta: { ...data.meta, updatedAt: Date.now() },
-    };
-    await set(stamped.meta.id, stamped, store);
   }
 
   async delete(id: string): Promise<void> {

--- a/packages/app/src/documents/migration.test.ts
+++ b/packages/app/src/documents/migration.test.ts
@@ -61,12 +61,6 @@ function makeFakeRepo(origin: DocumentOrigin, initial: DocumentData[] = []) {
   const store = new Map<string, DocumentData>();
   for (const d of initial) store.set(d.meta.id, d);
 
-  // For the API repo, the server allocates an INTEGER id. Tests that
-  // exercise the synced path can override this by providing their own
-  // create mock; the default below preserves the caller's id so
-  // assertions on specific ids stay simple.
-  let serverIdCounter = 1000;
-
   const list = vi.fn(
     async (): Promise<DocumentMeta[]> =>
       [...store.values()]
@@ -77,26 +71,20 @@ function makeFakeRepo(origin: DocumentOrigin, initial: DocumentData[] = []) {
     const d = store.get(id);
     return d ? { ...d, meta: { ...d.meta, origin } } : undefined;
   });
+  // Both local and synced repos honor the caller's id verbatim — UUID
+  // v7 is client-allocated, so the same id flows through every layer.
   const create = vi.fn(async (d: DocumentDraft): Promise<DocumentData> => {
-    // Synced repo allocates a server id; local repo honors any
-    // caller-supplied id and falls back to a fresh UUID otherwise.
-    // Mirror that policy so tests can exercise both.
-    const allocatedId =
-      origin === "synced"
-        ? String(++serverIdCounter)
-        : (d.meta.id ?? crypto.randomUUID());
     const now = Date.now();
     const stored: DocumentData = {
       ...d,
       meta: {
         ...d.meta,
-        id: allocatedId,
         origin,
         createdAt: d.meta.createdAt ?? now,
         updatedAt: now,
       },
     };
-    store.set(allocatedId, stored);
+    store.set(d.meta.id, stored);
     return stored;
   });
   const update = vi.fn(async (d: DocumentData): Promise<void> => {
@@ -320,7 +308,7 @@ describe("convertLocalDocToSynced", () => {
       .fn<(documentId: string, snapshot: TLStoreSnapshot) => Promise<void>>()
       .mockResolvedValue(undefined);
 
-    const result = await convertLocalDocToSynced({
+    await convertLocalDocToSynced({
       documentId: "doc-1",
       localRepository: localRepo.repo,
       syncedRepository: syncedRepo.repo,
@@ -329,20 +317,22 @@ describe("convertLocalDocToSynced", () => {
     });
 
     expect(syncedRepo.create).toHaveBeenCalledTimes(1);
-    // The synced repo allocates a server-side id; the migrated doc
-    // does NOT keep the local "doc-1" id.
-    expect(result.meta.id).not.toBe("doc-1");
-    expect(result.meta.origin).toBe("synced");
+    // With UUID v7 ids minted client-side, the synced doc keeps
+    // the same id as the local doc — no remap.
+    const synced = syncedRepo.store.get("doc-1");
+    expect(synced).toBeDefined();
+    expect(synced?.meta.origin).toBe("synced");
     // Sort-order is computed past the existing tail.
-    expect(result.meta.sortOrder > "a0").toBe(true);
+    expect(
+      synced?.meta.sortOrder !== undefined && synced.meta.sortOrder > "a0",
+    ).toBe(true);
 
-    // Asset upload and snapshot push both target the new server id,
-    // not the local UUID.
+    // Asset upload and snapshot push target the same id.
     expect(uploadAsset).toHaveBeenCalledTimes(1);
-    expect(uploadAsset.mock.calls[0][0]).toBe(result.meta.id);
+    expect(uploadAsset.mock.calls[0][0]).toBe("doc-1");
 
     expect(pushSnapshot).toHaveBeenCalledTimes(1);
-    expect(pushSnapshot.mock.calls[0][0]).toBe(result.meta.id);
+    expect(pushSnapshot.mock.calls[0][0]).toBe("doc-1");
     const pushedSnapshot = pushSnapshot.mock.calls[0][1];
     expect(getAssetSrc(pushedSnapshot, "asset:a")).toBe("/uploaded/asset:a");
 
@@ -472,19 +462,20 @@ describe("convertLocalDocToSynced", () => {
 
     const controller = new AbortController();
     // Abort mid-migration, right after syncedRepository.create runs.
+    // The synced doc is stored under the same id as the local doc
+    // (UUID v7 client-allocated, no remap).
     syncedRepo.repo.create = vi.fn(async (d: DocumentDraft) => {
       const now = Date.now();
       const allocated: DocumentData = {
         ...d,
         meta: {
           ...d.meta,
-          id: "server-1",
           origin: "synced",
           createdAt: d.meta.createdAt ?? now,
           updatedAt: now,
         },
       };
-      syncedRepo.store.set("server-1", allocated);
+      syncedRepo.store.set(d.meta.id, allocated);
       controller.abort();
       return allocated;
     });

--- a/packages/app/src/documents/migration.test.ts
+++ b/packages/app/src/documents/migration.test.ts
@@ -71,24 +71,23 @@ function makeFakeRepo(origin: DocumentOrigin, initial: DocumentData[] = []) {
     const d = store.get(id);
     return d ? { ...d, meta: { ...d.meta, origin } } : undefined;
   });
-  // Both local and synced repos honor the caller's id verbatim — UUID
-  // v7 is client-allocated, so the same id flows through every layer.
-  const create = vi.fn(async (d: DocumentDraft): Promise<DocumentData> => {
+  // Single upsert method matching the production repo. Both local and
+  // synced repos honor the caller's id verbatim — UUID v7 is
+  // client-allocated, so the same id flows through every layer.
+  const save = vi.fn(async (d: DocumentDraft): Promise<DocumentData> => {
     const now = Date.now();
+    const existing = store.get(d.meta.id);
     const stored: DocumentData = {
       ...d,
       meta: {
         ...d.meta,
         origin,
-        createdAt: d.meta.createdAt ?? now,
+        createdAt: existing?.meta.createdAt ?? d.meta.createdAt ?? now,
         updatedAt: now,
       },
     };
     store.set(d.meta.id, stored);
     return stored;
-  });
-  const update = vi.fn(async (d: DocumentData): Promise<void> => {
-    store.set(d.meta.id, d);
   });
   const del = vi.fn(async (id: string): Promise<void> => {
     store.delete(id);
@@ -96,11 +95,10 @@ function makeFakeRepo(origin: DocumentOrigin, initial: DocumentData[] = []) {
   const repo: DocumentRepository = {
     list,
     get,
-    create,
-    update,
+    save,
     delete: del,
   };
-  return { repo, store, list, get, create, update, delete: del };
+  return { repo, store, list, get, save, delete: del };
 }
 
 describe("isDataUrl", () => {
@@ -316,7 +314,7 @@ describe("convertLocalDocToSynced", () => {
       pushSnapshot,
     });
 
-    expect(syncedRepo.create).toHaveBeenCalledTimes(1);
+    expect(syncedRepo.save).toHaveBeenCalledTimes(1);
     // With UUID v7 ids minted client-side, the synced doc keeps
     // the same id as the local doc — no remap.
     const synced = syncedRepo.store.get("doc-1");
@@ -355,7 +353,7 @@ describe("convertLocalDocToSynced", () => {
       pushSnapshot,
     });
 
-    expect(syncedRepo.create).toHaveBeenCalledTimes(1);
+    expect(syncedRepo.save).toHaveBeenCalledTimes(1);
     expect(uploadAsset).not.toHaveBeenCalled();
     expect(pushSnapshot).not.toHaveBeenCalled();
     expect(localRepo.delete).toHaveBeenCalledWith("doc-1");
@@ -424,7 +422,7 @@ describe("convertLocalDocToSynced", () => {
         syncedRepository: syncedRepo.repo,
       }),
     ).rejects.toThrow(/not found/);
-    expect(syncedRepo.create).not.toHaveBeenCalled();
+    expect(syncedRepo.save).not.toHaveBeenCalled();
   });
 
   it("throws immediately without touching the repos when the abortSignal is already aborted", async () => {
@@ -449,7 +447,7 @@ describe("convertLocalDocToSynced", () => {
     ).rejects.toThrow();
 
     expect(localRepo.get).not.toHaveBeenCalled();
-    expect(syncedRepo.create).not.toHaveBeenCalled();
+    expect(syncedRepo.save).not.toHaveBeenCalled();
     expect(uploadAsset).not.toHaveBeenCalled();
     expect(pushSnapshot).not.toHaveBeenCalled();
     expect(localRepo.delete).not.toHaveBeenCalled();
@@ -464,7 +462,7 @@ describe("convertLocalDocToSynced", () => {
     // Abort mid-migration, right after syncedRepository.create runs.
     // The synced doc is stored under the same id as the local doc
     // (UUID v7 client-allocated, no remap).
-    syncedRepo.repo.create = vi.fn(async (d: DocumentDraft) => {
+    syncedRepo.repo.save = vi.fn(async (d: DocumentDraft) => {
       const now = Date.now();
       const allocated: DocumentData = {
         ...d,
@@ -495,7 +493,7 @@ describe("convertLocalDocToSynced", () => {
 
     // Server doc was created before the abort; the later snapshot
     // push was skipped and the local copy was not deleted.
-    expect(syncedRepo.repo.create).toHaveBeenCalledTimes(1);
+    expect(syncedRepo.repo.save).toHaveBeenCalledTimes(1);
     expect(pushSnapshot).not.toHaveBeenCalled();
     expect(localRepo.delete).not.toHaveBeenCalled();
   });
@@ -518,6 +516,6 @@ describe("convertLocalDocToSynced", () => {
         syncedRepository: syncedRepo.repo,
       }),
     ).rejects.toThrow(/not a local document/);
-    expect(syncedRepo.create).not.toHaveBeenCalled();
+    expect(syncedRepo.save).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/documents/migration.test.ts
+++ b/packages/app/src/documents/migration.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { TLStoreSnapshot } from "tldraw";
-import type { DocumentData, DocumentMeta, DocumentOrigin } from "./types";
+import type {
+  DocumentData,
+  DocumentDraft,
+  DocumentMeta,
+  DocumentOrigin,
+} from "./types";
 import type { DocumentRepository } from "./repository";
 import {
   convertLocalDocToSynced,
@@ -72,11 +77,14 @@ function makeFakeRepo(origin: DocumentOrigin, initial: DocumentData[] = []) {
     const d = store.get(id);
     return d ? { ...d, meta: { ...d.meta, origin } } : undefined;
   });
-  const create = vi.fn(async (d: DocumentData): Promise<DocumentData> => {
-    // Synced repo allocates a server id; local repo keeps the caller's
-    // id. Mirror that policy so tests can exercise both.
+  const create = vi.fn(async (d: DocumentDraft): Promise<DocumentData> => {
+    // Synced repo allocates a server id; local repo honors any
+    // caller-supplied id and falls back to a fresh UUID otherwise.
+    // Mirror that policy so tests can exercise both.
     const allocatedId =
-      origin === "synced" ? String(++serverIdCounter) : d.meta.id;
+      origin === "synced"
+        ? String(++serverIdCounter)
+        : (d.meta.id ?? crypto.randomUUID());
     const stored: DocumentData = {
       ...d,
       meta: { ...d.meta, id: allocatedId, origin },
@@ -457,7 +465,7 @@ describe("convertLocalDocToSynced", () => {
 
     const controller = new AbortController();
     // Abort mid-migration, right after syncedRepository.create runs.
-    syncedRepo.repo.create = vi.fn(async (d: DocumentData) => {
+    syncedRepo.repo.create = vi.fn(async (d: DocumentDraft) => {
       const allocated: DocumentData = {
         ...d,
         meta: { ...d.meta, id: "server-1", origin: "synced" },

--- a/packages/app/src/documents/migration.test.ts
+++ b/packages/app/src/documents/migration.test.ts
@@ -43,7 +43,7 @@ function makeLocalDoc(
     meta: {
       id,
       title: id,
-      order: 1,
+      sortOrder: "a0",
       createdAt: 0,
       updatedAt: 0,
       origin: "local",
@@ -56,24 +56,48 @@ function makeFakeRepo(origin: DocumentOrigin, initial: DocumentData[] = []) {
   const store = new Map<string, DocumentData>();
   for (const d of initial) store.set(d.meta.id, d);
 
+  // For the API repo, the server allocates an INTEGER id. Tests that
+  // exercise the synced path can override this by providing their own
+  // create mock; the default below preserves the caller's id so
+  // assertions on specific ids stay simple.
+  let serverIdCounter = 1000;
+
   const list = vi.fn(
     async (): Promise<DocumentMeta[]> =>
       [...store.values()]
         .map((d) => ({ ...d.meta, origin }))
-        .sort((a, b) => a.order - b.order),
+        .sort((a, b) => a.sortOrder.localeCompare(b.sortOrder)),
   );
   const get = vi.fn(async (id: string): Promise<DocumentData | undefined> => {
     const d = store.get(id);
     return d ? { ...d, meta: { ...d.meta, origin } } : undefined;
   });
-  const save = vi.fn(async (d: DocumentData): Promise<void> => {
+  const create = vi.fn(async (d: DocumentData): Promise<DocumentData> => {
+    // Synced repo allocates a server id; local repo keeps the caller's
+    // id. Mirror that policy so tests can exercise both.
+    const allocatedId =
+      origin === "synced" ? String(++serverIdCounter) : d.meta.id;
+    const stored: DocumentData = {
+      ...d,
+      meta: { ...d.meta, id: allocatedId, origin },
+    };
+    store.set(allocatedId, stored);
+    return stored;
+  });
+  const update = vi.fn(async (d: DocumentData): Promise<void> => {
     store.set(d.meta.id, d);
   });
   const del = vi.fn(async (id: string): Promise<void> => {
     store.delete(id);
   });
-  const repo: DocumentRepository = { list, get, save, delete: del };
-  return { repo, store, list, get, save, delete: del };
+  const repo: DocumentRepository = {
+    list,
+    get,
+    create,
+    update,
+    delete: del,
+  };
+  return { repo, store, list, get, create, update, delete: del };
 }
 
 describe("isDataUrl", () => {
@@ -256,13 +280,13 @@ describe("convertLocalDocToSynced", () => {
       "asset:a": assetRecord("asset:a", "data:image/png;base64,AAAA"),
     });
     const localRepo = makeFakeRepo("local", [makeLocalDoc("doc-1", snapshot)]);
-    // Pre-populate the synced repo with a doc at order 5 so the migrated
-    // doc should land at order 6 (maxOrder + 1) and not collide.
+    // Pre-populate the synced repo with a doc at sortOrder "a0"; the
+    // migrated doc should land strictly after it.
     const existingSynced: DocumentData = {
       meta: {
         id: "existing",
         title: "existing",
-        order: 5,
+        sortOrder: "a0",
         createdAt: 0,
         updatedAt: 0,
         origin: "synced",
@@ -281,7 +305,7 @@ describe("convertLocalDocToSynced", () => {
       .fn<(documentId: string, snapshot: TLStoreSnapshot) => Promise<void>>()
       .mockResolvedValue(undefined);
 
-    await convertLocalDocToSynced({
+    const result = await convertLocalDocToSynced({
       documentId: "doc-1",
       localRepository: localRepo.repo,
       syncedRepository: syncedRepo.repo,
@@ -289,17 +313,21 @@ describe("convertLocalDocToSynced", () => {
       pushSnapshot,
     });
 
-    expect(syncedRepo.save).toHaveBeenCalledTimes(1);
-    const savedMeta = syncedRepo.save.mock.calls[0][0].meta;
-    expect(savedMeta.id).toBe("doc-1");
-    expect(savedMeta.origin).toBe("synced");
-    // Order is recomputed against the synced list's max (5) + 1.
-    expect(savedMeta.order).toBe(6);
+    expect(syncedRepo.create).toHaveBeenCalledTimes(1);
+    // The synced repo allocates a server-side id; the migrated doc
+    // does NOT keep the local "doc-1" id.
+    expect(result.meta.id).not.toBe("doc-1");
+    expect(result.meta.origin).toBe("synced");
+    // Sort-order is computed past the existing tail.
+    expect(result.meta.sortOrder > "a0").toBe(true);
 
+    // Asset upload and snapshot push both target the new server id,
+    // not the local UUID.
     expect(uploadAsset).toHaveBeenCalledTimes(1);
-    expect(uploadAsset.mock.calls[0][0]).toBe("doc-1");
+    expect(uploadAsset.mock.calls[0][0]).toBe(result.meta.id);
 
     expect(pushSnapshot).toHaveBeenCalledTimes(1);
+    expect(pushSnapshot.mock.calls[0][0]).toBe(result.meta.id);
     const pushedSnapshot = pushSnapshot.mock.calls[0][1];
     expect(getAssetSrc(pushedSnapshot, "asset:a")).toBe("/uploaded/asset:a");
 
@@ -322,7 +350,7 @@ describe("convertLocalDocToSynced", () => {
       pushSnapshot,
     });
 
-    expect(syncedRepo.save).toHaveBeenCalledTimes(1);
+    expect(syncedRepo.create).toHaveBeenCalledTimes(1);
     expect(uploadAsset).not.toHaveBeenCalled();
     expect(pushSnapshot).not.toHaveBeenCalled();
     expect(localRepo.delete).toHaveBeenCalledWith("doc-1");
@@ -391,7 +419,7 @@ describe("convertLocalDocToSynced", () => {
         syncedRepository: syncedRepo.repo,
       }),
     ).rejects.toThrow(/not found/);
-    expect(syncedRepo.save).not.toHaveBeenCalled();
+    expect(syncedRepo.create).not.toHaveBeenCalled();
   });
 
   it("throws immediately without touching the repos when the abortSignal is already aborted", async () => {
@@ -416,22 +444,27 @@ describe("convertLocalDocToSynced", () => {
     ).rejects.toThrow();
 
     expect(localRepo.get).not.toHaveBeenCalled();
-    expect(syncedRepo.save).not.toHaveBeenCalled();
+    expect(syncedRepo.create).not.toHaveBeenCalled();
     expect(uploadAsset).not.toHaveBeenCalled();
     expect(pushSnapshot).not.toHaveBeenCalled();
     expect(localRepo.delete).not.toHaveBeenCalled();
   });
 
-  it("aborts mid-migration when the abortSignal fires after the synced save", async () => {
+  it("aborts mid-migration when the abortSignal fires after the synced create", async () => {
     const snapshot = snapshotWith({});
     const localRepo = makeFakeRepo("local", [makeLocalDoc("doc-1", snapshot)]);
     const syncedRepo = makeFakeRepo("synced");
 
     const controller = new AbortController();
-    // Abort mid-migration, right after syncedRepository.save runs.
-    syncedRepo.repo.save = vi.fn(async (d: DocumentData) => {
-      syncedRepo.store.set(d.meta.id, d);
+    // Abort mid-migration, right after syncedRepository.create runs.
+    syncedRepo.repo.create = vi.fn(async (d: DocumentData) => {
+      const allocated: DocumentData = {
+        ...d,
+        meta: { ...d.meta, id: "server-1", origin: "synced" },
+      };
+      syncedRepo.store.set("server-1", allocated);
       controller.abort();
+      return allocated;
     });
 
     const pushSnapshot = vi.fn();
@@ -447,9 +480,9 @@ describe("convertLocalDocToSynced", () => {
       }),
     ).rejects.toThrow();
 
-    // Metadata save completed before the abort; the later snapshot push
-    // was skipped and local copy was not deleted.
-    expect(syncedRepo.repo.save).toHaveBeenCalledTimes(1);
+    // Server doc was created before the abort; the later snapshot
+    // push was skipped and the local copy was not deleted.
+    expect(syncedRepo.repo.create).toHaveBeenCalledTimes(1);
     expect(pushSnapshot).not.toHaveBeenCalled();
     expect(localRepo.delete).not.toHaveBeenCalled();
   });
@@ -472,6 +505,6 @@ describe("convertLocalDocToSynced", () => {
         syncedRepository: syncedRepo.repo,
       }),
     ).rejects.toThrow(/not a local document/);
-    expect(syncedRepo.save).not.toHaveBeenCalled();
+    expect(syncedRepo.create).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/documents/migration.test.ts
+++ b/packages/app/src/documents/migration.test.ts
@@ -85,9 +85,16 @@ function makeFakeRepo(origin: DocumentOrigin, initial: DocumentData[] = []) {
       origin === "synced"
         ? String(++serverIdCounter)
         : (d.meta.id ?? crypto.randomUUID());
+    const now = Date.now();
     const stored: DocumentData = {
       ...d,
-      meta: { ...d.meta, id: allocatedId, origin },
+      meta: {
+        ...d.meta,
+        id: allocatedId,
+        origin,
+        createdAt: d.meta.createdAt ?? now,
+        updatedAt: now,
+      },
     };
     store.set(allocatedId, stored);
     return stored;
@@ -466,9 +473,16 @@ describe("convertLocalDocToSynced", () => {
     const controller = new AbortController();
     // Abort mid-migration, right after syncedRepository.create runs.
     syncedRepo.repo.create = vi.fn(async (d: DocumentDraft) => {
+      const now = Date.now();
       const allocated: DocumentData = {
         ...d,
-        meta: { ...d.meta, id: "server-1", origin: "synced" },
+        meta: {
+          ...d.meta,
+          id: "server-1",
+          origin: "synced",
+          createdAt: d.meta.createdAt ?? now,
+          updatedAt: now,
+        },
       };
       syncedRepo.store.set("server-1", allocated);
       controller.abort();

--- a/packages/app/src/documents/migration.test.ts
+++ b/packages/app/src/documents/migration.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 import type { TLStoreSnapshot } from "tldraw";
 import type {
   DocumentData,
-  DocumentDraft,
+  DocumentInput,
   DocumentMeta,
-  DocumentOrigin,
+  DocumentSource,
 } from "./types";
 import type { DocumentRepository } from "./repository";
 import {
@@ -51,37 +51,37 @@ function makeLocalDoc(
       sortOrder: "a0",
       createdAt: 0,
       updatedAt: 0,
-      origin: "local",
+      source: "local",
     },
     snapshot,
   };
 }
 
-function makeFakeRepo(origin: DocumentOrigin, initial: DocumentData[] = []) {
+function makeFakeRepo(source: DocumentSource, initial: DocumentData[] = []) {
   const store = new Map<string, DocumentData>();
   for (const d of initial) store.set(d.meta.id, d);
 
   const list = vi.fn(
     async (): Promise<DocumentMeta[]> =>
       [...store.values()]
-        .map((d) => ({ ...d.meta, origin }))
+        .map((d) => ({ ...d.meta, source }))
         .sort((a, b) => a.sortOrder.localeCompare(b.sortOrder)),
   );
   const get = vi.fn(async (id: string): Promise<DocumentData | undefined> => {
     const d = store.get(id);
-    return d ? { ...d, meta: { ...d.meta, origin } } : undefined;
+    return d ? { ...d, meta: { ...d.meta, source } } : undefined;
   });
   // Single upsert method matching the production repo. Both local and
   // synced repos honor the caller's id verbatim — UUID v7 is
   // client-allocated, so the same id flows through every layer.
-  const save = vi.fn(async (d: DocumentDraft): Promise<DocumentData> => {
+  const save = vi.fn(async (d: DocumentInput): Promise<DocumentData> => {
     const now = Date.now();
     const existing = store.get(d.meta.id);
     const stored: DocumentData = {
       ...d,
       meta: {
         ...d.meta,
-        origin,
+        source,
         createdAt: existing?.meta.createdAt ?? d.meta.createdAt ?? now,
         updatedAt: now,
       },
@@ -290,7 +290,7 @@ describe("convertLocalDocToSynced", () => {
         sortOrder: "a0",
         createdAt: 0,
         updatedAt: 0,
-        origin: "synced",
+        source: "synced",
       },
       snapshot: null,
     };
@@ -319,7 +319,7 @@ describe("convertLocalDocToSynced", () => {
     // the same id as the local doc — no remap.
     const synced = syncedRepo.store.get("doc-1");
     expect(synced).toBeDefined();
-    expect(synced?.meta.origin).toBe("synced");
+    expect(synced?.meta.source).toBe("synced");
     // Sort-order is computed past the existing tail.
     expect(
       synced?.meta.sortOrder !== undefined && synced.meta.sortOrder > "a0",
@@ -462,13 +462,13 @@ describe("convertLocalDocToSynced", () => {
     // Abort mid-migration, right after syncedRepository.create runs.
     // The synced doc is stored under the same id as the local doc
     // (UUID v7 client-allocated, no remap).
-    syncedRepo.repo.save = vi.fn(async (d: DocumentDraft) => {
+    syncedRepo.repo.save = vi.fn(async (d: DocumentInput) => {
       const now = Date.now();
       const allocated: DocumentData = {
         ...d,
         meta: {
           ...d.meta,
-          origin: "synced",
+          source: "synced",
           createdAt: d.meta.createdAt ?? now,
           updatedAt: now,
         },
@@ -501,10 +501,10 @@ describe("convertLocalDocToSynced", () => {
   it("throws when the document is already synced", async () => {
     const syncedDoc: DocumentData = {
       ...makeLocalDoc("doc-1"),
-      meta: { ...makeLocalDoc("doc-1").meta, origin: "synced" },
+      meta: { ...makeLocalDoc("doc-1").meta, source: "synced" },
     };
     const localRepo = makeFakeRepo("local");
-    // Force the local repo's get to return a synced-origin doc — the repo
+    // Force the local repo's get to return a synced-source doc — the repo
     // normally stamps "local", so this mimics a corrupted state to verify
     // the defensive guard.
     localRepo.repo.get = vi.fn().mockResolvedValue(syncedDoc);

--- a/packages/app/src/documents/migration.ts
+++ b/packages/app/src/documents/migration.ts
@@ -1,6 +1,5 @@
 import type { TLStoreSnapshot } from "tldraw";
 import type { DocumentRepository } from "./repository";
-import type { DocumentData } from "./types";
 import { nextTailSortOrder } from "./sort-order";
 
 export function isDataUrl(value: unknown): value is string {
@@ -192,34 +191,31 @@ export interface ConvertLocalDocToSyncedParams {
 }
 
 /**
- * Move a local IDB-backed document to the server. The server allocates
- * a new id (and slug) at creation time; the local id is discarded once
- * the migration completes.
+ * Move a local IDB-backed document to the server. With UUID v7 ids
+ * minted client-side, the local doc's id is also the canonical server
+ * id — no remap is needed. The same `documentId` flows through every
+ * step and the function's job reduces to "create the server row, push
+ * the snapshot, delete the local copy."
  *
  * Steps:
  *   1. Load the local document.
  *   2. Compute a fractional-indexing key after the synced list's
  *      current tail so the migrated doc lands at the end.
- *   3. POST /api/documents to create the server-side row. Server
- *      returns the canonical id+slug.
- *   4. Upload any inline `data:` URL assets to R2 under the *new*
- *      server id and rewrite the snapshot's asset srcs accordingly.
+ *   3. POST /api/documents — server inserts under the local id.
+ *   4. Upload any inline `data:` URL assets to R2 and rewrite the
+ *      snapshot's asset srcs accordingly.
  *   5. Push the rewritten snapshot into the document's Durable Object
- *      room via PUT /api/documents/:id/snapshot (with the new id).
- *   6. Delete the local IDB entry under the original local id.
- *
- * Returns the new doc data so callers can swap their `activeDocumentId`
- * to the server-allocated value.
+ *      room via PUT /api/documents/:id/snapshot.
+ *   6. Delete the local IDB entry.
  *
  * On failure after step 3 the local copy is intentionally preserved so
- * the user can retry. The half-created server row is left for the same
- * reason — the user can manually delete it, or a retry will create
- * another one (the local→synced relationship is identified only by
- * what the user converts, not by id).
+ * the user can retry. The half-created server row's `initializing_at`
+ * marker keeps it invisible until the snapshot push lands, and the
+ * server-side sweep cleans it up if the user gives up entirely.
  */
 export async function convertLocalDocToSynced(
   params: ConvertLocalDocToSyncedParams,
-): Promise<DocumentData> {
+): Promise<void> {
   const {
     documentId,
     localRepository,
@@ -251,15 +247,11 @@ export async function convertLocalDocToSynced(
 
   abortSignal?.throwIfAborted();
 
-  // POST /api/documents allocates the server id, slug, and updated_at.
-  // The local doc's `createdAt` is forwarded so the migrated doc keeps
-  // its original on-device creation time; without that override the
-  // server would stamp "now" and the timeline would reset. Spreading
-  // the rest of `local.meta` carries fields like `id` and `updatedAt`
-  // through the draft — the API repo discards them at the wire — but
-  // keeps the local id visible to test fakes that derive a
-  // deterministic "synced-<localId>" mapping for assertions.
-  const synced = await syncedRepository.create({
+  // POST /api/documents under the local id. The local doc's
+  // `createdAt` is forwarded so the migrated doc keeps its original
+  // on-device creation time; without that override the server would
+  // stamp "now" and the timeline would reset.
+  await syncedRepository.create({
     meta: {
       ...local.meta,
       sortOrder: newSortOrder,
@@ -267,20 +259,17 @@ export async function convertLocalDocToSynced(
     },
     snapshot: null,
   });
-  const serverId = synced.meta.id;
 
   if (local.snapshot) {
     abortSignal?.throwIfAborted();
     const rewritten = await uploadAssetDataUrls(local.snapshot, (file) =>
-      uploadAsset(serverId, file, abortSignal),
+      uploadAsset(documentId, file, abortSignal),
     );
     abortSignal?.throwIfAborted();
-    await pushSnapshot(serverId, rewritten, abortSignal);
+    await pushSnapshot(documentId, rewritten, abortSignal);
   }
 
   abortSignal?.throwIfAborted();
 
   await localRepository.delete(documentId);
-
-  return synced;
 }

--- a/packages/app/src/documents/migration.ts
+++ b/packages/app/src/documents/migration.ts
@@ -231,9 +231,9 @@ export async function convertLocalDocToSynced(
   if (!local) {
     throw new Error(`Local document ${documentId} not found`);
   }
-  if (local.meta.origin !== "local") {
+  if (local.meta.source !== "local") {
     throw new Error(
-      `Document ${documentId} is not a local document (origin: ${local.meta.origin})`,
+      `Document ${documentId} is not a local document (source: ${local.meta.source})`,
     );
   }
 
@@ -255,7 +255,7 @@ export async function convertLocalDocToSynced(
     meta: {
       ...local.meta,
       sortOrder: newSortOrder,
-      origin: "synced",
+      source: "synced",
     },
     snapshot: null,
   });

--- a/packages/app/src/documents/migration.ts
+++ b/packages/app/src/documents/migration.ts
@@ -251,7 +251,7 @@ export async function convertLocalDocToSynced(
   // `createdAt` is forwarded so the migrated doc keeps its original
   // on-device creation time; without that override the server would
   // stamp "now" and the timeline would reset.
-  await syncedRepository.create({
+  await syncedRepository.save({
     meta: {
       ...local.meta,
       sortOrder: newSortOrder,

--- a/packages/app/src/documents/migration.ts
+++ b/packages/app/src/documents/migration.ts
@@ -1,7 +1,7 @@
-import { generateKeyBetween } from "fractional-indexing";
 import type { TLStoreSnapshot } from "tldraw";
 import type { DocumentRepository } from "./repository";
 import type { DocumentData } from "./types";
+import { nextTailSortOrder } from "./sort-order";
 
 export function isDataUrl(value: unknown): value is string {
   return typeof value === "string" && value.startsWith("data:");
@@ -246,21 +246,8 @@ export async function convertLocalDocToSynced(
   // Append the migrated doc to the end of the synced list. Using the
   // synced repo's current tail as the "previous key" keeps each
   // migrated doc strictly after every existing synced doc.
-  //
-  // Known limitation: when multiple convertLocalDocToSynced calls run
-  // in parallel they can each read the same tail and compute keys that
-  // happen to collide on the lex level. Fractional indexing's
-  // `generateKeyBetween` is deterministic per (prev, next) pair, and
-  // both calls would pick the same key. The sidebar's stable sort
-  // still shows both, just in a non-deterministic order between them,
-  // and any user reorder heals the collision.
   const syncedList = await syncedRepository.list();
-  const sortedKeys = syncedList
-    .map((d) => d.sortOrder)
-    .filter((key): key is string => typeof key === "string")
-    .sort();
-  const tailKey = sortedKeys[sortedKeys.length - 1] ?? null;
-  const newSortOrder = generateKeyBetween(tailKey, null);
+  const newSortOrder = nextTailSortOrder(syncedList);
 
   abortSignal?.throwIfAborted();
 

--- a/packages/app/src/documents/migration.ts
+++ b/packages/app/src/documents/migration.ts
@@ -251,18 +251,19 @@ export async function convertLocalDocToSynced(
 
   abortSignal?.throwIfAborted();
 
-  // POST /api/documents allocates the server id and slug. The local
-  // id and slug-less metadata are passed-through fields; the server
-  // ignores `id` and stamps its own `slug`.
-  //
-  // createdAt is preserved from the local doc so migrated docs keep
-  // their original creation time; updatedAt advances to "now."
+  // POST /api/documents allocates the server id, slug, and updated_at.
+  // The local doc's `createdAt` is forwarded so the migrated doc keeps
+  // its original on-device creation time; without that override the
+  // server would stamp "now" and the timeline would reset. Spreading
+  // the rest of `local.meta` carries fields like `id` and `updatedAt`
+  // through the draft — the API repo discards them at the wire — but
+  // keeps the local id visible to test fakes that derive a
+  // deterministic "synced-<localId>" mapping for assertions.
   const synced = await syncedRepository.create({
     meta: {
       ...local.meta,
-      origin: "synced",
       sortOrder: newSortOrder,
-      updatedAt: Date.now(),
+      origin: "synced",
     },
     snapshot: null,
   });

--- a/packages/app/src/documents/migration.ts
+++ b/packages/app/src/documents/migration.ts
@@ -1,5 +1,7 @@
+import { generateKeyBetween } from "fractional-indexing";
 import type { TLStoreSnapshot } from "tldraw";
 import type { DocumentRepository } from "./repository";
+import type { DocumentData } from "./types";
 
 export function isDataUrl(value: unknown): value is string {
   return typeof value === "string" && value.startsWith("data:");
@@ -166,6 +168,7 @@ async function defaultPushSnapshot(
 }
 
 export interface ConvertLocalDocToSyncedParams {
+  /** The local doc's id (the UUID generated when it was created). */
   documentId: string;
   localRepository: DocumentRepository;
   syncedRepository: DocumentRepository;
@@ -189,27 +192,34 @@ export interface ConvertLocalDocToSyncedParams {
 }
 
 /**
- * Move a local IDB-backed document to the server under the same id.
+ * Move a local IDB-backed document to the server. The server allocates
+ * a new id (and slug) at creation time; the local id is discarded once
+ * the migration completes.
  *
  * Steps:
  *   1. Load the local document.
- *   2. Create server-side metadata via PUT /api/documents/:id
- *      (with the synced repository's save).
- *   3. Upload any inline `data:` URL assets to R2 and rewrite the
- *      snapshot's asset srcs to point at the uploaded URLs.
- *   4. Push the rewritten snapshot into the document's Durable Object
- *      room via PUT /api/documents/:id/snapshot.
- *   5. Delete the local IDB entry.
+ *   2. Compute a fractional-indexing key after the synced list's
+ *      current tail so the migrated doc lands at the end.
+ *   3. POST /api/documents to create the server-side row. Server
+ *      returns the canonical id+slug.
+ *   4. Upload any inline `data:` URL assets to R2 under the *new*
+ *      server id and rewrite the snapshot's asset srcs accordingly.
+ *   5. Push the rewritten snapshot into the document's Durable Object
+ *      room via PUT /api/documents/:id/snapshot (with the new id).
+ *   6. Delete the local IDB entry under the original local id.
  *
- * On failure after step 2 the local copy is intentionally preserved so
- * the user can retry. Server-side metadata left over from a partial run
- * is harmless: the next attempt is an upsert and the snapshot push with
- * `expectedSnapshotVersion: 0` will either succeed (fresh DO room) or
- * no-op (409) if the prior attempt got that far.
+ * Returns the new doc data so callers can swap their `activeDocumentId`
+ * to the server-allocated value.
+ *
+ * On failure after step 3 the local copy is intentionally preserved so
+ * the user can retry. The half-created server row is left for the same
+ * reason — the user can manually delete it, or a retry will create
+ * another one (the local→synced relationship is identified only by
+ * what the user converts, not by id).
  */
 export async function convertLocalDocToSynced(
   params: ConvertLocalDocToSyncedParams,
-): Promise<void> {
+): Promise<DocumentData> {
   const {
     documentId,
     localRepository,
@@ -233,44 +243,56 @@ export async function convertLocalDocToSynced(
 
   abortSignal?.throwIfAborted();
 
-  // Compute an order value against the synced repo so the migrated doc
-  // does not collide with an existing server doc's order.
+  // Append the migrated doc to the end of the synced list. Using the
+  // synced repo's current tail as the "previous key" keeps each
+  // migrated doc strictly after every existing synced doc.
   //
   // Known limitation: when multiple convertLocalDocToSynced calls run
-  // in parallel they can each read the same maxOrder and write the
-  // same order+1 to their respective new docs. The sidebar's stable
-  // sort still shows both, just in a non-deterministic order between
-  // them, and any user reorder heals the collision. Fixing this cleanly
-  // would require threading an atomic allocator through this function
-  // — deliberately deferred until convert-to-synced is commonly used
-  // with enough docs for the cosmetic ambiguity to matter.
+  // in parallel they can each read the same tail and compute keys that
+  // happen to collide on the lex level. Fractional indexing's
+  // `generateKeyBetween` is deterministic per (prev, next) pair, and
+  // both calls would pick the same key. The sidebar's stable sort
+  // still shows both, just in a non-deterministic order between them,
+  // and any user reorder heals the collision.
   const syncedList = await syncedRepository.list();
-  const maxOrder = syncedList.reduce((max, d) => Math.max(max, d.order), 0);
+  const sortedKeys = syncedList
+    .map((d) => d.sortOrder)
+    .filter((key): key is string => typeof key === "string")
+    .sort();
+  const tailKey = sortedKeys[sortedKeys.length - 1] ?? null;
+  const newSortOrder = generateKeyBetween(tailKey, null);
 
   abortSignal?.throwIfAborted();
 
+  // POST /api/documents allocates the server id and slug. The local
+  // id and slug-less metadata are passed-through fields; the server
+  // ignores `id` and stamps its own `slug`.
+  //
   // createdAt is preserved from the local doc so migrated docs keep
-  // their original creation time; only updatedAt advances.
-  await syncedRepository.save({
+  // their original creation time; updatedAt advances to "now."
+  const synced = await syncedRepository.create({
     meta: {
       ...local.meta,
       origin: "synced",
-      order: maxOrder + 1,
+      sortOrder: newSortOrder,
       updatedAt: Date.now(),
     },
     snapshot: null,
   });
+  const serverId = synced.meta.id;
 
   if (local.snapshot) {
     abortSignal?.throwIfAborted();
     const rewritten = await uploadAssetDataUrls(local.snapshot, (file) =>
-      uploadAsset(documentId, file, abortSignal),
+      uploadAsset(serverId, file, abortSignal),
     );
     abortSignal?.throwIfAborted();
-    await pushSnapshot(documentId, rewritten, abortSignal);
+    await pushSnapshot(serverId, rewritten, abortSignal);
   }
 
   abortSignal?.throwIfAborted();
 
   await localRepository.delete(documentId);
+
+  return synced;
 }

--- a/packages/app/src/documents/reconnect.test.ts
+++ b/packages/app/src/documents/reconnect.test.ts
@@ -155,10 +155,10 @@ describe("reconcileOfflineEdits", () => {
       list: vi
         .fn()
         .mockResolvedValue([
-          { id: "doc-id", title: "Foo", sortOrder: "a0", origin: "synced" },
+          { id: "doc-id", title: "Foo", sortOrder: "a0", source: "synced" },
         ]),
       // The fork flow mints its own UUID v7 client-side, then calls
-      // create(). The fake repo echoes the supplied draft so the
+      // save(). The fake repo echoes the supplied input so the
       // returned row carries that same id.
       save: vi.fn().mockImplementation(async (data) => ({
         meta: {
@@ -166,7 +166,7 @@ describe("reconcileOfflineEdits", () => {
           slug: "fork-slug",
           createdAt: 0,
           updatedAt: 0,
-          origin: "synced",
+          source: "synced",
         },
         snapshot: null,
       })),
@@ -195,16 +195,16 @@ describe("reconcileOfflineEdits", () => {
     });
 
     // The fork id is whatever uuidv7() produced — assert the shape
-    // (returned id is a UUID and matches what was passed to create()).
+    // (returned id is a UUID and matches what was passed to save()).
     expect(result.action).toBe("forked");
     if (result.action === "forked") {
       expect(result.forkedDocumentId).toMatch(
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
       );
-      const sentDraft = repository.save.mock.calls[0][0] as {
+      const sentInput = repository.save.mock.calls[0][0] as {
         meta: { id: string };
       };
-      expect(sentDraft.meta.id).toBe(result.forkedDocumentId);
+      expect(sentInput.meta.id).toBe(result.forkedDocumentId);
     }
     expect(repository.save).toHaveBeenCalledTimes(1);
   });
@@ -223,12 +223,12 @@ describe("reconcileOfflineEdits", () => {
         meta: { id: "doc-id", title: "Foo", sortOrder: "a0" },
       }),
       list: vi.fn().mockResolvedValue([
-        { id: "doc-id", title: "Foo", sortOrder: "a0", origin: "synced" },
+        { id: "doc-id", title: "Foo", sortOrder: "a0", source: "synced" },
         {
           id: "neighbor",
           title: "Neighbor",
           sortOrder: "a1",
-          origin: "synced",
+          source: "synced",
         },
       ]),
       save: vi.fn().mockImplementation(async (data) => ({
@@ -238,7 +238,7 @@ describe("reconcileOfflineEdits", () => {
           slug: "fork-slug",
           createdAt: 0,
           updatedAt: 0,
-          origin: "synced",
+          source: "synced",
         },
         snapshot: null,
       })),

--- a/packages/app/src/documents/reconnect.test.ts
+++ b/packages/app/src/documents/reconnect.test.ts
@@ -159,20 +159,19 @@ describe("reconcileOfflineEdits", () => {
         .mockResolvedValue([
           { id: "doc-id", title: "Foo", sortOrder: "a0", origin: "synced" },
         ]),
-      // The fork flow calls create() and uses the returned doc's id
-      // for the snapshot push. Return a fake server-allocated row.
-      create: vi.fn().mockResolvedValue({
+      // The fork flow mints its own UUID v7 client-side, then calls
+      // create(). The fake repo echoes the supplied draft so the
+      // returned row carries that same id.
+      create: vi.fn().mockImplementation(async (data) => ({
         meta: {
-          id: "fork-server-id",
+          ...data.meta,
           slug: "fork-slug",
-          title: "Foo (offline copy)",
-          sortOrder: "a1",
           createdAt: 0,
           updatedAt: 0,
           origin: "synced",
         },
         snapshot: null,
-      }),
+      })),
       update: vi.fn(),
       delete: vi.fn(),
     } as const;
@@ -198,10 +197,18 @@ describe("reconcileOfflineEdits", () => {
       repository: repository as never,
     });
 
-    expect(result).toMatchObject({
-      action: "forked",
-      forkedDocumentId: "fork-server-id",
-    });
+    // The fork id is whatever uuidv7() produced — assert the shape
+    // (returned id is a UUID and matches what was passed to create()).
+    expect(result.action).toBe("forked");
+    if (result.action === "forked") {
+      expect(result.forkedDocumentId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      const sentDraft = repository.create.mock.calls[0][0] as {
+        meta: { id: string };
+      };
+      expect(sentDraft.meta.id).toBe(result.forkedDocumentId);
+    }
     expect(repository.create).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/app/src/documents/reconnect.test.ts
+++ b/packages/app/src/documents/reconnect.test.ts
@@ -154,6 +154,11 @@ describe("reconcileOfflineEdits", () => {
       get: vi.fn().mockResolvedValue({
         meta: { id: "doc-id", title: "Foo", sortOrder: "a0" },
       }),
+      list: vi
+        .fn()
+        .mockResolvedValue([
+          { id: "doc-id", title: "Foo", sortOrder: "a0", origin: "synced" },
+        ]),
       // The fork flow calls create() and uses the returned doc's id
       // for the snapshot push. Return a fake server-allocated row.
       create: vi.fn().mockResolvedValue({
@@ -161,7 +166,7 @@ describe("reconcileOfflineEdits", () => {
           id: "fork-server-id",
           slug: "fork-slug",
           title: "Foo (offline copy)",
-          sortOrder: "a0V",
+          sortOrder: "a1",
           createdAt: 0,
           updatedAt: 0,
           origin: "synced",
@@ -198,6 +203,70 @@ describe("reconcileOfflineEdits", () => {
       forkedDocumentId: "fork-server-id",
     });
     expect(repository.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("places the fork past the synced list's tail, not just past the original key", async () => {
+    // The original sits at "a0"; another doc already sits at "a1".
+    // A naive `generateKeyBetween(originalKey, null)` would compute
+    // "a1" — colliding with the existing neighbor. The fork must land
+    // past the tail instead.
+    const local = createSnapshot("local-edits");
+    const baseline = createSnapshot("baseline");
+    const server = createSnapshot("server-diverged");
+
+    const repository = {
+      get: vi.fn().mockResolvedValue({
+        meta: { id: "doc-id", title: "Foo", sortOrder: "a0" },
+      }),
+      list: vi.fn().mockResolvedValue([
+        { id: "doc-id", title: "Foo", sortOrder: "a0", origin: "synced" },
+        {
+          id: "neighbor",
+          title: "Neighbor",
+          sortOrder: "a1",
+          origin: "synced",
+        },
+      ]),
+      create: vi.fn().mockImplementation(async (data) => ({
+        meta: {
+          ...data.meta,
+          id: "fork-server-id",
+          slug: "fork-slug",
+          createdAt: 0,
+          updatedAt: 0,
+          origin: "synced",
+        },
+        snapshot: null,
+      })),
+      update: vi.fn(),
+      delete: vi.fn(),
+    } as const;
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        mockResponse({ reason: "version-conflict", snapshotVersion: 10 }, 409),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({ snapshot: server, snapshotVersion: 10 }),
+      )
+      .mockResolvedValueOnce(mockResponse({ ok: true }));
+
+    await reconcileOfflineEdits({
+      documentId: "doc-id",
+      localSnapshot: local,
+      recovery: {
+        baselineSnapshot: baseline,
+        reconnectSnapshot: local,
+        hasPendingOfflineChanges: true,
+      },
+      snapshotVersion: 3,
+      repository: repository as never,
+    });
+
+    const sentToCreate = repository.create.mock.calls[0][0] as {
+      meta: { sortOrder: string };
+    };
+    expect(sentToCreate.meta.sortOrder > "a1").toBe(true);
   });
 
   it("retries a stale-revision push without forking when the server still matches the baseline", async () => {

--- a/packages/app/src/documents/reconnect.test.ts
+++ b/packages/app/src/documents/reconnect.test.ts
@@ -32,9 +32,10 @@ describe("reconcileOfflineEdits", () => {
     const snapshot = createSnapshot("doc");
     const repository = {
       get: vi.fn().mockResolvedValue({
-        meta: { id: "doc-id", title: "Foo", order: 1 },
+        meta: { id: "doc-id", title: "Foo", sortOrder: "a0" },
       }),
-      save: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
     } as const;
 
     const result = await reconcileOfflineEdits({
@@ -51,7 +52,7 @@ describe("reconcileOfflineEdits", () => {
 
     expect(repository.get).toHaveBeenCalledWith("doc-id");
     expect(vi.mocked(fetch)).not.toHaveBeenCalled();
-    expect(repository.save).not.toHaveBeenCalled();
+    expect(repository.create).not.toHaveBeenCalled();
     expect(result).toEqual({ action: "noop" });
   });
 
@@ -114,9 +115,10 @@ describe("reconcileOfflineEdits", () => {
 
     const repository = {
       get: vi.fn().mockResolvedValue({
-        meta: { id: "doc-id", title: "Foo", order: 1 },
+        meta: { id: "doc-id", title: "Foo", sortOrder: "a0" },
       }),
-      save: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
     } as const;
 
     vi.mocked(fetch)
@@ -140,7 +142,7 @@ describe("reconcileOfflineEdits", () => {
     });
 
     expect(result).toEqual({ action: "noop" });
-    expect(repository.save).not.toHaveBeenCalled();
+    expect(repository.create).not.toHaveBeenCalled();
   });
 
   it("forks when pending offline changes exist and the server has diverged", async () => {
@@ -150,9 +152,23 @@ describe("reconcileOfflineEdits", () => {
 
     const repository = {
       get: vi.fn().mockResolvedValue({
-        meta: { id: "doc-id", title: "Foo", order: 1 },
+        meta: { id: "doc-id", title: "Foo", sortOrder: "a0" },
       }),
-      save: vi.fn().mockResolvedValue(undefined),
+      // The fork flow calls create() and uses the returned doc's id
+      // for the snapshot push. Return a fake server-allocated row.
+      create: vi.fn().mockResolvedValue({
+        meta: {
+          id: "fork-server-id",
+          slug: "fork-slug",
+          title: "Foo (offline copy)",
+          sortOrder: "a0V",
+          createdAt: 0,
+          updatedAt: 0,
+          origin: "synced",
+        },
+        snapshot: null,
+      }),
+      update: vi.fn(),
       delete: vi.fn(),
     } as const;
 
@@ -177,8 +193,11 @@ describe("reconcileOfflineEdits", () => {
       repository: repository as never,
     });
 
-    expect(result).toMatchObject({ action: "forked" });
-    expect(repository.save).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      action: "forked",
+      forkedDocumentId: "fork-server-id",
+    });
+    expect(repository.create).toHaveBeenCalledTimes(1);
   });
 
   it("retries a stale-revision push without forking when the server still matches the baseline", async () => {
@@ -187,9 +206,10 @@ describe("reconcileOfflineEdits", () => {
 
     const repository = {
       get: vi.fn().mockResolvedValue({
-        meta: { id: "doc-id", title: "Foo", order: 1 },
+        meta: { id: "doc-id", title: "Foo", sortOrder: "a0" },
       }),
-      save: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
     } as const;
 
     vi.mocked(fetch)
@@ -214,6 +234,6 @@ describe("reconcileOfflineEdits", () => {
     });
 
     expect(result).toEqual({ action: "pushed" });
-    expect(repository.save).not.toHaveBeenCalled();
+    expect(repository.create).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/documents/reconnect.test.ts
+++ b/packages/app/src/documents/reconnect.test.ts
@@ -34,8 +34,7 @@ describe("reconcileOfflineEdits", () => {
       get: vi.fn().mockResolvedValue({
         meta: { id: "doc-id", title: "Foo", sortOrder: "a0" },
       }),
-      create: vi.fn(),
-      update: vi.fn(),
+      save: vi.fn(),
     } as const;
 
     const result = await reconcileOfflineEdits({
@@ -52,7 +51,7 @@ describe("reconcileOfflineEdits", () => {
 
     expect(repository.get).toHaveBeenCalledWith("doc-id");
     expect(vi.mocked(fetch)).not.toHaveBeenCalled();
-    expect(repository.create).not.toHaveBeenCalled();
+    expect(repository.save).not.toHaveBeenCalled();
     expect(result).toEqual({ action: "noop" });
   });
 
@@ -117,8 +116,7 @@ describe("reconcileOfflineEdits", () => {
       get: vi.fn().mockResolvedValue({
         meta: { id: "doc-id", title: "Foo", sortOrder: "a0" },
       }),
-      create: vi.fn(),
-      update: vi.fn(),
+      save: vi.fn(),
     } as const;
 
     vi.mocked(fetch)
@@ -142,7 +140,7 @@ describe("reconcileOfflineEdits", () => {
     });
 
     expect(result).toEqual({ action: "noop" });
-    expect(repository.create).not.toHaveBeenCalled();
+    expect(repository.save).not.toHaveBeenCalled();
   });
 
   it("forks when pending offline changes exist and the server has diverged", async () => {
@@ -162,7 +160,7 @@ describe("reconcileOfflineEdits", () => {
       // The fork flow mints its own UUID v7 client-side, then calls
       // create(). The fake repo echoes the supplied draft so the
       // returned row carries that same id.
-      create: vi.fn().mockImplementation(async (data) => ({
+      save: vi.fn().mockImplementation(async (data) => ({
         meta: {
           ...data.meta,
           slug: "fork-slug",
@@ -172,7 +170,6 @@ describe("reconcileOfflineEdits", () => {
         },
         snapshot: null,
       })),
-      update: vi.fn(),
       delete: vi.fn(),
     } as const;
 
@@ -204,12 +201,12 @@ describe("reconcileOfflineEdits", () => {
       expect(result.forkedDocumentId).toMatch(
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
       );
-      const sentDraft = repository.create.mock.calls[0][0] as {
+      const sentDraft = repository.save.mock.calls[0][0] as {
         meta: { id: string };
       };
       expect(sentDraft.meta.id).toBe(result.forkedDocumentId);
     }
-    expect(repository.create).toHaveBeenCalledTimes(1);
+    expect(repository.save).toHaveBeenCalledTimes(1);
   });
 
   it("places the fork past the synced list's tail, not just past the original key", async () => {
@@ -234,7 +231,7 @@ describe("reconcileOfflineEdits", () => {
           origin: "synced",
         },
       ]),
-      create: vi.fn().mockImplementation(async (data) => ({
+      save: vi.fn().mockImplementation(async (data) => ({
         meta: {
           ...data.meta,
           id: "fork-server-id",
@@ -245,7 +242,6 @@ describe("reconcileOfflineEdits", () => {
         },
         snapshot: null,
       })),
-      update: vi.fn(),
       delete: vi.fn(),
     } as const;
 
@@ -270,7 +266,7 @@ describe("reconcileOfflineEdits", () => {
       repository: repository as never,
     });
 
-    const sentToCreate = repository.create.mock.calls[0][0] as {
+    const sentToCreate = repository.save.mock.calls[0][0] as {
       meta: { sortOrder: string };
     };
     expect(sentToCreate.meta.sortOrder > "a1").toBe(true);
@@ -284,8 +280,7 @@ describe("reconcileOfflineEdits", () => {
       get: vi.fn().mockResolvedValue({
         meta: { id: "doc-id", title: "Foo", sortOrder: "a0" },
       }),
-      create: vi.fn(),
-      update: vi.fn(),
+      save: vi.fn(),
     } as const;
 
     vi.mocked(fetch)
@@ -310,6 +305,6 @@ describe("reconcileOfflineEdits", () => {
     });
 
     expect(result).toEqual({ action: "pushed" });
-    expect(repository.create).not.toHaveBeenCalled();
+    expect(repository.save).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/documents/reconnect.ts
+++ b/packages/app/src/documents/reconnect.ts
@@ -166,20 +166,15 @@ export async function reconcileOfflineEdits(params: {
 
   // Create the fork on the server. The fork is a distinct document
   // with its own id — we know that id only after the POST response
-  // (the API repo ignores any client-supplied id and the server
-  // allocates an INTEGER). Place the fork past the synced list's
-  // current tail so the new key is strictly greater than every
-  // existing key — generating off the original's key alone would
-  // collide with whatever doc sits immediately after it.
+  // (the API repo lets the server allocate an INTEGER). Place the
+  // fork past the synced list's current tail so the new key is
+  // strictly greater than every existing key — generating off the
+  // original's key alone would collide with whatever doc sits
+  // immediately after it.
   const syncedList = await repository.list();
   const forkSortOrder = nextTailSortOrder(syncedList);
   const created = await repository.create({
     meta: {
-      // Placeholder — the API repo ignores this and the server
-      // allocates the real id. Kept as a fresh UUID rather than
-      // reusing `documentId` so it doesn't read as "saving the fork
-      // under the original's id."
-      id: crypto.randomUUID(),
       title: forkTitle,
       createdAt: now,
       updatedAt: now,

--- a/packages/app/src/documents/reconnect.ts
+++ b/packages/app/src/documents/reconnect.ts
@@ -162,7 +162,6 @@ export async function reconcileOfflineEdits(params: {
   // Server has diverged — fork the local version as a new document.
   const originalTitle = serverDoc.meta.title;
   const forkTitle = `${originalTitle} (offline copy)`;
-  const now = Date.now();
 
   // Create the fork on the server. The fork is a distinct document
   // with its own id — we know that id only after the POST response
@@ -176,8 +175,6 @@ export async function reconcileOfflineEdits(params: {
   const created = await repository.create({
     meta: {
       title: forkTitle,
-      createdAt: now,
-      updatedAt: now,
       sortOrder: forkSortOrder,
       origin: "synced",
     },

--- a/packages/app/src/documents/reconnect.ts
+++ b/packages/app/src/documents/reconnect.ts
@@ -1,4 +1,5 @@
 import type { TLStoreSnapshot } from "tldraw";
+import { v7 as uuidv7 } from "uuid";
 import type { ApiDocumentRepository } from "./api-repository";
 import {
   snapshotsEqual,
@@ -163,24 +164,23 @@ export async function reconcileOfflineEdits(params: {
   const originalTitle = serverDoc.meta.title;
   const forkTitle = `${originalTitle} (offline copy)`;
 
-  // Create the fork on the server. The fork is a distinct document
-  // with its own id — we know that id only after the POST response
-  // (the API repo lets the server allocate an INTEGER). Place the
-  // fork past the synced list's current tail so the new key is
-  // strictly greater than every existing key — generating off the
-  // original's key alone would collide with whatever doc sits
-  // immediately after it.
+  // The fork's id is minted client-side as UUID v7 — same scheme as
+  // every other doc id. Place the fork past the synced list's
+  // current tail so the new key is strictly greater than every
+  // existing key — generating off the original's key alone would
+  // collide with whatever doc sits immediately after it.
+  const forkId = uuidv7();
   const syncedList = await repository.list();
   const forkSortOrder = nextTailSortOrder(syncedList);
-  const created = await repository.create({
+  await repository.create({
     meta: {
+      id: forkId,
       title: forkTitle,
       sortOrder: forkSortOrder,
       origin: "synced",
     },
     snapshot: null,
   });
-  const forkId = created.meta.id;
 
   // Push the local snapshot into the fork's Durable Object room.
   let forkPushRes: Response;

--- a/packages/app/src/documents/reconnect.ts
+++ b/packages/app/src/documents/reconnect.ts
@@ -1,4 +1,3 @@
-import { generateKeyBetween } from "fractional-indexing";
 import type { TLStoreSnapshot } from "tldraw";
 import type { ApiDocumentRepository } from "./api-repository";
 import {
@@ -6,6 +5,7 @@ import {
   shouldSkipReconnect,
   type ReconnectSnapshotState,
 } from "./offline-recovery";
+import { nextTailSortOrder } from "./sort-order";
 
 export type ReconnectResult =
   | { action: "noop" }
@@ -167,11 +167,12 @@ export async function reconcileOfflineEdits(params: {
   // Create the fork on the server. The fork is a distinct document
   // with its own id — we know that id only after the POST response
   // (the API repo ignores any client-supplied id and the server
-  // allocates an INTEGER). Place the fork's sort_order right after
-  // the original via fractional-indexing — the result is strictly
-  // > the original key, which is enough to sit "after" it even if
-  // other docs sit further along.
-  const forkSortOrder = generateKeyBetween(serverDoc.meta.sortOrder, null);
+  // allocates an INTEGER). Place the fork past the synced list's
+  // current tail so the new key is strictly greater than every
+  // existing key — generating off the original's key alone would
+  // collide with whatever doc sits immediately after it.
+  const syncedList = await repository.list();
+  const forkSortOrder = nextTailSortOrder(syncedList);
   const created = await repository.create({
     meta: {
       // Placeholder — the API repo ignores this and the server

--- a/packages/app/src/documents/reconnect.ts
+++ b/packages/app/src/documents/reconnect.ts
@@ -177,7 +177,7 @@ export async function reconcileOfflineEdits(params: {
       id: forkId,
       title: forkTitle,
       sortOrder: forkSortOrder,
-      origin: "synced",
+      source: "synced",
     },
     snapshot: null,
   });

--- a/packages/app/src/documents/reconnect.ts
+++ b/packages/app/src/documents/reconnect.ts
@@ -1,3 +1,4 @@
+import { generateKeyBetween } from "fractional-indexing";
 import type { TLStoreSnapshot } from "tldraw";
 import type { ApiDocumentRepository } from "./api-repository";
 import {
@@ -161,21 +162,32 @@ export async function reconcileOfflineEdits(params: {
   // Server has diverged — fork the local version as a new document.
   const originalTitle = serverDoc.meta.title;
   const forkTitle = `${originalTitle} (offline copy)`;
-  const forkId = crypto.randomUUID();
   const now = Date.now();
 
-  // Create the fork document metadata on the server.
-  await repository.save({
+  // Create the fork on the server. The fork is a distinct document
+  // with its own id — we know that id only after the POST response
+  // (the API repo ignores any client-supplied id and the server
+  // allocates an INTEGER). Place the fork's sort_order right after
+  // the original via fractional-indexing — the result is strictly
+  // > the original key, which is enough to sit "after" it even if
+  // other docs sit further along.
+  const forkSortOrder = generateKeyBetween(serverDoc.meta.sortOrder, null);
+  const created = await repository.create({
     meta: {
-      id: forkId,
+      // Placeholder — the API repo ignores this and the server
+      // allocates the real id. Kept as a fresh UUID rather than
+      // reusing `documentId` so it doesn't read as "saving the fork
+      // under the original's id."
+      id: crypto.randomUUID(),
       title: forkTitle,
       createdAt: now,
       updatedAt: now,
-      order: serverDoc.meta.order + 0.001,
+      sortOrder: forkSortOrder,
       origin: "synced",
     },
     snapshot: null,
   });
+  const forkId = created.meta.id;
 
   // Push the local snapshot into the fork's Durable Object room.
   let forkPushRes: Response;

--- a/packages/app/src/documents/reconnect.ts
+++ b/packages/app/src/documents/reconnect.ts
@@ -172,7 +172,7 @@ export async function reconcileOfflineEdits(params: {
   const forkId = uuidv7();
   const syncedList = await repository.list();
   const forkSortOrder = nextTailSortOrder(syncedList);
-  await repository.create({
+  await repository.save({
     meta: {
       id: forkId,
       title: forkTitle,

--- a/packages/app/src/documents/repository.ts
+++ b/packages/app/src/documents/repository.ts
@@ -4,15 +4,20 @@ export interface DocumentRepository {
   list(): Promise<DocumentMeta[]>;
   get(id: string): Promise<DocumentData | undefined>;
   /**
-   * Create a new document. The input `id` is optional: the local IDB
-   * repo allocates a UUID when missing (or honors a caller-supplied
-   * one); the API (synced) repo always ignores it and lets the server
-   * allocate the canonical id+slug at INSERT time.
+   * Save a document — insert if new, update if existing. The single
+   * upsert shape is consistent across both repos: the IDB repo
+   * collapses insert and update into the same `set()` call by id, and
+   * the API repo's `PUT /api/documents/:id` is server-side upsert.
    *
-   * Always returns the saved doc with the canonical id — callers must
-   * use the returned `meta.id` for any subsequent operations.
+   * The caller-supplied `id` is the canonical id everywhere — UUID v7
+   * is client-allocated, see the documents.id design note in the
+   * worker schema. The repo stamps timestamps; on insert it sets
+   * `createdAt` (or honors the optional override) and `updatedAt`,
+   * on update it bumps `updatedAt` and preserves `createdAt`.
+   *
+   * Returns the saved doc with all server-side stamps (slug, current
+   * timestamps) populated.
    */
-  create(draft: DocumentDraft): Promise<DocumentData>;
-  update(data: DocumentData): Promise<void>;
+  save(draft: DocumentDraft): Promise<DocumentData>;
   delete(id: string): Promise<void>;
 }

--- a/packages/app/src/documents/repository.ts
+++ b/packages/app/src/documents/repository.ts
@@ -3,6 +3,22 @@ import type { DocumentData, DocumentMeta } from "./types";
 export interface DocumentRepository {
   list(): Promise<DocumentMeta[]>;
   get(id: string): Promise<DocumentData | undefined>;
-  save(data: DocumentData): Promise<void>;
+  /**
+   * Create a new document. Each repository owns its own id-allocation
+   * policy:
+   *
+   * - The local IDB repo uses the caller-provided `data.meta.id`
+   *   verbatim (callers generate a UUID up front so a fresh local
+   *   doc has a stable identity even before any sync).
+   * - The API (synced) repo ignores `data.meta.id` and the slug;
+   *   the server allocates both at INSERT time and the returned
+   *   doc carries the canonical id+slug.
+   *
+   * Always returns the saved doc — callers must use its `meta.id`
+   * for any subsequent operations rather than the value they
+   * passed in.
+   */
+  create(data: DocumentData): Promise<DocumentData>;
+  update(data: DocumentData): Promise<void>;
   delete(id: string): Promise<void>;
 }

--- a/packages/app/src/documents/repository.ts
+++ b/packages/app/src/documents/repository.ts
@@ -1,4 +1,4 @@
-import type { DocumentData, DocumentDraft, DocumentMeta } from "./types";
+import type { DocumentData, DocumentInput, DocumentMeta } from "./types";
 
 export interface DocumentRepository {
   list(): Promise<DocumentMeta[]>;
@@ -18,6 +18,6 @@ export interface DocumentRepository {
    * Returns the saved doc with all server-side stamps (slug, current
    * timestamps) populated.
    */
-  save(draft: DocumentDraft): Promise<DocumentData>;
+  save(input: DocumentInput): Promise<DocumentData>;
   delete(id: string): Promise<void>;
 }

--- a/packages/app/src/documents/repository.ts
+++ b/packages/app/src/documents/repository.ts
@@ -1,24 +1,18 @@
-import type { DocumentData, DocumentMeta } from "./types";
+import type { DocumentData, DocumentDraft, DocumentMeta } from "./types";
 
 export interface DocumentRepository {
   list(): Promise<DocumentMeta[]>;
   get(id: string): Promise<DocumentData | undefined>;
   /**
-   * Create a new document. Each repository owns its own id-allocation
-   * policy:
+   * Create a new document. The input `id` is optional: the local IDB
+   * repo allocates a UUID when missing (or honors a caller-supplied
+   * one); the API (synced) repo always ignores it and lets the server
+   * allocate the canonical id+slug at INSERT time.
    *
-   * - The local IDB repo uses the caller-provided `data.meta.id`
-   *   verbatim (callers generate a UUID up front so a fresh local
-   *   doc has a stable identity even before any sync).
-   * - The API (synced) repo ignores `data.meta.id` and the slug;
-   *   the server allocates both at INSERT time and the returned
-   *   doc carries the canonical id+slug.
-   *
-   * Always returns the saved doc — callers must use its `meta.id`
-   * for any subsequent operations rather than the value they
-   * passed in.
+   * Always returns the saved doc with the canonical id — callers must
+   * use the returned `meta.id` for any subsequent operations.
    */
-  create(data: DocumentData): Promise<DocumentData>;
+  create(draft: DocumentDraft): Promise<DocumentData>;
   update(data: DocumentData): Promise<void>;
   delete(id: string): Promise<void>;
 }

--- a/packages/app/src/documents/snapshot-push.ts
+++ b/packages/app/src/documents/snapshot-push.ts
@@ -1,22 +1,17 @@
 import type { TLStoreSnapshot } from "tldraw";
 
 /**
- * Push a snapshot to a document's Durable Object room. Used as the
- * finalizing step of a multi-step doc creation:
+ * Push a snapshot to a document's Durable Object room. Used by the
+ * migration and reconnect-fork flows, both of which have a real
+ * snapshot to land. A successful push also clears the server-side
+ * `initializing_at` flag, finalizing the doc.
  *
- *   POST /api/documents             → row inserted (initializing_at = now)
- *   (assets, optional)
- *   PUT /api/documents/:id/snapshot → DO seeded, initializing_at cleared
- *
- * For a freshly-created synced doc with no content yet, callers pass
- * an empty snapshot. Migration and reconnect-fork flows push their own
- * real snapshots via their own logic; this helper exists for callers
- * who only need the contract-completing push.
- *
- * `expectedSnapshotVersion: 0` is the canonical "this is the first
- * snapshot for the doc" value — the server's snapshot push handler
- * rejects with 409 if the DO room already has a snapshot at a
- * different version.
+ * The fresh-create flow does NOT use this — it finalizes via
+ * `finalizeSyncedDocument` instead, since synthesizing a valid empty
+ * TLStoreSnapshot client-side requires reconstructing tldraw's
+ * schema descriptor and would also pre-seed the DO room with empty
+ * state, pre-empting useSync's natural "populate on first connect"
+ * path.
  */
 export async function pushSnapshot(
   documentId: string,
@@ -36,10 +31,21 @@ export async function pushSnapshot(
   }
 }
 
-// An empty TLStoreSnapshot used as the initial push for synced docs
-// created via `createDocument`. The DO room is seeded with no records;
-// useSync will populate it once the user starts editing.
-export const EMPTY_SNAPSHOT = {
-  store: {},
-  schema: {},
-} as unknown as TLStoreSnapshot;
+/**
+ * Finalize a fresh synced document so it becomes visible to the user.
+ * After `POST /api/documents` the row is marked `initializing_at` on
+ * the server; this endpoint clears the flag without touching the DO.
+ * The room stays un-seeded until the user opens the doc, at which
+ * point useSync populates it on first connect.
+ */
+export async function finalizeSyncedDocument(
+  documentId: string,
+): Promise<void> {
+  const res = await fetch(
+    `/api/documents/${encodeURIComponent(documentId)}/finalize`,
+    { method: "POST" },
+  );
+  if (!res.ok) {
+    throw new Error(`Document finalize failed: ${res.status}`);
+  }
+}

--- a/packages/app/src/documents/snapshot-push.ts
+++ b/packages/app/src/documents/snapshot-push.ts
@@ -33,10 +33,18 @@ export async function pushSnapshot(
 
 /**
  * Finalize a fresh synced document so it becomes visible to the user.
- * After `POST /api/documents` the row is marked `initializing_at` on
- * the server; this endpoint clears the flag without touching the DO.
- * The room stays un-seeded until the user opens the doc, at which
+ * After `PUT /api/documents/:id` the row is marked `initializing_at`
+ * on the server; this endpoint clears the flag without touching the
+ * DO. The room stays un-seeded until the user opens the doc, at which
  * point useSync populates it on first connect.
+ *
+ * Failure semantics: if `repo.save` succeeds but this call throws,
+ * the row exists on the server with `initializing_at` still set. It
+ * stays invisible to the user (the active-list query filters out
+ * `initializing_at IS NOT NULL` rows) and the server-side sweep
+ * eventually reaps it. The user's natural recovery is to retry, which
+ * is just a fresh insert under a new id — no client cleanup is
+ * needed because the row was never user-visible.
  */
 export async function finalizeSyncedDocument(
   documentId: string,

--- a/packages/app/src/documents/snapshot-push.ts
+++ b/packages/app/src/documents/snapshot-push.ts
@@ -1,0 +1,45 @@
+import type { TLStoreSnapshot } from "tldraw";
+
+/**
+ * Push a snapshot to a document's Durable Object room. Used as the
+ * finalizing step of a multi-step doc creation:
+ *
+ *   POST /api/documents             → row inserted (initializing_at = now)
+ *   (assets, optional)
+ *   PUT /api/documents/:id/snapshot → DO seeded, initializing_at cleared
+ *
+ * For a freshly-created synced doc with no content yet, callers pass
+ * an empty snapshot. Migration and reconnect-fork flows push their own
+ * real snapshots via their own logic; this helper exists for callers
+ * who only need the contract-completing push.
+ *
+ * `expectedSnapshotVersion: 0` is the canonical "this is the first
+ * snapshot for the doc" value — the server's snapshot push handler
+ * rejects with 409 if the DO room already has a snapshot at a
+ * different version.
+ */
+export async function pushSnapshot(
+  documentId: string,
+  snapshot: TLStoreSnapshot,
+  expectedSnapshotVersion: number,
+): Promise<void> {
+  const res = await fetch(
+    `/api/documents/${encodeURIComponent(documentId)}/snapshot`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ snapshot, expectedSnapshotVersion }),
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`Snapshot push failed: ${res.status}`);
+  }
+}
+
+// An empty TLStoreSnapshot used as the initial push for synced docs
+// created via `createDocument`. The DO room is seeded with no records;
+// useSync will populate it once the user starts editing.
+export const EMPTY_SNAPSHOT = {
+  store: {},
+  schema: {},
+} as unknown as TLStoreSnapshot;

--- a/packages/app/src/documents/sort-order.ts
+++ b/packages/app/src/documents/sort-order.ts
@@ -18,10 +18,7 @@ import type { DocumentMeta } from "./types";
 export function nextTailSortOrder(
   existing: ReadonlyArray<Pick<DocumentMeta, "sortOrder">>,
 ): string {
-  const keys = existing
-    .map((d) => d.sortOrder)
-    .filter((key): key is string => typeof key === "string")
-    .sort();
+  const keys = existing.map((d) => d.sortOrder).sort();
   const tail = keys[keys.length - 1] ?? null;
   return generateKeyBetween(tail, null);
 }

--- a/packages/app/src/documents/sort-order.ts
+++ b/packages/app/src/documents/sort-order.ts
@@ -1,0 +1,27 @@
+import { generateKeyBetween } from "fractional-indexing";
+import type { DocumentMeta } from "./types";
+
+/**
+ * Compute the fractional-indexing key that places a new doc at the
+ * end of `existing`. `existing` is sorted by `sortOrder`
+ * lexicographically and the new key is bumped past the tail.
+ *
+ * If `existing` is empty, falls back to the package's "first" key
+ * (typically `"a0"`) via `generateKeyBetween(null, null)`.
+ *
+ * Known limitation: when two callers race on the same `existing`
+ * snapshot they pick the same key. `generateKeyBetween` is
+ * deterministic per (prev, next) pair, so the collision is silent —
+ * the sidebar's stable sort still shows both, just in a
+ * non-deterministic order between them, and any user reorder heals it.
+ */
+export function nextTailSortOrder(
+  existing: ReadonlyArray<Pick<DocumentMeta, "sortOrder">>,
+): string {
+  const keys = existing
+    .map((d) => d.sortOrder)
+    .filter((key): key is string => typeof key === "string")
+    .sort();
+  const tail = keys[keys.length - 1] ?? null;
+  return generateKeyBetween(tail, null);
+}

--- a/packages/app/src/documents/types.ts
+++ b/packages/app/src/documents/types.ts
@@ -27,20 +27,30 @@ export interface DocumentData {
 }
 
 /**
- * Input shape for creating a new document. The id is optional because
- * each repository owns its own id-allocation policy:
+ * Input shape for creating a new document.
  *
- * - The local IDB repo allocates a fresh UUID when `id` is omitted,
- *   or uses the caller-provided id when supplied (callers may want
- *   to mint the id upfront so they can reference it before the
- *   create resolves).
- * - The API (synced) repo always ignores `id`; the server allocates
- *   the canonical INTEGER id at INSERT time. Caller-supplied values
- *   are silently dropped.
+ * The repository owns id allocation and timestamp stamping; callers
+ * supply only the user-meaningful fields:
  *
- * `create()` always returns a `DocumentData` with the canonical id.
+ * - `id` is optional. The local IDB repo mints a fresh UUID when
+ *   omitted (or honors a caller-supplied one for stable identity-
+ *   from-creation); the API repo always ignores it and the server
+ *   allocates the canonical INTEGER id at INSERT time.
+ * - `createdAt` is optional. It exists only as an escape hatch for
+ *   the local→synced migration to preserve a doc's on-device
+ *   creation time. In every other call site the repo (or the
+ *   server, via column DEFAULT) stamps it.
+ * - `updatedAt` is not on the draft at all — repos always stamp it
+ *   themselves on create; on update, the IDB repo bumps it and the
+ *   server's updated_at trigger handles it.
+ *
+ * `create()` always returns a `DocumentData` with the canonical id
+ * and timestamps.
  */
 export interface DocumentDraft {
-  meta: Omit<DocumentMeta, "id"> & { id?: string };
+  meta: Pick<DocumentMeta, "title" | "sortOrder" | "origin"> & {
+    id?: string;
+    createdAt?: number;
+  };
   snapshot: TLStoreSnapshot | null;
 }

--- a/packages/app/src/documents/types.ts
+++ b/packages/app/src/documents/types.ts
@@ -29,13 +29,15 @@ export interface DocumentData {
 /**
  * Input shape for creating a new document.
  *
- * The repository owns id allocation and timestamp stamping; callers
- * supply only the user-meaningful fields:
+ * `id` is required: every doc has its UUID v7 minted client-side at
+ * the moment of creation. The same id flows through both the IDB
+ * write and (later, on migration) the POST /api/documents call,
+ * unchanged. See the documents.id design note in the worker schema
+ * for why the id is client-allocated.
  *
- * - `id` is optional. The local IDB repo mints a fresh UUID when
- *   omitted (or honors a caller-supplied one for stable identity-
- *   from-creation); the API repo always ignores it and the server
- *   allocates the canonical INTEGER id at INSERT time.
+ * The repository owns timestamp stamping; callers supply only the
+ * user-meaningful fields plus the id:
+ *
  * - `createdAt` is optional. It exists only as an escape hatch for
  *   the local→synced migration to preserve a doc's on-device
  *   creation time. In every other call site the repo (or the
@@ -43,13 +45,9 @@ export interface DocumentData {
  * - `updatedAt` is not on the draft at all — repos always stamp it
  *   themselves on create; on update, the IDB repo bumps it and the
  *   server's updated_at trigger handles it.
- *
- * `create()` always returns a `DocumentData` with the canonical id
- * and timestamps.
  */
 export interface DocumentDraft {
-  meta: Pick<DocumentMeta, "title" | "sortOrder" | "origin"> & {
-    id?: string;
+  meta: Pick<DocumentMeta, "id" | "title" | "sortOrder" | "origin"> & {
     createdAt?: number;
   };
   snapshot: TLStoreSnapshot | null;

--- a/packages/app/src/documents/types.ts
+++ b/packages/app/src/documents/types.ts
@@ -1,6 +1,6 @@
 import type { TLStoreSnapshot } from "tldraw";
 
-export type DocumentOrigin = "local" | "synced";
+export type DocumentSource = "local" | "synced";
 
 export interface DocumentMeta {
   id: string;
@@ -18,7 +18,13 @@ export interface DocumentMeta {
    * ordering of documents in the sidebar.
    */
   sortOrder: string;
-  origin: DocumentOrigin;
+  /**
+   * Where the document lives — `"local"` for IDB-backed local-only
+   * docs and `"synced"` for server-backed docs. The `Source` term is
+   * used here (rather than `Origin`) to avoid confusion with URL
+   * origins (`location.origin`, CORS origins, etc.).
+   */
+  source: DocumentSource;
 }
 
 export interface DocumentData {
@@ -27,11 +33,11 @@ export interface DocumentData {
 }
 
 /**
- * Input shape for creating a new document.
+ * Input shape for creating or updating a document via `repo.save`.
  *
  * `id` is required: every doc has its UUID v7 minted client-side at
  * the moment of creation. The same id flows through both the IDB
- * write and (later, on migration) the POST /api/documents call,
+ * write and (later, on migration) the PUT /api/documents/:id call,
  * unchanged. See the documents.id design note in the worker schema
  * for why the id is client-allocated.
  *
@@ -42,12 +48,12 @@ export interface DocumentData {
  *   the local→synced migration to preserve a doc's on-device
  *   creation time. In every other call site the repo (or the
  *   server, via column DEFAULT) stamps it.
- * - `updatedAt` is not on the draft at all — repos always stamp it
+ * - `updatedAt` is not on the input at all — repos always stamp it
  *   themselves on create; on update, the IDB repo bumps it and the
  *   server's updated_at trigger handles it.
  */
-export interface DocumentDraft {
-  meta: Pick<DocumentMeta, "id" | "title" | "sortOrder" | "origin"> & {
+export interface DocumentInput {
+  meta: Pick<DocumentMeta, "id" | "title" | "sortOrder" | "source"> & {
     createdAt?: number;
   };
   snapshot: TLStoreSnapshot | null;

--- a/packages/app/src/documents/types.ts
+++ b/packages/app/src/documents/types.ts
@@ -4,10 +4,20 @@ export type DocumentOrigin = "local" | "synced";
 
 export interface DocumentMeta {
   id: string;
+  /**
+   * Server-issued URL handle for synced docs; absent for local-only
+   * docs that haven't yet been migrated to the server.
+   */
+  slug?: string;
   title: string;
   createdAt: number;
   updatedAt: number;
-  order: number;
+  /**
+   * Fractional-indexing key (the `fractional-indexing` npm package).
+   * Lexicographic order over these strings matches the user-facing
+   * ordering of documents in the sidebar.
+   */
+  sortOrder: string;
   origin: DocumentOrigin;
 }
 

--- a/packages/app/src/documents/types.ts
+++ b/packages/app/src/documents/types.ts
@@ -25,3 +25,22 @@ export interface DocumentData {
   meta: DocumentMeta;
   snapshot: TLStoreSnapshot | null;
 }
+
+/**
+ * Input shape for creating a new document. The id is optional because
+ * each repository owns its own id-allocation policy:
+ *
+ * - The local IDB repo allocates a fresh UUID when `id` is omitted,
+ *   or uses the caller-provided id when supplied (callers may want
+ *   to mint the id upfront so they can reference it before the
+ *   create resolves).
+ * - The API (synced) repo always ignores `id`; the server allocates
+ *   the canonical INTEGER id at INSERT time. Caller-supplied values
+ *   are silently dropped.
+ *
+ * `create()` always returns a `DocumentData` with the canonical id.
+ */
+export interface DocumentDraft {
+  meta: Omit<DocumentMeta, "id"> & { id?: string };
+  snapshot: TLStoreSnapshot | null;
+}

--- a/packages/app/src/documents/useDocumentManager.test.tsx
+++ b/packages/app/src/documents/useDocumentManager.test.tsx
@@ -12,7 +12,7 @@ function makeLocalDocWithSnapshot(id: string): DocumentData {
     meta: {
       id,
       title: id,
-      order: 1,
+      sortOrder: "a0",
       origin: "local",
       createdAt: 0,
       updatedAt: 0,
@@ -23,12 +23,12 @@ function makeLocalDocWithSnapshot(id: string): DocumentData {
 
 function makeDoc(
   id: string,
-  order: number,
+  sortOrder: string,
   origin: DocumentOrigin,
   title = id,
 ): DocumentData {
   return {
-    meta: { id, title, order, origin, createdAt: 0, updatedAt: 0 },
+    meta: { id, title, sortOrder, origin, createdAt: 0, updatedAt: 0 },
     snapshot: null,
   };
 }
@@ -43,21 +43,41 @@ function makeFakeRepo(origin: DocumentOrigin, initial: DocumentData[] = []) {
     async (): Promise<DocumentMeta[]> =>
       [...store.values()]
         .map((d) => ({ ...d.meta, origin }))
-        .sort((a, b) => a.order - b.order),
+        .sort((a, b) => a.sortOrder.localeCompare(b.sortOrder)),
   );
   const get = vi.fn(async (id: string): Promise<DocumentData | undefined> => {
     const d = store.get(id);
     return d ? { ...d, meta: { ...d.meta, origin } } : undefined;
   });
-  const save = vi.fn(async (d: DocumentData): Promise<void> => {
+  // For the synced repo the server allocates ids in the real worker;
+  // here we derive a deterministic "synced-<localId>" so tests that
+  // need to correlate a migration with its server-side row (e.g. the
+  // pushSnapshot mock keyed by documentId) have a predictable mapping.
+  // The local repo keeps the caller's id verbatim, mimicking IDB.
+  const create = vi.fn(async (d: DocumentData): Promise<DocumentData> => {
+    const allocatedId = origin === "synced" ? `synced-${d.meta.id}` : d.meta.id;
+    const stored: DocumentData = {
+      ...d,
+      meta: { ...d.meta, id: allocatedId, origin },
+    };
+    store.set(allocatedId, stored);
+    return stored;
+  });
+  const update = vi.fn(async (d: DocumentData): Promise<void> => {
     store.set(d.meta.id, d);
   });
   const del = vi.fn(async (id: string): Promise<void> => {
     store.delete(id);
   });
 
-  const repo: DocumentRepository = { list, get, save, delete: del };
-  return { repo, store, list, get, save, delete: del };
+  const repo: DocumentRepository = {
+    list,
+    get,
+    create,
+    update,
+    delete: del,
+  };
+  return { repo, store, list, get, create, update, delete: del };
 }
 
 describe("useDocumentManager", () => {
@@ -74,12 +94,12 @@ describe("useDocumentManager", () => {
 
   it("merges synced and local documents on initial load with synced first", async () => {
     const localRepo = makeFakeRepo("local", [
-      makeDoc("L1", 1, "local"),
-      makeDoc("L2", 2, "local"),
+      makeDoc("L1", "a0", "local"),
+      makeDoc("L2", "a1", "local"),
     ]);
     const syncedRepo = makeFakeRepo("synced", [
-      makeDoc("S1", 1, "synced"),
-      makeDoc("S2", 2, "synced"),
+      makeDoc("S1", "a0", "synced"),
+      makeDoc("S2", "a1", "synced"),
     ]);
 
     const { result } = renderHook(() =>
@@ -118,14 +138,14 @@ describe("useDocumentManager", () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(syncedRepo.save).toHaveBeenCalledTimes(1);
-    expect(localRepo.save).not.toHaveBeenCalled();
+    expect(syncedRepo.create).toHaveBeenCalledTimes(1);
+    expect(localRepo.create).not.toHaveBeenCalled();
     expect(result.current.documents).toHaveLength(1);
     expect(result.current.documents[0].origin).toBe("synced");
   });
 
   it("completes initial load with local docs when the synced list rejects", async () => {
-    const localRepo = makeFakeRepo("local", [makeDoc("L1", 1, "local")]);
+    const localRepo = makeFakeRepo("local", [makeDoc("L1", "a0", "local")]);
     const syncedRepo = makeFakeRepo("synced");
     syncedRepo.repo.list = vi.fn().mockRejectedValue(new Error("503"));
 
@@ -147,7 +167,7 @@ describe("useDocumentManager", () => {
 
   it("preserves the last-known synced list when a later list rejects", async () => {
     const localRepo = makeFakeRepo("local");
-    const syncedRepo = makeFakeRepo("synced", [makeDoc("S1", 1, "synced")]);
+    const syncedRepo = makeFakeRepo("synced", [makeDoc("S1", "a0", "synced")]);
 
     const { result } = renderHook(() =>
       useDocumentManager({
@@ -171,8 +191,8 @@ describe("useDocumentManager", () => {
   });
 
   it("routes selectDocument to the synced repo immediately after refreshDocuments picks up a new doc", async () => {
-    const localRepo = makeFakeRepo("local", [makeDoc("L1", 1, "local")]);
-    const syncedRepo = makeFakeRepo("synced", [makeDoc("S1", 1, "synced")]);
+    const localRepo = makeFakeRepo("local", [makeDoc("L1", "a0", "local")]);
+    const syncedRepo = makeFakeRepo("synced", [makeDoc("S1", "a0", "synced")]);
 
     const { result } = renderHook(() =>
       useDocumentManager({
@@ -186,7 +206,7 @@ describe("useDocumentManager", () => {
     // Simulate a fork landing server-side between refresh and select — the
     // ref-sync invariant requires that selectDocument sees the new doc
     // immediately, without waiting for React to commit the next render.
-    syncedRepo.store.set("S2", makeDoc("S2", 2, "synced"));
+    syncedRepo.store.set("S2", makeDoc("S2", "a1", "synced"));
 
     await act(async () => {
       await result.current.refreshDocuments();
@@ -201,7 +221,7 @@ describe("useDocumentManager", () => {
 
   it("falls back to creating a local replacement when deleting the last doc and synced save fails", async () => {
     const localRepo = makeFakeRepo("local");
-    const syncedRepo = makeFakeRepo("synced", [makeDoc("S1", 1, "synced")]);
+    const syncedRepo = makeFakeRepo("synced", [makeDoc("S1", "a0", "synced")]);
 
     const { result } = renderHook(() =>
       useDocumentManager({
@@ -213,21 +233,23 @@ describe("useDocumentManager", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.documents).toHaveLength(1);
 
-    // Synced save fails — the replacement should still land, but as local.
-    syncedRepo.repo.save = vi.fn().mockRejectedValue(new Error("server down"));
+    // Synced create fails — the replacement should still land, but as local.
+    syncedRepo.repo.create = vi
+      .fn()
+      .mockRejectedValue(new Error("server down"));
 
     await act(async () => {
       await result.current.deleteDocument("S1");
     });
 
-    expect(localRepo.save).toHaveBeenCalledTimes(1);
+    expect(localRepo.create).toHaveBeenCalledTimes(1);
     expect(result.current.documents).toHaveLength(1);
     expect(result.current.documents[0].origin).toBe("local");
     expect(vi.mocked(console.error)).toHaveBeenCalled();
   });
 
   it("migrates a local doc to synced via convertToSynced and keeps it selected with the new origin", async () => {
-    const localRepo = makeFakeRepo("local", [makeDoc("doc-1", 1, "local")]);
+    const localRepo = makeFakeRepo("local", [makeDoc("doc-1", "a0", "local")]);
     const syncedRepo = makeFakeRepo("synced");
 
     const uploadAsset = vi.fn();
@@ -249,9 +271,11 @@ describe("useDocumentManager", () => {
       await result.current.convertToSynced("doc-1");
     });
 
-    expect(syncedRepo.save).toHaveBeenCalledTimes(1);
+    expect(syncedRepo.create).toHaveBeenCalledTimes(1);
     expect(localRepo.delete).toHaveBeenCalledWith("doc-1");
-    expect(result.current.activeDocument?.id).toBe("doc-1");
+    // The migrated doc gets a server-allocated id (≠ "doc-1") and the
+    // active doc should be swapped to it. Origin flips to synced.
+    expect(result.current.activeDocument?.id).not.toBe("doc-1");
     expect(result.current.activeDocument?.origin).toBe("synced");
   });
 
@@ -340,9 +364,12 @@ describe("useDocumentManager", () => {
       expect(result.current.converting.has("doc-2")).toBe(true);
     });
 
-    // Resolve in reverse order to show the ids track their own completion.
+    // The pushSnapshot mock receives the *server-allocated* id, not
+    // the local id. Our test fake's synced repo allocates server ids
+    // as `"synced-<localId>"`, so the resolvers keyed on what
+    // pushSnapshot saw map back via the same prefix.
     await act(async () => {
-      resolvers["doc-2"]();
+      resolvers["synced-doc-2"]();
       await secondConvert;
     });
 
@@ -350,7 +377,7 @@ describe("useDocumentManager", () => {
     expect(result.current.converting.has("doc-2")).toBe(false);
 
     await act(async () => {
-      resolvers["doc-1"]();
+      resolvers["synced-doc-1"]();
       await firstConvert;
     });
 
@@ -415,7 +442,9 @@ describe("useDocumentManager", () => {
     const pushSnapshot = vi
       .fn<(documentId: string, snapshot: TLStoreSnapshot) => Promise<void>>()
       .mockImplementation(async (documentId) => {
-        if (documentId === "doc-bad") {
+        // The mock receives the server-allocated id, mapped from the
+        // local id by the test fake (`synced-<localId>`).
+        if (documentId === "synced-doc-bad") {
           throw new Error("Snapshot push failed: 413");
         }
       });
@@ -601,7 +630,7 @@ describe("useDocumentManager", () => {
     // deletion has something to clean up.
     await waitFor(() => {
       expect(result.current.converting.has("doc-1")).toBe(true);
-      expect(syncedRepo.save).toHaveBeenCalledTimes(1);
+      expect(syncedRepo.create).toHaveBeenCalledTimes(1);
     });
 
     await act(async () => {
@@ -614,13 +643,20 @@ describe("useDocumentManager", () => {
     expect(result.current.converting.has("doc-1")).toBe(false);
     expect(result.current.conversionErrors.has("doc-1")).toBe(false);
 
-    // The orphan synced metadata that the aborted migration left behind
-    // was cleaned up by deleteDocument.
-    expect(syncedRepo.delete).toHaveBeenCalledWith("doc-1");
-    expect(syncedRepo.store.has("doc-1")).toBe(false);
+    // The local doc was deleted by id "doc-1". With server-allocated
+    // ids, the orphan synced metadata (if it was already created
+    // before the abort) cannot be cleaned up by the local id —
+    // deleteDocument does not attempt that anymore. The server row
+    // would surface on a future refresh and need manual cleanup; we
+    // accept that for the rare race window.
+    expect(localRepo.delete).toHaveBeenCalledWith("doc-1");
 
-    // doc-1 is gone, doc-2 remains active.
-    expect(result.current.documents.map((d) => d.id)).toEqual(["doc-2"]);
+    // doc-1 is gone from the local sidebar; doc-2 remains active.
+    // Note: a phantom synced row from the half-completed migration
+    // remains and shows up in the list. Cleaning it up would require
+    // tracking the server-allocated id back up to the manager —
+    // tracked as a follow-up; tolerable for the rare race window.
+    expect(result.current.documents.map((d) => d.id)).toContain("doc-2");
 
     // Drain the mocked push so no pending promise leaks between tests.
     resolvePush();
@@ -715,7 +751,7 @@ describe("useDocumentManager", () => {
   });
 
   it("convertToSynced is a no-op when no synced repository is configured", async () => {
-    const localRepo = makeFakeRepo("local", [makeDoc("doc-1", 1, "local")]);
+    const localRepo = makeFakeRepo("local", [makeDoc("doc-1", "a0", "local")]);
 
     const { result } = renderHook(() =>
       useDocumentManager({ localRepository: localRepo.repo }),
@@ -732,7 +768,7 @@ describe("useDocumentManager", () => {
   });
 
   it("treats createDocument({origin: 'synced'}) as a no-op when no synced repository is configured", async () => {
-    const localRepo = makeFakeRepo("local", [makeDoc("L1", 1, "local")]);
+    const localRepo = makeFakeRepo("local", [makeDoc("L1", "a0", "local")]);
 
     const { result } = renderHook(() =>
       useDocumentManager({ localRepository: localRepo.repo }),
@@ -748,7 +784,7 @@ describe("useDocumentManager", () => {
     // exists from the fixture, and the synced-origin create should not fall
     // through to local here (that fallback is only for the last-doc-delete
     // replacement path).
-    expect(localRepo.save).not.toHaveBeenCalled();
+    expect(localRepo.create).not.toHaveBeenCalled();
     expect(result.current.documents.map((d) => d.id)).toEqual(["L1"]);
   });
 });

--- a/packages/app/src/documents/useDocumentManager.test.tsx
+++ b/packages/app/src/documents/useDocumentManager.test.tsx
@@ -54,25 +54,24 @@ function makeFakeRepo(origin: DocumentOrigin, initial: DocumentData[] = []) {
     const d = store.get(id);
     return d ? { ...d, meta: { ...d.meta, origin } } : undefined;
   });
-  // Both local and synced repos honor the caller's id verbatim — UUID
-  // v7 is client-allocated, so the same id flows through every layer
-  // and tests can assert on the original id everywhere.
-  const create = vi.fn(async (d: DocumentDraft): Promise<DocumentData> => {
+  // Single upsert method matching the production repo. Both local and
+  // synced repos honor the caller's id verbatim — UUID v7 is
+  // client-allocated, so the same id flows through every layer and
+  // tests can assert on the original id everywhere.
+  const save = vi.fn(async (d: DocumentDraft): Promise<DocumentData> => {
     const now = Date.now();
+    const existing = store.get(d.meta.id);
     const stored: DocumentData = {
       ...d,
       meta: {
         ...d.meta,
         origin,
-        createdAt: d.meta.createdAt ?? now,
+        createdAt: existing?.meta.createdAt ?? d.meta.createdAt ?? now,
         updatedAt: now,
       },
     };
     store.set(d.meta.id, stored);
     return stored;
-  });
-  const update = vi.fn(async (d: DocumentData): Promise<void> => {
-    store.set(d.meta.id, d);
   });
   const del = vi.fn(async (id: string): Promise<void> => {
     store.delete(id);
@@ -81,11 +80,10 @@ function makeFakeRepo(origin: DocumentOrigin, initial: DocumentData[] = []) {
   const repo: DocumentRepository = {
     list,
     get,
-    create,
-    update,
+    save,
     delete: del,
   };
-  return { repo, store, list, get, create, update, delete: del };
+  return { repo, store, list, get, save, delete: del };
 }
 
 describe("useDocumentManager", () => {
@@ -158,8 +156,8 @@ describe("useDocumentManager", () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(syncedRepo.create).toHaveBeenCalledTimes(1);
-    expect(localRepo.create).not.toHaveBeenCalled();
+    expect(syncedRepo.save).toHaveBeenCalledTimes(1);
+    expect(localRepo.save).not.toHaveBeenCalled();
     expect(result.current.documents).toHaveLength(1);
     expect(result.current.documents[0].origin).toBe("synced");
   });
@@ -254,15 +252,13 @@ describe("useDocumentManager", () => {
     expect(result.current.documents).toHaveLength(1);
 
     // Synced create fails — the replacement should still land, but as local.
-    syncedRepo.repo.create = vi
-      .fn()
-      .mockRejectedValue(new Error("server down"));
+    syncedRepo.repo.save = vi.fn().mockRejectedValue(new Error("server down"));
 
     await act(async () => {
       await result.current.deleteDocument("S1");
     });
 
-    expect(localRepo.create).toHaveBeenCalledTimes(1);
+    expect(localRepo.save).toHaveBeenCalledTimes(1);
     expect(result.current.documents).toHaveLength(1);
     expect(result.current.documents[0].origin).toBe("local");
     expect(vi.mocked(console.error)).toHaveBeenCalled();
@@ -291,7 +287,7 @@ describe("useDocumentManager", () => {
       await result.current.convertToSynced("doc-1");
     });
 
-    expect(syncedRepo.create).toHaveBeenCalledTimes(1);
+    expect(syncedRepo.save).toHaveBeenCalledTimes(1);
     expect(localRepo.delete).toHaveBeenCalledWith("doc-1");
     // The migrated doc keeps its UUID v7 id across the local→synced
     // transition; only the origin flips.
@@ -648,7 +644,7 @@ describe("useDocumentManager", () => {
     // deletion has something to clean up.
     await waitFor(() => {
       expect(result.current.converting.has("doc-1")).toBe(true);
-      expect(syncedRepo.create).toHaveBeenCalledTimes(1);
+      expect(syncedRepo.save).toHaveBeenCalledTimes(1);
     });
 
     await act(async () => {
@@ -797,7 +793,7 @@ describe("useDocumentManager", () => {
     // exists from the fixture, and the synced-origin create should not fall
     // through to local here (that fallback is only for the last-doc-delete
     // replacement path).
-    expect(localRepo.create).not.toHaveBeenCalled();
+    expect(localRepo.save).not.toHaveBeenCalled();
     expect(result.current.documents.map((d) => d.id)).toEqual(["L1"]);
   });
 });

--- a/packages/app/src/documents/useDocumentManager.test.tsx
+++ b/packages/app/src/documents/useDocumentManager.test.tsx
@@ -100,10 +100,22 @@ describe("useDocumentManager", () => {
     // them in tests to keep output readable; individual assertions below
     // verify that the log fires when expected via vi.mocked(console.error).
     vi.spyOn(console, "error").mockImplementation(() => {});
+    // Synced creation finalizes by pushing an empty initial snapshot via
+    // PUT /api/documents/:id/snapshot. Stub fetch so that call resolves
+    // OK and tests don't hit a real network.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      } as Response),
+    );
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("merges synced and local documents on initial load with synced first", async () => {

--- a/packages/app/src/documents/useDocumentManager.test.tsx
+++ b/packages/app/src/documents/useDocumentManager.test.tsx
@@ -3,7 +3,12 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import type { TLStoreSnapshot } from "tldraw";
 import { useDocumentManager } from "./useDocumentManager";
 import type { DocumentRepository } from "./repository";
-import type { DocumentData, DocumentMeta, DocumentOrigin } from "./types";
+import type {
+  DocumentData,
+  DocumentDraft,
+  DocumentMeta,
+  DocumentOrigin,
+} from "./types";
 
 const emptySnapshot = { store: {}, schema: {} } as unknown as TLStoreSnapshot;
 
@@ -53,9 +58,11 @@ function makeFakeRepo(origin: DocumentOrigin, initial: DocumentData[] = []) {
   // here we derive a deterministic "synced-<localId>" so tests that
   // need to correlate a migration with its server-side row (e.g. the
   // pushSnapshot mock keyed by documentId) have a predictable mapping.
-  // The local repo keeps the caller's id verbatim, mimicking IDB.
-  const create = vi.fn(async (d: DocumentData): Promise<DocumentData> => {
-    const allocatedId = origin === "synced" ? `synced-${d.meta.id}` : d.meta.id;
+  // The local repo keeps the caller's id verbatim, mimicking IDB; if
+  // the caller didn't supply one, mint a UUID like the real repo does.
+  const create = vi.fn(async (d: DocumentDraft): Promise<DocumentData> => {
+    const localId = d.meta.id ?? crypto.randomUUID();
+    const allocatedId = origin === "synced" ? `synced-${localId}` : localId;
     const stored: DocumentData = {
       ...d,
       meta: { ...d.meta, id: allocatedId, origin },

--- a/packages/app/src/documents/useDocumentManager.test.tsx
+++ b/packages/app/src/documents/useDocumentManager.test.tsx
@@ -54,27 +54,21 @@ function makeFakeRepo(origin: DocumentOrigin, initial: DocumentData[] = []) {
     const d = store.get(id);
     return d ? { ...d, meta: { ...d.meta, origin } } : undefined;
   });
-  // For the synced repo the server allocates ids in the real worker;
-  // here we derive a deterministic "synced-<localId>" so tests that
-  // need to correlate a migration with its server-side row (e.g. the
-  // pushSnapshot mock keyed by documentId) have a predictable mapping.
-  // The local repo keeps the caller's id verbatim, mimicking IDB; if
-  // the caller didn't supply one, mint a UUID like the real repo does.
+  // Both local and synced repos honor the caller's id verbatim — UUID
+  // v7 is client-allocated, so the same id flows through every layer
+  // and tests can assert on the original id everywhere.
   const create = vi.fn(async (d: DocumentDraft): Promise<DocumentData> => {
     const now = Date.now();
-    const localId = d.meta.id ?? crypto.randomUUID();
-    const allocatedId = origin === "synced" ? `synced-${localId}` : localId;
     const stored: DocumentData = {
       ...d,
       meta: {
         ...d.meta,
-        id: allocatedId,
         origin,
         createdAt: d.meta.createdAt ?? now,
         updatedAt: now,
       },
     };
-    store.set(allocatedId, stored);
+    store.set(d.meta.id, stored);
     return stored;
   });
   const update = vi.fn(async (d: DocumentData): Promise<void> => {
@@ -299,9 +293,9 @@ describe("useDocumentManager", () => {
 
     expect(syncedRepo.create).toHaveBeenCalledTimes(1);
     expect(localRepo.delete).toHaveBeenCalledWith("doc-1");
-    // The migrated doc gets a server-allocated id (≠ "doc-1") and the
-    // active doc should be swapped to it. Origin flips to synced.
-    expect(result.current.activeDocument?.id).not.toBe("doc-1");
+    // The migrated doc keeps its UUID v7 id across the local→synced
+    // transition; only the origin flips.
+    expect(result.current.activeDocument?.id).toBe("doc-1");
     expect(result.current.activeDocument?.origin).toBe("synced");
   });
 
@@ -390,12 +384,10 @@ describe("useDocumentManager", () => {
       expect(result.current.converting.has("doc-2")).toBe(true);
     });
 
-    // The pushSnapshot mock receives the *server-allocated* id, not
-    // the local id. Our test fake's synced repo allocates server ids
-    // as `"synced-<localId>"`, so the resolvers keyed on what
-    // pushSnapshot saw map back via the same prefix.
+    // pushSnapshot receives the same id the local doc had — UUID v7
+    // is client-allocated and carries through unchanged.
     await act(async () => {
-      resolvers["synced-doc-2"]();
+      resolvers["doc-2"]();
       await secondConvert;
     });
 
@@ -403,7 +395,7 @@ describe("useDocumentManager", () => {
     expect(result.current.converting.has("doc-2")).toBe(false);
 
     await act(async () => {
-      resolvers["synced-doc-1"]();
+      resolvers["doc-1"]();
       await firstConvert;
     });
 
@@ -468,9 +460,9 @@ describe("useDocumentManager", () => {
     const pushSnapshot = vi
       .fn<(documentId: string, snapshot: TLStoreSnapshot) => Promise<void>>()
       .mockImplementation(async (documentId) => {
-        // The mock receives the server-allocated id, mapped from the
-        // local id by the test fake (`synced-<localId>`).
-        if (documentId === "synced-doc-bad") {
+        // pushSnapshot receives the same id the local doc had — UUID v7
+        // is client-allocated and unchanged across the migration.
+        if (documentId === "doc-bad") {
           throw new Error("Snapshot push failed: 413");
         }
       });
@@ -669,20 +661,15 @@ describe("useDocumentManager", () => {
     expect(result.current.converting.has("doc-1")).toBe(false);
     expect(result.current.conversionErrors.has("doc-1")).toBe(false);
 
-    // The local doc was deleted by id "doc-1". With server-allocated
-    // ids, the orphan synced metadata (if it was already created
-    // before the abort) cannot be cleaned up by the local id —
-    // deleteDocument does not attempt that anymore. The server row
-    // would surface on a future refresh and need manual cleanup; we
-    // accept that for the rare race window.
+    // With UUID, the local id and server id match, so the orphan
+    // synced row from the half-completed migration is cleaned up
+    // immediately by deleteDocument's syncedRepository.delete(id).
     expect(localRepo.delete).toHaveBeenCalledWith("doc-1");
+    expect(syncedRepo.delete).toHaveBeenCalledWith("doc-1");
+    expect(syncedRepo.store.has("doc-1")).toBe(false);
 
-    // doc-1 is gone from the local sidebar; doc-2 remains active.
-    // Note: a phantom synced row from the half-completed migration
-    // remains and shows up in the list. Cleaning it up would require
-    // tracking the server-allocated id back up to the manager —
-    // tracked as a follow-up; tolerable for the rare race window.
-    expect(result.current.documents.map((d) => d.id)).toContain("doc-2");
+    // doc-1 is gone everywhere; doc-2 remains.
+    expect(result.current.documents.map((d) => d.id)).toEqual(["doc-2"]);
 
     // Drain the mocked push so no pending promise leaks between tests.
     resolvePush();

--- a/packages/app/src/documents/useDocumentManager.test.tsx
+++ b/packages/app/src/documents/useDocumentManager.test.tsx
@@ -61,11 +61,18 @@ function makeFakeRepo(origin: DocumentOrigin, initial: DocumentData[] = []) {
   // The local repo keeps the caller's id verbatim, mimicking IDB; if
   // the caller didn't supply one, mint a UUID like the real repo does.
   const create = vi.fn(async (d: DocumentDraft): Promise<DocumentData> => {
+    const now = Date.now();
     const localId = d.meta.id ?? crypto.randomUUID();
     const allocatedId = origin === "synced" ? `synced-${localId}` : localId;
     const stored: DocumentData = {
       ...d,
-      meta: { ...d.meta, id: allocatedId, origin },
+      meta: {
+        ...d.meta,
+        id: allocatedId,
+        origin,
+        createdAt: d.meta.createdAt ?? now,
+        updatedAt: now,
+      },
     };
     store.set(allocatedId, stored);
     return stored;

--- a/packages/app/src/documents/useDocumentManager.test.tsx
+++ b/packages/app/src/documents/useDocumentManager.test.tsx
@@ -5,9 +5,9 @@ import { useDocumentManager } from "./useDocumentManager";
 import type { DocumentRepository } from "./repository";
 import type {
   DocumentData,
-  DocumentDraft,
+  DocumentInput,
   DocumentMeta,
-  DocumentOrigin,
+  DocumentSource,
 } from "./types";
 
 const emptySnapshot = { store: {}, schema: {} } as unknown as TLStoreSnapshot;
@@ -18,7 +18,7 @@ function makeLocalDocWithSnapshot(id: string): DocumentData {
       id,
       title: id,
       sortOrder: "a0",
-      origin: "local",
+      source: "local",
       createdAt: 0,
       updatedAt: 0,
     },
@@ -29,43 +29,43 @@ function makeLocalDocWithSnapshot(id: string): DocumentData {
 function makeDoc(
   id: string,
   sortOrder: string,
-  origin: DocumentOrigin,
+  source: DocumentSource,
   title = id,
 ): DocumentData {
   return {
-    meta: { id, title, sortOrder, origin, createdAt: 0, updatedAt: 0 },
+    meta: { id, title, sortOrder, source, createdAt: 0, updatedAt: 0 },
     snapshot: null,
   };
 }
 
-function makeFakeRepo(origin: DocumentOrigin, initial: DocumentData[] = []) {
+function makeFakeRepo(source: DocumentSource, initial: DocumentData[] = []) {
   const store = new Map<string, DocumentData>();
   for (const d of initial) store.set(d.meta.id, d);
 
-  // Each fake stamps `origin` on list/get to mimic the real repo behavior so
-  // the hook sees DocumentMeta objects with the correct origin field.
+  // Each fake stamps `source` on list/get to mimic the real repo behavior so
+  // the hook sees DocumentMeta objects with the correct source field.
   const list = vi.fn(
     async (): Promise<DocumentMeta[]> =>
       [...store.values()]
-        .map((d) => ({ ...d.meta, origin }))
+        .map((d) => ({ ...d.meta, source }))
         .sort((a, b) => a.sortOrder.localeCompare(b.sortOrder)),
   );
   const get = vi.fn(async (id: string): Promise<DocumentData | undefined> => {
     const d = store.get(id);
-    return d ? { ...d, meta: { ...d.meta, origin } } : undefined;
+    return d ? { ...d, meta: { ...d.meta, source } } : undefined;
   });
   // Single upsert method matching the production repo. Both local and
   // synced repos honor the caller's id verbatim — UUID v7 is
   // client-allocated, so the same id flows through every layer and
-  // tests can assert on the original id everywhere.
-  const save = vi.fn(async (d: DocumentDraft): Promise<DocumentData> => {
+  // tests can assert on the same id everywhere.
+  const save = vi.fn(async (d: DocumentInput): Promise<DocumentData> => {
     const now = Date.now();
     const existing = store.get(d.meta.id);
     const stored: DocumentData = {
       ...d,
       meta: {
         ...d.meta,
-        origin,
+        source,
         createdAt: existing?.meta.createdAt ?? d.meta.createdAt ?? now,
         updatedAt: now,
       },
@@ -135,7 +135,7 @@ describe("useDocumentManager", () => {
       "L1",
       "L2",
     ]);
-    expect(result.current.documents.map((d) => d.origin)).toEqual([
+    expect(result.current.documents.map((d) => d.source)).toEqual([
       "synced",
       "synced",
       "local",
@@ -159,7 +159,7 @@ describe("useDocumentManager", () => {
     expect(syncedRepo.save).toHaveBeenCalledTimes(1);
     expect(localRepo.save).not.toHaveBeenCalled();
     expect(result.current.documents).toHaveLength(1);
-    expect(result.current.documents[0].origin).toBe("synced");
+    expect(result.current.documents[0].source).toBe("synced");
   });
 
   it("completes initial load with local docs when the synced list rejects", async () => {
@@ -234,7 +234,7 @@ describe("useDocumentManager", () => {
     expect(syncedRepo.get).toHaveBeenCalledWith("S2");
     expect(localRepo.get).not.toHaveBeenCalledWith("S2");
     expect(result.current.activeDocumentId).toBe("S2");
-    expect(result.current.activeDocument?.origin).toBe("synced");
+    expect(result.current.activeDocument?.source).toBe("synced");
   });
 
   it("falls back to creating a local replacement when deleting the last doc and synced save fails", async () => {
@@ -260,11 +260,11 @@ describe("useDocumentManager", () => {
 
     expect(localRepo.save).toHaveBeenCalledTimes(1);
     expect(result.current.documents).toHaveLength(1);
-    expect(result.current.documents[0].origin).toBe("local");
+    expect(result.current.documents[0].source).toBe("local");
     expect(vi.mocked(console.error)).toHaveBeenCalled();
   });
 
-  it("migrates a local doc to synced via convertToSynced and keeps it selected with the new origin", async () => {
+  it("migrates a local doc to synced via convertToSynced and keeps it selected with the new source", async () => {
     const localRepo = makeFakeRepo("local", [makeDoc("doc-1", "a0", "local")]);
     const syncedRepo = makeFakeRepo("synced");
 
@@ -281,7 +281,7 @@ describe("useDocumentManager", () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.activeDocument?.id).toBe("doc-1");
-    expect(result.current.activeDocument?.origin).toBe("local");
+    expect(result.current.activeDocument?.source).toBe("local");
 
     await act(async () => {
       await result.current.convertToSynced("doc-1");
@@ -290,9 +290,9 @@ describe("useDocumentManager", () => {
     expect(syncedRepo.save).toHaveBeenCalledTimes(1);
     expect(localRepo.delete).toHaveBeenCalledWith("doc-1");
     // The migrated doc keeps its UUID v7 id across the local→synced
-    // transition; only the origin flips.
+    // transition; only the source flips.
     expect(result.current.activeDocument?.id).toBe("doc-1");
-    expect(result.current.activeDocument?.origin).toBe("synced");
+    expect(result.current.activeDocument?.source).toBe("synced");
   });
 
   it("exposes converting while a migration is in flight and clears it on completion", async () => {
@@ -556,7 +556,7 @@ describe("useDocumentManager", () => {
     expect(result.current.conversionErrors.has("doc-1")).toBe(false);
     expect(pushSnapshot).toHaveBeenCalledTimes(2);
     expect(localRepo.delete).toHaveBeenCalledWith("doc-1");
-    expect(result.current.activeDocument?.origin).toBe("synced");
+    expect(result.current.activeDocument?.source).toBe("synced");
   });
 
   it("clears conversionErrors for a doc when it is deleted", async () => {
@@ -773,10 +773,10 @@ describe("useDocumentManager", () => {
     });
 
     expect(localRepo.delete).not.toHaveBeenCalled();
-    expect(result.current.documents[0].origin).toBe("local");
+    expect(result.current.documents[0].source).toBe("local");
   });
 
-  it("treats createDocument({origin: 'synced'}) as a no-op when no synced repository is configured", async () => {
+  it("treats createDocument({source: 'synced'}) as a no-op when no synced repository is configured", async () => {
     const localRepo = makeFakeRepo("local", [makeDoc("L1", "a0", "local")]);
 
     const { result } = renderHook(() =>
@@ -786,11 +786,11 @@ describe("useDocumentManager", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     await act(async () => {
-      await result.current.createDocument({ origin: "synced" });
+      await result.current.createDocument({ source: "synced" });
     });
 
     // localRepo.save should have been called exactly zero times — L1 already
-    // exists from the fixture, and the synced-origin create should not fall
+    // exists from the fixture, and the synced-source create should not fall
     // through to local here (that fallback is only for the last-doc-delete
     // replacement path).
     expect(localRepo.save).not.toHaveBeenCalled();

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -189,7 +189,7 @@ export function useDocumentManager(params: {
     if (!existing) return;
 
     const { document } = getSnapshot(editor.store);
-    await localRepository.update({
+    await localRepository.save({
       ...existing,
       snapshot: document,
     });
@@ -216,7 +216,7 @@ export function useDocumentManager(params: {
         );
         // The synced repo allocates a server-side id at create; use the
         // returned doc's id rather than the draft's UUID.
-        const saved = await repo.create(draft);
+        const saved = await repo.save(draft);
         if (cancelled) return;
         if (defaultOrigin === "synced") {
           await finalizeSyncedDocument(saved.meta.id);
@@ -307,7 +307,7 @@ export function useDocumentManager(params: {
           nextTailSortOrder(existing),
           origin,
         );
-        const saved = await repo.create(draft);
+        const saved = await repo.save(draft);
         if (origin === "synced") {
           await finalizeSyncedDocument(saved.meta.id);
         }
@@ -401,7 +401,7 @@ export function useDocumentManager(params: {
         );
         let saved: DocumentData;
         try {
-          saved = await defaultRepo.create(draft);
+          saved = await defaultRepo.save(draft);
           if (defaultOrigin === "synced") {
             await finalizeSyncedDocument(saved.meta.id);
           }
@@ -416,7 +416,7 @@ export function useDocumentManager(params: {
               "local",
             );
             try {
-              saved = await localRepository.create(localDraft);
+              saved = await localRepository.save(localDraft);
             } catch (localError) {
               console.error(
                 "Failed to create replacement local document",
@@ -467,7 +467,7 @@ export function useDocumentManager(params: {
       if (!repo) return;
       const data = await repo.get(id);
       if (!data) return;
-      await repo.update({
+      await repo.save({
         ...data,
         meta: { ...data.meta, title },
       });
@@ -485,7 +485,7 @@ export function useDocumentManager(params: {
       if (!repo) return;
       const data = await repo.get(id);
       if (!data) return;
-      await repo.update({
+      await repo.save({
         ...data,
         meta: { ...data.meta, sortOrder: newSortOrder },
       });

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -1,4 +1,3 @@
-import { generateKeyBetween } from "fractional-indexing";
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { getSnapshot, type Editor, type TLStoreSnapshot } from "tldraw";
 import type { DocumentRepository } from "./repository";
@@ -7,6 +6,7 @@ import {
   convertLocalDocToSynced,
   type ConvertLocalDocToSyncedParams,
 } from "./migration";
+import { nextTailSortOrder } from "./sort-order";
 
 function createNewDocument(
   sortOrder: string,
@@ -23,22 +23,6 @@ function createNewDocument(
     },
     snapshot: null,
   };
-}
-
-/**
- * Compute the fractional-indexing key that places a new doc at the
- * end of `existing`. `existing` may include local and synced rows
- * mixed; we sort their keys lexicographically and bump past the tail.
- * If there are no existing keys, falls back to the package's "first"
- * key via `generateKeyBetween(null, null)` (typically `"a0"`).
- */
-function nextTailSortOrder(existing: ReadonlyArray<DocumentMeta>): string {
-  const keys = existing
-    .map((d) => d.sortOrder)
-    .filter((key): key is string => typeof key === "string")
-    .sort();
-  const tail = keys[keys.length - 1] ?? null;
-  return generateKeyBetween(tail, null);
 }
 
 export interface DocumentManager {
@@ -331,17 +315,8 @@ export function useDocumentManager(params: {
 
       // Cancel any in-flight convert-to-synced migration for this id
       // before touching storage. The migration's catch handler will see
-      // controller.signal.aborted and exit silently; its half-done state
-      // is cleaned up below.
-      const migrationController = migrationAbortControllersRef.current.get(id);
-      const wasMigrating = migrationController !== undefined;
-      if (migrationController) {
-        migrationController.abort();
-        migrationAbortControllersRef.current.delete(id);
-      }
-
-      await repo.delete(id);
-
+      // controller.signal.aborted and exit silently.
+      //
       // With server-allocated ids, the local id we have here doesn't
       // match the server-side row's id (the server allocated its own
       // INTEGER at POST time). Cleaning up a half-migrated server doc
@@ -350,7 +325,13 @@ export function useDocumentManager(params: {
       // mid-migration *and* the server doc was already created, the
       // user will see a leftover row on the next refresh and can
       // delete it manually. Acceptable for the rare race window.
-      void wasMigrating;
+      const migrationController = migrationAbortControllersRef.current.get(id);
+      if (migrationController) {
+        migrationController.abort();
+        migrationAbortControllersRef.current.delete(id);
+      }
+
+      await repo.delete(id);
 
       // Drop any stale convert-to-synced state for this id. An entry in
       // conversionErrors would otherwise linger in memory with no row to

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -1,23 +1,25 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { getSnapshot, type Editor, type TLStoreSnapshot } from "tldraw";
 import type { DocumentRepository } from "./repository";
-import type { DocumentData, DocumentMeta, DocumentOrigin } from "./types";
+import type {
+  DocumentData,
+  DocumentDraft,
+  DocumentMeta,
+  DocumentOrigin,
+} from "./types";
 import {
   convertLocalDocToSynced,
   type ConvertLocalDocToSyncedParams,
 } from "./migration";
 import { nextTailSortOrder } from "./sort-order";
 
-function createNewDocument(
+function createNewDocumentDraft(
   sortOrder: string,
   origin: DocumentOrigin,
-): DocumentData {
+): DocumentDraft {
   return {
     meta: {
-      id: crypto.randomUUID(),
       title: "Untitled",
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
       sortOrder,
       origin,
     },
@@ -182,7 +184,6 @@ export function useDocumentManager(params: {
     const { document } = getSnapshot(editor.store);
     await localRepository.update({
       ...existing,
-      meta: { ...existing.meta, updatedAt: Date.now() },
       snapshot: document,
     });
   }, [localRepository]);
@@ -202,7 +203,10 @@ export function useDocumentManager(params: {
           : "local";
         const repo = getRepository(defaultOrigin);
         if (!repo) return;
-        const draft = createNewDocument(nextTailSortOrder([]), defaultOrigin);
+        const draft = createNewDocumentDraft(
+          nextTailSortOrder([]),
+          defaultOrigin,
+        );
         // The synced repo allocates a server-side id at create; use the
         // returned doc's id rather than the draft's UUID.
         const saved = await repo.create(draft);
@@ -288,7 +292,10 @@ export function useDocumentManager(params: {
       // change.
       try {
         const existing = await repo.list();
-        const draft = createNewDocument(nextTailSortOrder(existing), origin);
+        const draft = createNewDocumentDraft(
+          nextTailSortOrder(existing),
+          origin,
+        );
         const saved = await repo.create(draft);
 
         editorRef.current = null;
@@ -363,7 +370,10 @@ export function useDocumentManager(params: {
           : "local";
         const defaultRepo = getRepository(defaultOrigin);
         if (!defaultRepo) return;
-        const draft = createNewDocument(nextTailSortOrder([]), defaultOrigin);
+        const draft = createNewDocumentDraft(
+          nextTailSortOrder([]),
+          defaultOrigin,
+        );
         let saved: DocumentData;
         try {
           saved = await defaultRepo.create(draft);
@@ -373,7 +383,7 @@ export function useDocumentManager(params: {
             error,
           );
           if (defaultOrigin === "synced") {
-            const localDraft = createNewDocument(
+            const localDraft = createNewDocumentDraft(
               nextTailSortOrder([]),
               "local",
             );
@@ -431,7 +441,7 @@ export function useDocumentManager(params: {
       if (!data) return;
       await repo.update({
         ...data,
-        meta: { ...data.meta, title, updatedAt: Date.now() },
+        meta: { ...data.meta, title },
       });
       await refreshDocuments();
     },
@@ -449,7 +459,7 @@ export function useDocumentManager(params: {
       if (!data) return;
       await repo.update({
         ...data,
-        meta: { ...data.meta, sortOrder: newSortOrder, updatedAt: Date.now() },
+        meta: { ...data.meta, sortOrder: newSortOrder },
       });
       await refreshDocuments();
     },

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -12,16 +12,7 @@ import {
   type ConvertLocalDocToSyncedParams,
 } from "./migration";
 import { nextTailSortOrder } from "./sort-order";
-import { EMPTY_SNAPSHOT, pushSnapshot } from "./snapshot-push";
-
-// Synced creation is a two-step server protocol: the POST inserts a
-// row marked `initializing_at`, and a finalizing snapshot push clears
-// it. Without the second step the server's sweep would reap the row
-// after its grace window — so every synced create here pushes an
-// empty initial snapshot to immediately complete the contract.
-async function finalizeSyncedDocument(documentId: string): Promise<void> {
-  await pushSnapshot(documentId, EMPTY_SNAPSHOT, 0);
-}
+import { finalizeSyncedDocument } from "./snapshot-push";
 
 function createNewDocumentDraft(
   sortOrder: string,

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -12,6 +12,16 @@ import {
   type ConvertLocalDocToSyncedParams,
 } from "./migration";
 import { nextTailSortOrder } from "./sort-order";
+import { EMPTY_SNAPSHOT, pushSnapshot } from "./snapshot-push";
+
+// Synced creation is a two-step server protocol: the POST inserts a
+// row marked `initializing_at`, and a finalizing snapshot push clears
+// it. Without the second step the server's sweep would reap the row
+// after its grace window — so every synced create here pushes an
+// empty initial snapshot to immediately complete the contract.
+async function finalizeSyncedDocument(documentId: string): Promise<void> {
+  await pushSnapshot(documentId, EMPTY_SNAPSHOT, 0);
+}
 
 function createNewDocumentDraft(
   sortOrder: string,
@@ -211,6 +221,10 @@ export function useDocumentManager(params: {
         // returned doc's id rather than the draft's UUID.
         const saved = await repo.create(draft);
         if (cancelled) return;
+        if (defaultOrigin === "synced") {
+          await finalizeSyncedDocument(saved.meta.id);
+          if (cancelled) return;
+        }
         commitDocuments([saved.meta]);
         commitActiveDocumentId(saved.meta.id);
         setActiveSnapshot(null);
@@ -297,6 +311,9 @@ export function useDocumentManager(params: {
           origin,
         );
         const saved = await repo.create(draft);
+        if (origin === "synced") {
+          await finalizeSyncedDocument(saved.meta.id);
+        }
 
         editorRef.current = null;
         commitActiveDocumentId(saved.meta.id);
@@ -377,6 +394,9 @@ export function useDocumentManager(params: {
         let saved: DocumentData;
         try {
           saved = await defaultRepo.create(draft);
+          if (defaultOrigin === "synced") {
+            await finalizeSyncedDocument(saved.meta.id);
+          }
         } catch (error) {
           console.error(
             `Failed to create replacement ${defaultOrigin} document; falling back to local`,

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -1,3 +1,4 @@
+import { generateKeyBetween } from "fractional-indexing";
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { getSnapshot, type Editor, type TLStoreSnapshot } from "tldraw";
 import type { DocumentRepository } from "./repository";
@@ -8,7 +9,7 @@ import {
 } from "./migration";
 
 function createNewDocument(
-  order: number,
+  sortOrder: string,
   origin: DocumentOrigin,
 ): DocumentData {
   return {
@@ -17,11 +18,27 @@ function createNewDocument(
       title: "Untitled",
       createdAt: Date.now(),
       updatedAt: Date.now(),
-      order,
+      sortOrder,
       origin,
     },
     snapshot: null,
   };
+}
+
+/**
+ * Compute the fractional-indexing key that places a new doc at the
+ * end of `existing`. `existing` may include local and synced rows
+ * mixed; we sort their keys lexicographically and bump past the tail.
+ * If there are no existing keys, falls back to the package's "first"
+ * key via `generateKeyBetween(null, null)` (typically `"a0"`).
+ */
+function nextTailSortOrder(existing: ReadonlyArray<DocumentMeta>): string {
+  const keys = existing
+    .map((d) => d.sortOrder)
+    .filter((key): key is string => typeof key === "string")
+    .sort();
+  const tail = keys[keys.length - 1] ?? null;
+  return generateKeyBetween(tail, null);
 }
 
 export interface DocumentManager {
@@ -42,7 +59,7 @@ export interface DocumentManager {
   createDocument: (options?: { origin?: DocumentOrigin }) => Promise<void>;
   deleteDocument: (id: string) => Promise<void>;
   renameDocument: (id: string, title: string) => Promise<void>;
-  reorderDocument: (id: string, newOrder: number) => Promise<void>;
+  reorderDocument: (id: string, newSortOrder: string) => Promise<void>;
   convertToSynced: (id: string) => Promise<void>;
   registerEditor: (editor: Editor) => () => void;
   refreshDocuments: () => Promise<void>;
@@ -179,7 +196,7 @@ export function useDocumentManager(params: {
     if (!existing) return;
 
     const { document } = getSnapshot(editor.store);
-    await localRepository.save({
+    await localRepository.update({
       ...existing,
       meta: { ...existing.meta, updatedAt: Date.now() },
       snapshot: document,
@@ -201,11 +218,13 @@ export function useDocumentManager(params: {
           : "local";
         const repo = getRepository(defaultOrigin);
         if (!repo) return;
-        const doc = createNewDocument(1, defaultOrigin);
-        await repo.save(doc);
+        const draft = createNewDocument(nextTailSortOrder([]), defaultOrigin);
+        // The synced repo allocates a server-side id at create; use the
+        // returned doc's id rather than the draft's UUID.
+        const saved = await repo.create(draft);
         if (cancelled) return;
-        commitDocuments([doc.meta]);
-        commitActiveDocumentId(doc.meta.id);
+        commitDocuments([saved.meta]);
+        commitActiveDocumentId(saved.meta.id);
         setActiveSnapshot(null);
       } else {
         commitDocuments(metas);
@@ -278,18 +297,18 @@ export function useDocumentManager(params: {
       const repo = getRepository(origin);
       if (!repo) return;
 
-      // Compute order against just this repo's docs so each group stays
-      // independently ordered. Catch repository failures (e.g. synced
-      // server unreachable) so the button click doesn't end in an
-      // unhandled rejection with no user-visible change.
+      // Compute the next sort_order key against just this repo's docs
+      // so each group stays independently ordered. Catch repository
+      // failures (e.g. synced server unreachable) so the button click
+      // doesn't end in an unhandled rejection with no user-visible
+      // change.
       try {
         const existing = await repo.list();
-        const maxOrder = existing.reduce((max, d) => Math.max(max, d.order), 0);
-        const doc = createNewDocument(maxOrder + 1, origin);
-        await repo.save(doc);
+        const draft = createNewDocument(nextTailSortOrder(existing), origin);
+        const saved = await repo.create(draft);
 
         editorRef.current = null;
-        commitActiveDocumentId(doc.meta.id);
+        commitActiveDocumentId(saved.meta.id);
         setActiveSnapshot(null);
         await refreshDocuments();
       } catch (error) {
@@ -323,21 +342,15 @@ export function useDocumentManager(params: {
 
       await repo.delete(id);
 
-      // If the migration had already persisted metadata to the synced
-      // repo before we aborted (step 2 of convertLocalDocToSynced), a
-      // ghost synced copy of the deleted doc would otherwise appear on
-      // the next refresh. Best-effort cleanup — a 404 is fine, it just
-      // means the migration hadn't reached that step yet.
-      if (wasMigrating && syncedRepository) {
-        try {
-          await syncedRepository.delete(id);
-        } catch (error) {
-          console.error(
-            `Failed to clean up synced metadata after aborting migration of ${id}`,
-            error,
-          );
-        }
-      }
+      // With server-allocated ids, the local id we have here doesn't
+      // match the server-side row's id (the server allocated its own
+      // INTEGER at POST time). Cleaning up a half-migrated server doc
+      // would require tracking the server-allocated id from inside
+      // the migration — deliberately deferred. If the user deletes
+      // mid-migration *and* the server doc was already created, the
+      // user will see a leftover row on the next refresh and can
+      // delete it manually. Acceptable for the rare race window.
+      void wasMigrating;
 
       // Drop any stale convert-to-synced state for this id. An entry in
       // conversionErrors would otherwise linger in memory with no row to
@@ -369,19 +382,22 @@ export function useDocumentManager(params: {
           : "local";
         const defaultRepo = getRepository(defaultOrigin);
         if (!defaultRepo) return;
-        const doc = createNewDocument(1, defaultOrigin);
+        const draft = createNewDocument(nextTailSortOrder([]), defaultOrigin);
+        let saved: DocumentData;
         try {
-          await defaultRepo.save(doc);
+          saved = await defaultRepo.create(draft);
         } catch (error) {
           console.error(
             `Failed to create replacement ${defaultOrigin} document; falling back to local`,
             error,
           );
           if (defaultOrigin === "synced") {
-            const localDoc = createNewDocument(1, "local");
+            const localDraft = createNewDocument(
+              nextTailSortOrder([]),
+              "local",
+            );
             try {
-              await localRepository.save(localDoc);
-              doc.meta = localDoc.meta;
+              saved = await localRepository.create(localDraft);
             } catch (localError) {
               console.error(
                 "Failed to create replacement local document",
@@ -393,9 +409,9 @@ export function useDocumentManager(params: {
             return;
           }
         }
-        commitDocuments([doc.meta]);
+        commitDocuments([saved.meta]);
         editorRef.current = null;
-        commitActiveDocumentId(doc.meta.id);
+        commitActiveDocumentId(saved.meta.id);
         setActiveSnapshot(null);
         return;
       }
@@ -432,7 +448,7 @@ export function useDocumentManager(params: {
       if (!repo) return;
       const data = await repo.get(id);
       if (!data) return;
-      await repo.save({
+      await repo.update({
         ...data,
         meta: { ...data.meta, title, updatedAt: Date.now() },
       });
@@ -442,7 +458,7 @@ export function useDocumentManager(params: {
   );
 
   const reorderDocument = useCallback(
-    async (id: string, newOrder: number) => {
+    async (id: string, newSortOrder: string) => {
       if (id === activeDocumentIdRef.current) {
         await saveCurrentEditor();
       }
@@ -450,9 +466,9 @@ export function useDocumentManager(params: {
       if (!repo) return;
       const data = await repo.get(id);
       if (!data) return;
-      await repo.save({
+      await repo.update({
         ...data,
-        meta: { ...data.meta, order: newOrder, updatedAt: Date.now() },
+        meta: { ...data.meta, sortOrder: newSortOrder, updatedAt: Date.now() },
       });
       await refreshDocuments();
     },
@@ -509,8 +525,9 @@ export function useDocumentManager(params: {
         setConverting(next);
       };
 
+      let migrated: DocumentData;
       try {
-        await convertLocalDocToSynced({
+        migrated = await convertLocalDocToSynced({
           documentId: id,
           localRepository,
           syncedRepository,
@@ -545,12 +562,13 @@ export function useDocumentManager(params: {
       clearInFlight();
       await refreshDocuments();
 
-      // The converted doc keeps its id; re-commit the active id so the
-      // active-origin ref flips from "local" to "synced" and the
-      // correct editor container renders on the next tick.
+      // The converted doc gets a server-allocated id (different from
+      // the local UUID). If the active doc is the one we just
+      // migrated, swap to the new id so the editor key updates and
+      // the synced container takes over.
       if (id === activeDocumentIdRef.current) {
         editorRef.current = null;
-        commitActiveDocumentId(id);
+        commitActiveDocumentId(migrated.meta.id);
       }
     },
     [

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { getSnapshot, type Editor, type TLStoreSnapshot } from "tldraw";
+import { v7 as uuidv7 } from "uuid";
 import type { DocumentRepository } from "./repository";
 import type {
   DocumentData,
@@ -20,6 +21,11 @@ function createNewDocumentDraft(
 ): DocumentDraft {
   return {
     meta: {
+      // Mint the doc id upfront so callers (and the server, on
+      // synced creates) see the same id from the moment the doc
+      // exists. v7 keeps client-allocated ids time-monotonic on
+      // the server's B-tree.
+      id: uuidv7(),
       title: "Untitled",
       sortOrder,
       origin,
@@ -331,22 +337,33 @@ export function useDocumentManager(params: {
       // Cancel any in-flight convert-to-synced migration for this id
       // before touching storage. The migration's catch handler will see
       // controller.signal.aborted and exit silently.
-      //
-      // With server-allocated ids, the local id we have here doesn't
-      // match the server-side row's id (the server allocated its own
-      // INTEGER at POST time). Cleaning up a half-migrated server doc
-      // would require tracking the server-allocated id from inside
-      // the migration — deliberately deferred. If the user deletes
-      // mid-migration *and* the server doc was already created, the
-      // user will see a leftover row on the next refresh and can
-      // delete it manually. Acceptable for the rare race window.
       const migrationController = migrationAbortControllersRef.current.get(id);
+      const wasMigrating = migrationController !== undefined;
       if (migrationController) {
         migrationController.abort();
         migrationAbortControllersRef.current.delete(id);
       }
 
       await repo.delete(id);
+
+      // If the migration's POST already landed before we aborted
+      // (step 3 of convertLocalDocToSynced), the server holds a
+      // half-finished row at the same id. Best-effort cleanup —
+      // a 404 here is fine, it just means the migration hadn't
+      // reached step 3 yet. Without this immediate cleanup the
+      // server-side sweep would still reap the row after the
+      // initializing-grace window, but the user would briefly
+      // see a stale entry on the next refresh in the meantime.
+      if (wasMigrating && syncedRepository) {
+        try {
+          await syncedRepository.delete(id);
+        } catch (error) {
+          console.error(
+            `Failed to clean up synced metadata after aborted migration of ${id}`,
+            error,
+          );
+        }
+      }
 
       // Drop any stale convert-to-synced state for this id. An entry in
       // conversionErrors would otherwise linger in memory with no row to
@@ -527,9 +544,8 @@ export function useDocumentManager(params: {
         setConverting(next);
       };
 
-      let migrated: DocumentData;
       try {
-        migrated = await convertLocalDocToSynced({
+        await convertLocalDocToSynced({
           documentId: id,
           localRepository,
           syncedRepository,
@@ -540,8 +556,7 @@ export function useDocumentManager(params: {
         clearInFlight();
         if (controller.signal.aborted) {
           // The migration was cancelled from deleteDocument. That path
-          // has already run its own cleanup (local delete, synced
-          // metadata cleanup, listAllDocuments), so don't double-log,
+          // has already run its own cleanup, so don't double-log,
           // surface an error, or refresh again.
           return;
         }
@@ -554,7 +569,7 @@ export function useDocumentManager(params: {
           );
           return next;
         });
-        // Refresh in case the server metadata was created before the
+        // Refresh in case the server row was created before the
         // failure; the local copy is intentionally preserved by
         // convertLocalDocToSynced so the user can retry.
         await refreshDocuments();
@@ -564,13 +579,14 @@ export function useDocumentManager(params: {
       clearInFlight();
       await refreshDocuments();
 
-      // The converted doc gets a server-allocated id (different from
-      // the local UUID). If the active doc is the one we just
-      // migrated, swap to the new id so the editor key updates and
-      // the synced container takes over.
+      // The doc keeps its id across the local→synced transition
+      // (UUID v7 is client-allocated, see migration docs). If the
+      // active doc is the one we just migrated, re-commit the same
+      // id so the active-origin ref flips from "local" to "synced"
+      // and the synced container takes over the editor.
       if (id === activeDocumentIdRef.current) {
         editorRef.current = null;
-        commitActiveDocumentId(migrated.meta.id);
+        commitActiveDocumentId(id);
       }
     },
     [

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -4,9 +4,9 @@ import { v7 as uuidv7 } from "uuid";
 import type { DocumentRepository } from "./repository";
 import type {
   DocumentData,
-  DocumentDraft,
+  DocumentInput,
   DocumentMeta,
-  DocumentOrigin,
+  DocumentSource,
 } from "./types";
 import {
   convertLocalDocToSynced,
@@ -15,10 +15,10 @@ import {
 import { nextTailSortOrder } from "./sort-order";
 import { finalizeSyncedDocument } from "./snapshot-push";
 
-function createNewDocumentDraft(
+function createNewDocumentInput(
   sortOrder: string,
-  origin: DocumentOrigin,
-): DocumentDraft {
+  source: DocumentSource,
+): DocumentInput {
   return {
     meta: {
       // Mint the doc id upfront so callers (and the server, on
@@ -28,7 +28,7 @@ function createNewDocumentDraft(
       id: uuidv7(),
       title: "Untitled",
       sortOrder,
-      origin,
+      source,
     },
     snapshot: null,
   };
@@ -49,7 +49,7 @@ export interface DocumentManager {
    */
   conversionErrors: ReadonlyMap<string, Error>;
   selectDocument: (id: string) => Promise<void>;
-  createDocument: (options?: { origin?: DocumentOrigin }) => Promise<void>;
+  createDocument: (options?: { source?: DocumentSource }) => Promise<void>;
   deleteDocument: (id: string) => Promise<void>;
   renameDocument: (id: string, title: string) => Promise<void>;
   reorderDocument: (id: string, newSortOrder: string) => Promise<void>;
@@ -103,30 +103,30 @@ export function useDocumentManager(params: {
   // Keep refs in sync with state via a pair of commit helpers so actions
   // that run immediately after a state change (e.g. selecting a
   // freshly-forked doc after refreshDocuments, or reading the active
-  // doc's origin from a store listener right after a doc switch) can see
+  // doc's source from a store listener right after a doc switch) can see
   // the updated values before React commits the next render.
   const documentsRef = useRef<DocumentMeta[]>(documents);
   const activeDocumentIdRef = useRef<string | null>(null);
-  const activeDocumentOriginRef = useRef<DocumentOrigin | null>(null);
+  const activeDocumentSourceRef = useRef<DocumentSource | null>(null);
 
-  const syncActiveOriginRef = (
+  const syncActiveSourceRef = (
     nextDocs: DocumentMeta[],
     activeId: string | null,
   ) => {
-    activeDocumentOriginRef.current = activeId
-      ? (nextDocs.find((d) => d.id === activeId)?.origin ?? null)
+    activeDocumentSourceRef.current = activeId
+      ? (nextDocs.find((d) => d.id === activeId)?.source ?? null)
       : null;
   };
 
   const commitDocuments = useCallback((next: DocumentMeta[]) => {
     documentsRef.current = next;
-    syncActiveOriginRef(next, activeDocumentIdRef.current);
+    syncActiveSourceRef(next, activeDocumentIdRef.current);
     setDocuments(next);
   }, []);
 
   const commitActiveDocumentId = useCallback((next: string | null) => {
     activeDocumentIdRef.current = next;
-    syncActiveOriginRef(documentsRef.current, next);
+    syncActiveSourceRef(documentsRef.current, next);
     setActiveDocumentId(next);
   }, []);
 
@@ -139,8 +139,8 @@ export function useDocumentManager(params: {
   // latest merged list. Falls back to the implicit "local only" repo when
   // called before the first load settles.
   const getRepository = useCallback(
-    (origin: DocumentOrigin | undefined): DocumentRepository | null => {
-      if (origin === "synced") return syncedRepository ?? null;
+    (source: DocumentSource | undefined): DocumentRepository | null => {
+      if (source === "synced") return syncedRepository ?? null;
       return localRepository;
     },
     [localRepository, syncedRepository],
@@ -148,7 +148,7 @@ export function useDocumentManager(params: {
   const findRepositoryForId = useCallback(
     (id: string): DocumentRepository | null => {
       const meta = documentsRef.current.find((d) => d.id === id);
-      return getRepository(meta?.origin);
+      return getRepository(meta?.source);
     },
     [getRepository],
   );
@@ -166,7 +166,7 @@ export function useDocumentManager(params: {
       syncedRepository
         ? syncedRepository.list().catch((error) => {
             console.error("Failed to list synced documents", error);
-            return documentsRef.current.filter((d) => d.origin === "synced");
+            return documentsRef.current.filter((d) => d.source === "synced");
           })
         : Promise.resolve([] as DocumentMeta[]),
       localRepository.list(),
@@ -177,9 +177,9 @@ export function useDocumentManager(params: {
   }, [localRepository, syncedRepository]);
 
   const saveCurrentEditor = useCallback(async () => {
-    // Only local-origin documents are persisted via this hook — synced
+    // Only local-source documents are persisted via this hook — synced
     // documents are persisted by useSync over WebSocket.
-    if (activeDocumentOriginRef.current !== "local") return;
+    if (activeDocumentSourceRef.current !== "local") return;
 
     const editor = editorRef.current;
     const docId = activeDocumentIdRef.current;
@@ -205,20 +205,20 @@ export function useDocumentManager(params: {
       if (metas.length === 0) {
         // Prefer creating the first document in the synced repo when the
         // user is logged in; otherwise create it locally.
-        const defaultOrigin: DocumentOrigin = syncedRepository
+        const defaultSource: DocumentSource = syncedRepository
           ? "synced"
           : "local";
-        const repo = getRepository(defaultOrigin);
+        const repo = getRepository(defaultSource);
         if (!repo) return;
-        const draft = createNewDocumentDraft(
+        const input = createNewDocumentInput(
           nextTailSortOrder([]),
-          defaultOrigin,
+          defaultSource,
         );
         // The synced repo allocates a server-side id at create; use the
-        // returned doc's id rather than the draft's UUID.
-        const saved = await repo.save(draft);
+        // returned doc's id rather than the input's UUID.
+        const saved = await repo.save(input);
         if (cancelled) return;
-        if (defaultOrigin === "synced") {
+        if (defaultSource === "synced") {
           await finalizeSyncedDocument(saved.meta.id);
           if (cancelled) return;
         }
@@ -228,7 +228,7 @@ export function useDocumentManager(params: {
       } else {
         commitDocuments(metas);
         const firstMeta = metas[0];
-        const repo = getRepository(firstMeta.origin);
+        const repo = getRepository(firstMeta.source);
         const data = repo ? await repo.get(firstMeta.id) : undefined;
         if (cancelled) return;
         commitActiveDocumentId(firstMeta.id);
@@ -288,12 +288,12 @@ export function useDocumentManager(params: {
   );
 
   const createDocument = useCallback(
-    async (options?: { origin?: DocumentOrigin }) => {
+    async (options?: { source?: DocumentSource }) => {
       await saveCurrentEditor();
 
-      const origin: DocumentOrigin =
-        options?.origin ?? (syncedRepository ? "synced" : "local");
-      const repo = getRepository(origin);
+      const source: DocumentSource =
+        options?.source ?? (syncedRepository ? "synced" : "local");
+      const repo = getRepository(source);
       if (!repo) return;
 
       // Compute the next sort_order key against just this repo's docs
@@ -303,12 +303,12 @@ export function useDocumentManager(params: {
       // change.
       try {
         const existing = await repo.list();
-        const draft = createNewDocumentDraft(
+        const input = createNewDocumentInput(
           nextTailSortOrder(existing),
-          origin,
+          source,
         );
-        const saved = await repo.save(draft);
-        if (origin === "synced") {
+        const saved = await repo.save(input);
+        if (source === "synced") {
           await finalizeSyncedDocument(saved.meta.id);
         }
 
@@ -317,7 +317,7 @@ export function useDocumentManager(params: {
         setActiveSnapshot(null);
         await refreshDocuments();
       } catch (error) {
-        console.error(`Failed to create ${origin} document`, error);
+        console.error(`Failed to create ${source} document`, error);
       }
     },
     [
@@ -387,36 +387,36 @@ export function useDocumentManager(params: {
 
       if (remaining.length === 0) {
         // Create a new document if we deleted the last one; use the
-        // current default origin. Fall back to local creation if the
+        // current default source. Fall back to local creation if the
         // preferred (synced) save fails so the user is not left with an
         // empty sidebar after a successful delete.
-        const defaultOrigin: DocumentOrigin = syncedRepository
+        const defaultSource: DocumentSource = syncedRepository
           ? "synced"
           : "local";
-        const defaultRepo = getRepository(defaultOrigin);
+        const defaultRepo = getRepository(defaultSource);
         if (!defaultRepo) return;
-        const draft = createNewDocumentDraft(
+        const input = createNewDocumentInput(
           nextTailSortOrder([]),
-          defaultOrigin,
+          defaultSource,
         );
         let saved: DocumentData;
         try {
-          saved = await defaultRepo.save(draft);
-          if (defaultOrigin === "synced") {
+          saved = await defaultRepo.save(input);
+          if (defaultSource === "synced") {
             await finalizeSyncedDocument(saved.meta.id);
           }
         } catch (error) {
           console.error(
-            `Failed to create replacement ${defaultOrigin} document; falling back to local`,
+            `Failed to create replacement ${defaultSource} document; falling back to local`,
             error,
           );
-          if (defaultOrigin === "synced") {
-            const localDraft = createNewDocumentDraft(
+          if (defaultSource === "synced") {
+            const localInput = createNewDocumentInput(
               nextTailSortOrder([]),
               "local",
             );
             try {
-              saved = await localRepository.save(localDraft);
+              saved = await localRepository.save(localInput);
             } catch (localError) {
               console.error(
                 "Failed to create replacement local document",
@@ -440,7 +440,7 @@ export function useDocumentManager(params: {
       if (id === activeDocumentIdRef.current) {
         // Switch to the first remaining document
         const nextMeta = remaining[0];
-        const nextRepo = getRepository(nextMeta.origin);
+        const nextRepo = getRepository(nextMeta.source);
         const data = nextRepo ? await nextRepo.get(nextMeta.id) : undefined;
         editorRef.current = null;
         commitActiveDocumentId(nextMeta.id);
@@ -507,7 +507,7 @@ export function useDocumentManager(params: {
       // returning the first match would otherwise pick the synced one
       // and silently block the retry.
       const meta = documentsRef.current.find(
-        (d) => d.id === id && d.origin === "local",
+        (d) => d.id === id && d.source === "local",
       );
       if (!meta) return;
 
@@ -582,7 +582,7 @@ export function useDocumentManager(params: {
       // The doc keeps its id across the local→synced transition
       // (UUID v7 is client-allocated, see migration docs). If the
       // active doc is the one we just migrated, re-commit the same
-      // id so the active-origin ref flips from "local" to "synced"
+      // id so the active-source ref flips from "local" to "synced"
       // and the synced container takes over the editor.
       if (id === activeDocumentIdRef.current) {
         editorRef.current = null;
@@ -604,13 +604,13 @@ export function useDocumentManager(params: {
       editorRef.current = editor;
 
       // Synced documents are persisted by useSync; this auto-save path is
-      // only for local-origin docs. The check is re-evaluated on every
+      // only for local-source docs. The check is re-evaluated on every
       // store event below so switching the active doc takes effect without
       // re-registering.
       let timer: ReturnType<typeof setTimeout> | undefined;
       const stopListening = editor.store.listen(
         () => {
-          if (activeDocumentOriginRef.current !== "local") return;
+          if (activeDocumentSourceRef.current !== "local") return;
           clearTimeout(timer);
           timer = setTimeout(() => {
             saveCurrentEditor();
@@ -637,17 +637,17 @@ export function useDocumentManager(params: {
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (
-        activeDocumentOriginRef.current === "local" &&
+        activeDocumentSourceRef.current === "local" &&
         document.visibilityState === "hidden"
       ) {
         saveCurrentEditor();
       }
     };
     const handlePageHide = () => {
-      if (activeDocumentOriginRef.current === "local") saveCurrentEditor();
+      if (activeDocumentSourceRef.current === "local") saveCurrentEditor();
     };
     const handleBeforeUnload = () => {
-      if (activeDocumentOriginRef.current === "local") saveCurrentEditor();
+      if (activeDocumentSourceRef.current === "local") saveCurrentEditor();
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
     window.addEventListener("pagehide", handlePageHide);

--- a/packages/app/src/documents/useSyncedRepository.ts
+++ b/packages/app/src/documents/useSyncedRepository.ts
@@ -1,0 +1,25 @@
+import { createContext, useContext } from "react";
+import type { ApiDocumentRepository } from "./api-repository";
+
+// The synced (server-backed) document repository is workspace-scoped:
+// every instance is bound to a single workspace_id resolved after
+// login. Two consumers need it — the DocumentManagerProvider for
+// list/get/create/update/delete, and the OfflineAwareSyncedContainer
+// for the reconnect/fork flow. Carrying the same instance through a
+// context avoids constructing it twice or threading it through
+// component props.
+//
+// The context value is `null` when the user is logged out (no synced
+// repo exists). Consumers in the synced-only paths must guard against
+// that case.
+export const SyncedRepositoryContext =
+  createContext<ApiDocumentRepository | null>(null);
+
+/**
+ * Read the synced repository from context. Returns `null` when the
+ * user is logged out — callers should handle that case (typically by
+ * rendering an unauthenticated UI instead of attempting a sync flow).
+ */
+export function useSyncedRepository(): ApiDocumentRepository | null {
+  return useContext(SyncedRepositoryContext);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       tldraw:
         specifier: 3.15.5
         version: 3.15.5(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      uuid:
+        specifier: ^14.0.0
+        version: 14.0.0
     devDependencies:
       '@testing-library/react':
         specifier: ^16.3.2
@@ -6946,6 +6949,10 @@ packages:
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==, tarball: https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz}
+    hasBin: true
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==, tarball: https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz}
     hasBin: true
 
   valibot@1.3.1:
@@ -15636,6 +15643,8 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@11.1.0: {}
+
+  uuid@14.0.0: {}
 
   valibot@1.3.1(typescript@5.8.3):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       anipres:
         specifier: workspace:*
         version: link:../anipres
+      fractional-indexing:
+        specifier: ^3.2.0
+        version: 3.2.0
       idb-keyval:
         specifier: ^6.2.1
         version: 6.2.2
@@ -4585,6 +4588,10 @@ packages:
 
   fractional-indexing-jittered@1.0.0:
     resolution: {integrity: sha512-0tLU0FOedVY7lrvN4LK0DVj6FTuYM0pWDpN97/8UTZE2lx1+OwX8+2uL7IOWc2PmktYTHQjMT6FvZZ3SGCdZdg==, tarball: https://registry.npmjs.org/fractional-indexing-jittered/-/fractional-indexing-jittered-1.0.0.tgz}
+
+  fractional-indexing@3.2.0:
+    resolution: {integrity: sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ==, tarball: https://registry.npmjs.org/fractional-indexing/-/fractional-indexing-3.2.0.tgz}
+    engines: {node: ^14.13.1 || >=16.0.0}
 
   framesync@6.1.2:
     resolution: {integrity: sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==, tarball: https://registry.npmjs.org/framesync/-/framesync-6.1.2.tgz}
@@ -11013,14 +11020,6 @@ snapshots:
     optionalDependencies:
       vite: 7.2.6(@types/node@22.13.10)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(tsx@4.19.2)(yaml@2.8.2)
 
-  '@vitest/mocker@4.0.6(vite@7.2.6(@types/node@24.10.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(tsx@4.19.2)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 4.0.6
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.2.6(@types/node@24.10.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(tsx@4.19.2)(yaml@2.8.2)
-
   '@vitest/pretty-format@4.0.6':
     dependencies:
       tinyrainbow: 3.0.3
@@ -12771,6 +12770,8 @@ snapshots:
     optional: true
 
   fractional-indexing-jittered@1.0.0: {}
+
+  fractional-indexing@3.2.0: {}
 
   framesync@6.1.2:
     dependencies:
@@ -15837,7 +15838,7 @@ snapshots:
   vitest@4.0.6(@types/debug@4.1.12)(@types/node@24.10.0)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@25.0.1)(sass-embedded@1.93.3)(sass@1.93.3)(tsx@4.19.2)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.6
-      '@vitest/mocker': 4.0.6(vite@7.2.6(@types/node@24.10.0)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(tsx@4.19.2)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.6(vite@7.2.6(@types/node@22.13.10)(jiti@2.6.1)(sass-embedded@1.93.3)(sass@1.93.3)(tsx@4.19.2)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.6
       '@vitest/runner': 4.0.6
       '@vitest/snapshot': 4.0.6


### PR DESCRIPTION
## Summary

After the worker schema + API redesign in #448, the frontend still spoke the old contract: `PUT /api/documents/:uuid` as an upsert, integer `order`, single `save()` method on the repository. This PR adapts the app side to the post-#448 contract so document CRUD, the local → synced migration, and the offline reconnect flow all work end-to-end.

The commits build up incrementally; each one is independently reviewable.

### Document ids: client-allocated UUID v7

Documents are identified by client-minted UUID v7 (via the `uuid` npm package, `v7()`). The same id flows unchanged through every layer — IDB write, `PUT /api/documents/:id`, asset upload paths, snapshot push, active-doc tracking. v7 specifically (vs v4) so the time prefix keeps the server's B-tree inserts mostly-sequential, recovering the locality an INTEGER autoincrement PK would have given.

### Sort order: fractional indexing

`order: number` → `sortOrder: string` (the `fractional-indexing` package's keys, compared via `localeCompare`). New `nextTailSortOrder(existing)` helper centralizes the "place past the tail" calculation; `useDocumentManager`, `convertLocalDocToSynced`, and the reconnect-fork all use it.

### Repository interface (`DocumentRepository`)

Collapsed into a single upsert method matching the worker's `PUT /api/documents/:id`:

```ts
interface DocumentRepository {
  list(): Promise<DocumentMeta[]>;
  get(id: string): Promise<DocumentData | undefined>;
  save(input: DocumentInput): Promise<DocumentData>;
  delete(id: string): Promise<void>;
}
```

- `save()` is insert-if-new / update-if-existing on both implementations. IDB collapses to one `set()` call; the API repo's `PUT` is server-side upsert.
- `DocumentInput` is the input shape — required `id`, `title`, `sortOrder`, `source`; optional `createdAt` for the migration's preserve-on-device-creation-time use case.
- The repository owns timestamps (callers no longer mint them). On insert, `createdAt` honors the optional override or stamps now; on update, `createdAt` is preserved and `updatedAt` is bumped.

### API repository (`ApiDocumentRepository`)

- Constructor takes a `workspaceId: string`. Every list/save call is scoped to that workspace; `App.tsx` resolves the user's workspace via `GET /api/workspaces` after login and constructs the repo with it.
- `list()` → `GET /api/documents?workspace_id=:wsid`.
- `save(input)` → `PUT /api/documents/:id` with `{ workspace_id, title, sort_order, created_at? }`. Server returns the canonical row (with the slug it allocated).
- `get(id)` and `delete(id)` are unchanged-shape per-doc routes; the doc id implicitly identifies the workspace.

### Local → synced migration

`convertLocalDocToSynced` simplifies to `Promise<void>` — with UUID v7 ids client-allocated, the local id is also the canonical server id. No remap, no `serverId` variable, no active-doc id swap. Steps:

1. Load the local doc.
2. Compute a fractional-indexing key past the synced list's tail.
3. `PUT /api/documents/:id` (server inserts under the local id, marking the row `initializing_at`).
4. Upload `data:`-URL assets to R2 and rewrite the snapshot.
5. Push the rewritten snapshot via `PUT /:id/snapshot` (this clears `initializing_at` server-side).
6. Delete the local IDB entry.

On failure after step 3 the local copy is preserved so the user can retry. The half-created server row's `initializing_at` keeps it invisible until finalized; the server-side sweep cleans it up if the user gives up.

### Fresh synced create

For `createDocument({ source: "synced" })`, after `repo.save(input)` the app calls `POST /api/documents/:id/finalize` to clear `initializing_at` server-side. The DO room stays un-seeded — `useSync` populates it on the user's first connect, matching pre-PR behavior. New `snapshot-push.ts` exposes both `pushSnapshot()` (used by migration + fork) and `finalizeSyncedDocument()` (used by fresh-create).

If `save` succeeds but `finalize` throws, the row stays hidden behind `initializing_at` and the server-side sweep reaps it; no client cleanup needed.

### Reconnect / offline-fork

Fork mints its UUID v7 client-side via `uuidv7()`, lists the synced repo to compute a sort_order past the tail, and `repo.save()`s with the new id. No placeholder ids; no server-allocation roundtrip needed.

### Mid-migration delete cleanup

If the user deletes a doc while migration is in flight, `deleteDocument` aborts the migration's `AbortController` and best-effort `syncedRepository.delete(id)`s the half-created server row. `localId === serverId` under UUID v7, so this is a one-line cleanup that reaches the right row. The server's `initializing_at` sweep is still the safety net for non-aborted abandonment (tab close, network failure, browser crash).

### App wiring

- `App.tsx` discovers the user's workspaces via `GET /api/workspaces` after login, binds the synced repo to the (Phase 1: only) workspace, and waits for both auth + workspace resolution before rendering. The fetched value is tagged with the user id so a user-A → user-B transition derives `null` until the new fetch lands.
- Workspace-discovery failures (HTTP error, empty list, fetch reject) log to console and render a `role="alert"` message with a refresh hint instead of hanging on a blank screen — Phase 1 always provisions exactly one workspace at signup, so reaching that path means genuinely broken state.
- New `SyncedRepositoryContext` (component file) + `useSyncedRepository` (context value file) following the existing `DocumentManagerContext` split. `OfflineAwareSyncedContainer` consumes the same repo instance via the context instead of constructing its own at module scope (which can't work anymore since the workspace id is runtime-resolved).

### Terminology

- `DocumentDraft` → `DocumentInput` ("input to a mutation"; "draft" is reserved for any future user-facing draft state).
- `DocumentOrigin` / `meta.origin` → `DocumentSource` / `meta.source` (avoids the mental collision with URL origins, `location.origin`, CORS origins).

### Tests

- `api-repository.test.ts` (new): wire-shape coverage for list/get/save/delete, including the `?workspace_id=` query param, the `created_at` optional-override path, and a re-save accepting a full `DocumentData`.
- `migration.test.ts`, `useDocumentManager.test.tsx`, `reconnect.test.ts`: updated for the UUID-everywhere model. Test fakes drop the synthetic `synced-${localId}` mapping (no longer needed; ids flow through verbatim).
- 74 tests pass; typecheck and lint clean.

### Dependencies

- `uuid` v14 (for `v7()`).
- `fractional-indexing` v3 (for `generateKeyBetween`).

## Test plan

- [x] `pnpm --filter app test --run` — 74 / 74 pass
- [x] `pnpm --filter app typecheck` — clean
- [x] `pnpm --filter app lint` — clean
- [ ] Manual: log in, click "Migrate this document" on a local doc, verify the doc keeps its id and source flips to synced
- [ ] Manual: create a fresh synced doc, verify it appears in the sidebar after the `/finalize` call lands
- [ ] Manual: reorder synced docs, reload, verify order persists
- [ ] Manual: go offline, edit, reconnect, verify push-or-fork still works (fork lands past the tail with a v7 id)
- [ ] Manual: log in as user A, log out, log in as user B; verify the synced sidebar reflects B's docs (not a stale A view)
- [ ] Manual: simulate a workspace fetch failure (e.g. devtools network throttle to offline post-login), verify the error UI renders instead of a blank screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)