### PR TITLE
feat(app): convert-to-synced polish — friendly errors, aria-live, upload pool

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -46,9 +46,11 @@ See [Post-Launch Hardening](./design-server-sync.md#post-launch-hardening) in th
 
 ## Convert-to-synced polish
 
-Follow-ups deferred from the convert-to-synced PRs (#431–#435). None are blocking; group here so they surface during a Phase 6 polish pass.
+Follow-ups deferred from the convert-to-synced PRs (#431–#435) — all four shipped together.
 
-- **Friendly error-message mapping**: `conversionError.message` flows directly to the button's `title` / `aria-label` today, surfacing strings like `"Asset upload failed: 413"` or `"signal timed out"`. Map to user-friendly text (413 → "This file is too large", `AbortError` → "Upload timed out — check your connection and try again", other 4xx/5xx → "Couldn't reach the server. Try again.").
-- **`aria-live` region for screen readers**: Convert state changes only announce when the button is re-focused. A `<div aria-live="polite">` near the sidebar footer would announce success/failure passively. Needs a small design pass on when/what to announce.
-- **Asset-upload concurrency cap**: `uploadAssetDataUrls` runs every data-URL asset upload in parallel via `Promise.all`. A legacy doc with many inline images will fire N simultaneous requests. Add a small pool (4–6 in flight) to be kinder to the browser connection pool and the worker.
-- **Tighten internal `composeWithTimeout` / default-helper signatures**: The internal `composeWithTimeout(userSignal?: AbortSignal)` helper and the `abortSignal?: AbortSignal` params on `defaultUploadAsset` / `defaultPushSnapshot` read like they can be called without an argument, but every call site passes the value. Change those internals to `AbortSignal | undefined` for an honest signature. The public `ConvertLocalDocToSyncedParams` interface keeps `?` for consumer ergonomics.
+Done:
+
+- **Friendly error-message mapping**: `getConversionErrorMessage` in `documents/conversion-error-message.ts` maps `Asset upload failed: 413` → "This file is too large", `AbortError`/`TimeoutError` → "Upload timed out…", network `TypeError` → "Couldn't reach the server…", etc. Used by both the per-doc button title/aria-label and the new `aria-live` region.
+- **`aria-live` region for screen readers**: `<div role="status" aria-live="polite">` rendered above the sidebar footer (visually hidden via `srOnly`). Announces "Uploading {title}…" on convert start and "Failed to upload {title}: {friendly}" on failure.
+- **Asset-upload concurrency cap**: `uploadAssetDataUrls` now uses a `pooledMap` helper with `ASSET_UPLOAD_CONCURRENCY = 4`. Keeps the pool full (work-stealing pattern, not batched) so the slowest upload in a wave doesn't gate the next wave.
+- **Tighten internal `composeWithTimeout` / default-helper signatures**: Internal `composeWithTimeout` and `defaultUploadAsset` / `defaultPushSnapshot` use `AbortSignal | undefined` instead of `?: AbortSignal`. Public `ConvertLocalDocToSyncedParams` keeps `?` for consumer ergonomics.

--- a/packages/app/src/components/DocumentListItem.tsx
+++ b/packages/app/src/components/DocumentListItem.tsx
@@ -1,5 +1,6 @@
 import { CloudUpload, Loader2, X } from "lucide-react";
 import { useState, useRef, useEffect } from "react";
+import { getConversionErrorMessage } from "../documents/conversion-error-message";
 import type { DocumentMeta } from "../documents/types";
 import styles from "./DocumentListItem.module.css";
 
@@ -57,15 +58,18 @@ export function DocumentListItem({
   };
 
   const canConvert = onConvert !== undefined && doc.source === "local";
+  const friendlyError = conversionError
+    ? getConversionErrorMessage(conversionError)
+    : null;
   const convertTitle = isConverting
     ? "Uploading…"
-    : conversionError
-      ? `Upload failed: ${conversionError.message}. Click to retry.`
+    : friendlyError
+      ? `${friendlyError} Click to retry.`
       : "Upload to cloud";
   const convertAriaLabel = isConverting
     ? `Uploading ${doc.title} to cloud`
-    : conversionError
-      ? `Retry uploading ${doc.title} to cloud (previous attempt failed)`
+    : friendlyError
+      ? `Retry uploading ${doc.title} to cloud (${friendlyError})`
       : `Upload ${doc.title} to cloud`;
 
   return (

--- a/packages/app/src/components/DocumentSidebar.module.css
+++ b/packages/app/src/components/DocumentSidebar.module.css
@@ -182,3 +182,18 @@
 :global([data-color-scheme="dark"]) .authButton:hover {
   background: rgba(255, 255, 255, 0.08);
 }
+
+/* Visually hidden but accessible to screen readers. Used for an
+   aria-live region that announces convert-to-synced state changes
+   without taking up visual space. */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/packages/app/src/components/DocumentSidebar.tsx
+++ b/packages/app/src/components/DocumentSidebar.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useAuth } from "../auth/useAuth";
+import { getConversionErrorMessage } from "../documents/conversion-error-message";
 import { useDocumentManagerContext } from "../documents/useDocumentManagerContext";
 import type { DocumentMeta } from "../documents/types";
 import type { ColorSchemePreference } from "../hooks/useColorScheme";
@@ -92,6 +93,35 @@ export function DocumentSidebar({
     window.history.replaceState({}, "", next);
   }, []);
 
+  // Announcement string for the convert-to-synced aria-live region.
+  // The convert-to-synced button itself updates its `title` /
+  // `aria-label` in place, but those only get re-announced when the
+  // button receives focus. The polite live region below announces
+  // start / failure transitions to screen readers as they happen,
+  // without taking focus.
+  //
+  // Errors take precedence over in-flight state: when a doc fails
+  // mid-conversion, useDocumentManager moves it from `converting`
+  // into `conversionErrors`, so the error branch fires on the
+  // failure transition. Successful completions don't appear here
+  // (the doc just moves out of `converting` into the synced group);
+  // the visible badge change is enough.
+  const conversionAnnouncement = useMemo(() => {
+    for (const [id, err] of conversionErrors) {
+      const doc = documents.find((d) => d.id === id);
+      if (doc) {
+        return `Failed to upload ${doc.title} to cloud: ${getConversionErrorMessage(err)}`;
+      }
+    }
+    if (converting.size === 0) return "";
+    if (converting.size === 1) {
+      const id = [...converting][0];
+      const doc = documents.find((d) => d.id === id);
+      if (doc) return `Uploading ${doc.title} to cloud.`;
+    }
+    return `Uploading ${converting.size} documents to cloud.`;
+  }, [converting, conversionErrors, documents]);
+
   const { syncedDocs, localDocs } = useMemo(() => {
     const synced: DocumentMeta[] = [];
     const local: DocumentMeta[] = [];
@@ -168,6 +198,14 @@ export function DocumentSidebar({
           <div className={styles.groupHeader}>Local</div>
         )}
         {renderGroup(localDocs)}
+      </div>
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className={styles.srOnly}
+      >
+        {conversionAnnouncement}
       </div>
       <div className={styles.footer}>
         <NetworkStatus />

--- a/packages/app/src/documents/conversion-error-message.test.ts
+++ b/packages/app/src/documents/conversion-error-message.test.ts
@@ -8,12 +8,19 @@ function withName(name: string, message: string): Error {
 }
 
 describe("getConversionErrorMessage", () => {
-  it("maps 413 to a too-large message", () => {
+  it("maps 413 to a too-large message across each throw site", () => {
     expect(
       getConversionErrorMessage(new Error("Asset upload failed: 413")),
     ).toMatch(/too large/i);
     expect(
       getConversionErrorMessage(new Error("Snapshot push failed: 413")),
+    ).toMatch(/too large/i);
+    // Document finalize doesn't realistically return 413, but the
+    // helper covers the throw-site prefix uniformly so a future
+    // path that surfaces a finalize failure renders the same family
+    // of friendly messages instead of falling through to the generic.
+    expect(
+      getConversionErrorMessage(new Error("Document finalize failed: 413")),
     ).toMatch(/too large/i);
   });
 

--- a/packages/app/src/documents/conversion-error-message.test.ts
+++ b/packages/app/src/documents/conversion-error-message.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { getConversionErrorMessage } from "./conversion-error-message";
+
+function withName(name: string, message: string): Error {
+  const e = new Error(message);
+  e.name = name;
+  return e;
+}
+
+describe("getConversionErrorMessage", () => {
+  it("maps 413 to a too-large message", () => {
+    expect(
+      getConversionErrorMessage(new Error("Asset upload failed: 413")),
+    ).toMatch(/too large/i);
+    expect(
+      getConversionErrorMessage(new Error("Snapshot push failed: 413")),
+    ).toMatch(/too large/i);
+  });
+
+  it("maps 401 / 403 to a re-login message", () => {
+    expect(
+      getConversionErrorMessage(new Error("Asset upload failed: 401")),
+    ).toMatch(/log in/i);
+    expect(
+      getConversionErrorMessage(new Error("Asset upload failed: 403")),
+    ).toMatch(/log in/i);
+  });
+
+  it("maps other 4xx to a server-rejected message that surfaces the status", () => {
+    expect(
+      getConversionErrorMessage(new Error("Asset upload failed: 422")),
+    ).toMatch(/server rejected/i);
+    expect(
+      getConversionErrorMessage(new Error("Asset upload failed: 422")),
+    ).toMatch(/422/);
+  });
+
+  it("maps 5xx to a server-trouble message", () => {
+    expect(
+      getConversionErrorMessage(new Error("Snapshot push failed: 500")),
+    ).toMatch(/server is having trouble/i);
+    expect(
+      getConversionErrorMessage(new Error("Snapshot push failed: 502")),
+    ).toMatch(/server is having trouble/i);
+  });
+
+  it("maps TimeoutError and AbortError to a timeout message", () => {
+    expect(
+      getConversionErrorMessage(withName("TimeoutError", "signal timed out")),
+    ).toMatch(/timed out/i);
+    expect(
+      getConversionErrorMessage(withName("AbortError", "aborted")),
+    ).toMatch(/timed out/i);
+  });
+
+  it("maps fetch-network failures (TypeError) to a connection message", () => {
+    expect(
+      getConversionErrorMessage(withName("TypeError", "Failed to fetch")),
+    ).toMatch(/couldn't reach the server/i);
+    // Match by message text too — older browsers / non-fetch sources.
+    expect(
+      getConversionErrorMessage(
+        new Error("NetworkError when attempting to fetch resource."),
+      ),
+    ).toMatch(/couldn't reach the server/i);
+  });
+
+  it("falls back to a generic message for unrecognized errors", () => {
+    expect(getConversionErrorMessage(new Error("something weird"))).toMatch(
+      /something went wrong/i,
+    );
+  });
+});

--- a/packages/app/src/documents/conversion-error-message.ts
+++ b/packages/app/src/documents/conversion-error-message.ts
@@ -1,0 +1,56 @@
+/**
+ * Map a raw `convertLocalDocToSynced` failure into a user-facing
+ * sentence. The raw `Error.message` strings come from a few well-known
+ * sites:
+ *
+ * - `defaultUploadAsset` throws `"Asset upload failed: <status>"`
+ * - `defaultPushSnapshot` throws `"Snapshot push failed: <status>"`
+ * - The shared `composeWithTimeout` produces `AbortSignal.timeout(...)`
+ *   which surfaces as `TimeoutError` on the abort signal
+ * - User-cancellation / mid-migration delete surfaces as `AbortError`
+ * - Network failures (offline, DNS, CORS) surface as `TypeError:
+ *   Failed to fetch` in most browsers
+ *
+ * Anything not recognized falls through to a generic "try again"
+ * message — better than exposing internal HTTP / Error vocab to the
+ * user.
+ */
+export function getConversionErrorMessage(error: Error): string {
+  // `AbortSignal.timeout` produces a `TimeoutError`; user-cancellation
+  // produces `AbortError`. Both manifest as the migration timing out
+  // from the user's perspective.
+  if (error.name === "TimeoutError" || error.name === "AbortError") {
+    return "Upload timed out — check your connection and try again.";
+  }
+
+  const httpMatch = error.message.match(
+    /^(?:Asset upload|Snapshot push) failed: (\d+)/,
+  );
+  if (httpMatch) {
+    const status = Number(httpMatch[1]);
+    if (status === 413) return "This file is too large.";
+    if (status === 401 || status === 403) {
+      return "Your session has expired. Please log in and try again.";
+    }
+    if (status >= 400 && status < 500) {
+      return `The server rejected the upload (${status}). Try a different file or a smaller one.`;
+    }
+    if (status >= 500) {
+      return "The server is having trouble. Please try again in a moment.";
+    }
+  }
+
+  // `fetch` rejects with a `TypeError` on network failures — DNS,
+  // offline, CORS, certificate, etc. The message text varies by
+  // browser ("Failed to fetch", "NetworkError when attempting to
+  // fetch resource.", "Load failed"); match by Error name to stay
+  // browser-agnostic.
+  if (
+    error.name === "TypeError" ||
+    /failed to fetch|networkerror|load failed/i.test(error.message)
+  ) {
+    return "Couldn't reach the server. Check your connection and try again.";
+  }
+
+  return "Something went wrong. Please try again.";
+}

--- a/packages/app/src/documents/conversion-error-message.ts
+++ b/packages/app/src/documents/conversion-error-message.ts
@@ -1,10 +1,15 @@
 /**
- * Map a raw `convertLocalDocToSynced` failure into a user-facing
- * sentence. The raw `Error.message` strings come from a few well-known
- * sites:
+ * Map a raw failure from any of the synced-doc upload paths
+ * (`convertLocalDocToSynced`, `finalizeSyncedDocument`,
+ * `pushSnapshot` from the reconnect-fork) into a user-facing
+ * sentence. The raw `Error.message` strings come from a few
+ * well-known sites:
  *
  * - `defaultUploadAsset` throws `"Asset upload failed: <status>"`
- * - `defaultPushSnapshot` throws `"Snapshot push failed: <status>"`
+ * - `defaultPushSnapshot` / `pushSnapshot` throw `"Snapshot push
+ *   failed: <status>"`
+ * - `finalizeSyncedDocument` throws `"Document finalize failed:
+ *   <status>"`
  * - The shared `composeWithTimeout` produces `AbortSignal.timeout(...)`
  *   which surfaces as `TimeoutError` on the abort signal
  * - User-cancellation / mid-migration delete surfaces as `AbortError`
@@ -24,7 +29,7 @@ export function getConversionErrorMessage(error: Error): string {
   }
 
   const httpMatch = error.message.match(
-    /^(?:Asset upload|Snapshot push) failed: (\d+)/,
+    /^(?:Asset upload|Snapshot push|Document finalize) failed: (\d+)/,
   );
   if (httpMatch) {
     const status = Number(httpMatch[1]);

--- a/packages/app/src/documents/migration.test.ts
+++ b/packages/app/src/documents/migration.test.ts
@@ -273,6 +273,66 @@ describe("uploadAssetDataUrls", () => {
     expect(result).toBe(snapshot);
     expect(uploadFile).not.toHaveBeenCalled();
   });
+
+  it("caps in-flight uploads to ASSET_UPLOAD_CONCURRENCY (=4) when many assets are present", async () => {
+    // 10 data-URL assets, 4-way pool: max 4 should be in flight at any
+    // moment. Use manually-resolved promises so the test can observe
+    // the in-flight count without races.
+    const records: Record<string, ReturnType<typeof assetRecord>> = {};
+    for (let i = 0; i < 10; i++) {
+      records[`asset:${i}`] = assetRecord(
+        `asset:${i}`,
+        `data:image/png;base64,AAAA${i}`,
+      );
+    }
+    const snapshot = snapshotWith(records);
+
+    let inFlight = 0;
+    let peakInFlight = 0;
+    const resolvers: Array<() => void> = [];
+
+    const uploadFile = vi
+      .fn<(file: File) => Promise<{ src: string }>>()
+      .mockImplementation((file) => {
+        inFlight++;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        return new Promise<{ src: string }>((resolve) => {
+          resolvers.push(() => {
+            inFlight--;
+            resolve({ src: `/uploaded/${file.name}` });
+          });
+        });
+      });
+
+    // Yield enough times to let chained microtasks settle. Each
+    // resolved upload triggers `await fn()` to resume, which enqueues
+    // the next iteration; that iteration calls `fn(items[i+1])` (a
+    // mocked promise that resolves later). One `await Promise.resolve()`
+    // unblocks one such hop; flushing several covers the full chain.
+    const flushMicrotasks = async () => {
+      for (let i = 0; i < 8; i++) await Promise.resolve();
+    };
+
+    const promise = uploadAssetDataUrls(snapshot, uploadFile);
+
+    // Wait for the initial pool to fill: the first 4 uploads should be
+    // dispatched before any complete.
+    await flushMicrotasks();
+    expect(inFlight).toBe(4);
+
+    // Drain in waves. Each wave: resolve everything currently in
+    // flight, then yield until the pool has dispatched whatever
+    // backlog work it can. Loop ends when no more work is queued.
+    while (resolvers.length > 0) {
+      const batch = resolvers.splice(0, resolvers.length);
+      for (const resolve of batch) resolve();
+      await flushMicrotasks();
+    }
+
+    await promise;
+    expect(uploadFile).toHaveBeenCalledTimes(10);
+    expect(peakInFlight).toBe(4);
+  });
 });
 
 describe("convertLocalDocToSynced", () => {

--- a/packages/app/src/documents/migration.ts
+++ b/packages/app/src/documents/migration.ts
@@ -78,15 +78,55 @@ export function rewriteAssetSrcs(
   return { ...snapshot, store: newStore as typeof snapshot.store };
 }
 
+// Cap on simultaneous in-flight asset uploads during a migration.
+// Browsers cap parallel HTTP/1.1 connections at 6 per host; the worker
+// also has its own per-request cost. 4 leaves headroom for unrelated
+// requests (the doc-list query, snapshot push, etc.) while still
+// pipelining enough to feel fast on a doc with many embedded images.
+const ASSET_UPLOAD_CONCURRENCY = 4;
+
+/**
+ * Run `fn` over each input with at most `limit` concurrent calls. Keeps
+ * the pool full: as one call resolves, the next item is dispatched
+ * (vs. batching, which would wait for the slowest in each batch
+ * before starting the next group).
+ *
+ * Results are returned in input order. On the first rejection the
+ * outer promise rejects; in-flight calls are not actively cancelled
+ * (the pool will not start any further items, but already-running
+ * fetches must finish or be aborted via a separate signal).
+ */
+async function pooledMap<T, R>(
+  items: ReadonlyArray<T>,
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      while (true) {
+        const i = nextIndex++;
+        if (i >= items.length) return;
+        results[i] = await fn(items[i]);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
 /**
  * Scan a snapshot for inline `data:` URL assets, upload each via the
  * injected `uploadFile` callback, and return a new snapshot with the
  * asset srcs rewritten to the uploaded URLs. Snapshots with no data-URL
  * assets are returned unchanged.
  *
- * Uploads run in parallel. On partial failure some assets may still
- * reach R2 even though the promise rejects; the worker's asset GC
- * reconciles orphans against the live snapshot and cleans them up.
+ * Uploads run with bounded concurrency (`ASSET_UPLOAD_CONCURRENCY`).
+ * On partial failure some assets may still reach R2 even though the
+ * outer promise rejects; the worker's asset GC reconciles orphans
+ * against the live snapshot and cleans them up.
  */
 export async function uploadAssetDataUrls(
   snapshot: TLStoreSnapshot,
@@ -99,12 +139,14 @@ export async function uploadAssetDataUrls(
   // derives the final asset key's extension from the validated MIME
   // type and ignores this filename entirely (see
   // packages/worker/src/assets.ts). Passing the record id is enough.
-  const entries = await Promise.all(
-    assets.map(async (asset) => {
+  const entries = await pooledMap(
+    assets,
+    ASSET_UPLOAD_CONCURRENCY,
+    async (asset) => {
       const file = await dataUrlToFile(asset.dataUrl, asset.recordId);
       const { src } = await uploadFile(file);
       return [asset.recordId, src] as const;
-    }),
+    },
   );
   return rewriteAssetSrcs(snapshot, new Map(entries));
 }
@@ -116,7 +158,13 @@ export async function uploadAssetDataUrls(
 // surface as a visible failure rather than an indefinite spinner.
 const MIGRATION_FETCH_TIMEOUT_MS = 60_000;
 
-function composeWithTimeout(userSignal?: AbortSignal): AbortSignal {
+// Internal-only signatures use `AbortSignal | undefined` rather than
+// `?: AbortSignal` because every internal caller passes the parameter
+// explicitly (often from a forwarded `abortSignal`). The optional `?`
+// would invite a "looks safe to omit" reading at the call site that
+// doesn't reflect actual usage. The public
+// `ConvertLocalDocToSyncedParams` keeps `?` for consumer ergonomics.
+function composeWithTimeout(userSignal: AbortSignal | undefined): AbortSignal {
   const timeoutSignal = AbortSignal.timeout(MIGRATION_FETCH_TIMEOUT_MS);
   return userSignal
     ? AbortSignal.any([userSignal, timeoutSignal])
@@ -126,7 +174,7 @@ function composeWithTimeout(userSignal?: AbortSignal): AbortSignal {
 async function defaultUploadAsset(
   documentId: string,
   file: File,
-  abortSignal?: AbortSignal,
+  abortSignal: AbortSignal | undefined,
 ): Promise<{ src: string }> {
   const formData = new FormData();
   formData.append("file", file);
@@ -147,7 +195,7 @@ async function defaultUploadAsset(
 async function defaultPushSnapshot(
   documentId: string,
   snapshot: TLStoreSnapshot,
-  abortSignal?: AbortSignal,
+  abortSignal: AbortSignal | undefined,
 ): Promise<void> {
   const res = await fetch(
     `/api/documents/${encodeURIComponent(documentId)}/snapshot`,


### PR DESCRIPTION
## Summary

Wraps up the convert-to-synced polish list from \`docs/TODO.md\`. All four items in one PR — they're tightly related and the user-facing UX delta is most coherent when they ship together.

## What's in

### 1. Friendly error-message mapping

New \`documents/conversion-error-message.ts:getConversionErrorMessage(error)\` translates the raw \`Error.message\` strings the migration throws (e.g. \`Asset upload failed: 413\`) into user-facing sentences. Used by the per-doc button title/aria-label in \`DocumentListItem\` and by the new aria-live region.

| Error | User-facing message |
|---|---|
| \`Asset/Snapshot ... failed: 413\` | "This file is too large." |
| \`...: 401\` / \`...: 403\` | "Your session has expired. Please log in and try again." |
| \`...: 4xx\` (other) | "The server rejected the upload (N). Try a different file or a smaller one." |
| \`...: 5xx\` | "The server is having trouble. Please try again in a moment." |
| \`TimeoutError\` / \`AbortError\` | "Upload timed out — check your connection and try again." |
| \`TypeError\` (fetch network failure) | "Couldn't reach the server. Check your connection and try again." |
| Otherwise | "Something went wrong. Please try again." |

### 2. Aria-live region

The per-doc button's \`title\` / \`aria-label\` only get announced when the button receives focus, so silent in-flight conversions never reached screen-reader users. Added a polite \`aria-live\` region above the sidebar footer (visually hidden via a small \`srOnly\` utility class) that derives its content from \`converting\` + \`conversionErrors\`:

- "Uploading {title} to cloud." on convert start
- "Uploading N documents to cloud." when multiple are converting at once
- "Failed to upload {title} to cloud: {friendly message}" on failure

Successes don't announce — the doc-list group change covers that visually, and the button title/aria-label updates in place.

### 3. Asset-upload concurrency cap

\`uploadAssetDataUrls\` now uses a small \`pooledMap(items, limit, fn)\` helper with \`ASSET_UPLOAD_CONCURRENCY = 4\`. Work-stealing pattern (next item dispatched as one resolves) rather than batched (which would stall on the slowest upload in each wave). 4 leaves headroom under the browser's typical 6-per-host HTTP/1.1 connection cap so the doc-list refresh and snapshot push still get connection slots while uploads are in flight.

### 4. Internal signature tightening

\`composeWithTimeout(userSignal?: AbortSignal)\` → \`(userSignal: AbortSignal | undefined)\`, and the same change for \`defaultUploadAsset\` / \`defaultPushSnapshot\`'s \`abortSignal\` parameter. Every internal caller passes the value explicitly; \`?\` was misleading. The public \`ConvertLocalDocToSyncedParams\` interface keeps \`?\` for consumer ergonomics.

## Tests

- 7 new unit tests for \`getConversionErrorMessage\` covering each mapping branch
- 1 new test for \`uploadAssetDataUrls\` asserting the in-flight peak stays at 4 across 10 staged uploads (work-stealing dispatch)
- App test count: 80 → **88 passing**
- Lint + typecheck clean

## Test plan

- [x] \`pnpm --filter app test\` — 88/88 pass
- [x] \`pnpm --filter app lint\` — clean
- [x] \`pnpm --filter app typecheck\` — clean
- [ ] Manual: trigger a 413 (e.g. attempt to migrate a doc with a >5 MB image) → button title says "This file is too large. Click to retry." (not "Upload failed: 413")
- [ ] Manual: kill network mid-conversion → "Upload timed out…" or "Couldn't reach the server…" surfaces, not raw \`AbortError\`/\`TypeError\`
- [ ] Manual (a11y): turn on VoiceOver / NVDA, click "Upload to cloud" on a local doc → hear "Uploading {title} to cloud" without re-focusing the button; if it fails, hear the friendly failure message
- [ ] Manual: migrate a doc with 10+ embedded images → DevTools network tab shows at most 4 \`POST /api/documents/:id/assets\` requests in flight at any moment

🤖 Generated with [Claude Code](https://claude.com/claude-code)