### PR TITLE
feat(auth): disconnect a linked OAuth provider + AccountFooter extraction

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4,8 +4,6 @@ Tasks deferred during development that should be addressed before production rel
 
 ## Authentication
 
-- **Disconnect a linked provider**: Account linking lands the connect direction; the disconnect direction is the natural follow-up. Needs a `DELETE /auth/identities/:provider/:provider_id` route with a "can't remove the last identity" safety check, plus a confirmation UI in the existing account-settings modal. The session cookie can keep working as long as another identity remains for the same `user_id`.
-
 - **Merge two accounts**: When a user clicks "Connect {provider}" while logged in as User A, but the provider account is already linked to User B, the v1 implementation just shows a clear error ("This provider account is already linked to a different anipres account."). The richer behavior is to offer a merge: combine User A's and User B's documents under one user, delete the other. This is genuinely useful (real users will hit "I have two accounts and want to combine them") but it's a substantially bigger feature — it crosses the Phase 1 1:1 user↔workspace invariant (the surviving user owns two workspaces, which is Extension A territory), needs explicit confirmation UX (destructive, no undo without an undo window), and has its own race + rollback questions. Track separately.
 
 - **Google OAuth scope for email-based linking**: Currently requests `openid` only and identifies users by `sub`. The shipped account-linking flow uses an explicit "Connect" entry point (no email matching needed), so this remains as-is. _If_ a future merge / email-based-suggest feature is added, widen to `openid email`.

--- a/docs/design-server-sync.md
+++ b/docs/design-server-sync.md
@@ -459,12 +459,12 @@ Done:
 - Convert-to-synced UX with per-doc spinner / error / retry
 - Input validation: valibot schemas at the worker boundary, with worker-side test pipeline
 - Workspace-discovery error UI (visible message instead of blank screen)
-- Account-settings modal opened from the sidebar; lists linked OAuth identities (`GET /auth/identities`)
+- Account-settings modal opened from the sidebar's `AccountFooter`; lists linked OAuth identities (`GET /auth/identities`)
 - Account linking — the existing OAuth callbacks branch on the session cookie: a logged-in user completing the OAuth dance attaches the new `(provider, provider_id)` to the current `user_id` (via `attachIdentityToCurrentUser` in `auth/session.ts`); a logged-out user follows the existing login flow. Conflict ("provider account is already linked to a different user") surfaces as a redirect-flash error.
+- Disconnect a linked provider — `DELETE /auth/identities/:provider/:provider_id` with a server-side "can't remove your last sign-in method" guard (atomic single-statement check via subquery); two-click in-row Confirm/Cancel UI in the settings modal
 
 Remaining (see [TODO.md](./TODO.md)):
 
-- Disconnect-a-linked-provider flow (link is in; the unlink direction is the natural follow-up)
 - Merge two accounts on conflict (a meaningfully bigger feature; tracked separately)
 - Convert-to-synced polish (friendly error mapping, `aria-live` announce, asset-upload concurrency cap)
 

--- a/packages/app/src/auth/types.ts
+++ b/packages/app/src/auth/types.ts
@@ -1,4 +1,3 @@
 export interface User {
   id: number;
-  provider: string;
 }

--- a/packages/app/src/components/AccountFooter.module.css
+++ b/packages/app/src/components/AccountFooter.module.css
@@ -1,0 +1,30 @@
+/* Footer-row buttons used by AccountFooter (login / logout / open
+   settings). Match the look the auth buttons had inside DocumentSidebar
+   before this component was extracted. */
+.button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 10px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: none;
+  cursor: pointer;
+  font-size: 13px;
+  color: #666;
+}
+
+.button:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+:global([data-color-scheme="dark"]) .button {
+  border-color: #444;
+  color: #999;
+}
+
+:global([data-color-scheme="dark"]) .button:hover {
+  background: rgba(255, 255, 255, 0.08);
+}

--- a/packages/app/src/components/AccountFooter.tsx
+++ b/packages/app/src/components/AccountFooter.tsx
@@ -1,0 +1,120 @@
+import { Github, LogIn, LogOut, Settings } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useAuth } from "../auth/useAuth";
+import { AccountSettingsModal } from "./AccountSettingsModal";
+import styles from "./AccountFooter.module.css";
+
+// Pull the account-link flash from the current URL — set by the
+// worker's redirect after the OAuth callback resolves a link
+// operation. Returns null when neither query param is present
+// (the common case: ordinary navigation, not arriving from a link
+// flow).
+function readLinkFlashFromUrl(): {
+  code: string;
+  kind: "success" | "error";
+} | null {
+  if (typeof window === "undefined") return null;
+  const params = new URLSearchParams(window.location.search);
+  const success = params.get("account_link");
+  const error = params.get("account_link_error");
+  if (!success && !error) return null;
+  return {
+    code: error ?? success ?? "",
+    kind: error ? "error" : "success",
+  };
+}
+
+/**
+ * Account-related controls for the sidebar footer. Owns its own
+ * lifecycle:
+ *
+ * - When logged out: renders the per-provider login buttons.
+ * - When logged in: renders the "Account settings" button (opens
+ *   the modal) and the "Log out" button.
+ *
+ * Also owns the post-OAuth-link flash: reads `?account_link[_error]`
+ * params from the URL on mount, pops the modal open with the flash
+ * visible, and strips the params via `replaceState` so a refresh
+ * doesn't re-show it. Lives here (rather than in `DocumentSidebar`)
+ * so the sidebar stays a document-list component and doesn't grow
+ * account-management concerns.
+ */
+export function AccountFooter() {
+  const { user, loginWithGitHub, loginWithGoogle, logout } = useAuth();
+
+  // Lazy state init reads the URL once at mount — avoids the React
+  // lint trap of synchronously setting state in an effect, and lands
+  // the modal open on first paint when arriving from an OAuth-link
+  // redirect.
+  const [linkFlash, setLinkFlash] = useState<{
+    code: string;
+    kind: "success" | "error";
+  } | null>(readLinkFlashFromUrl);
+  const [settingsOpen, setSettingsOpen] = useState<boolean>(
+    () => readLinkFlashFromUrl() !== null,
+  );
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (!params.has("account_link") && !params.has("account_link_error")) {
+      return;
+    }
+    params.delete("account_link");
+    params.delete("account_link_error");
+    const search = params.toString();
+    const next =
+      window.location.pathname +
+      (search ? `?${search}` : "") +
+      window.location.hash;
+    window.history.replaceState({}, "", next);
+  }, []);
+
+  if (!user) {
+    return (
+      <>
+        <button
+          type="button"
+          className={styles.button}
+          onClick={loginWithGitHub}
+        >
+          <Github size={14} /> Log in with GitHub
+        </button>
+        <button
+          type="button"
+          className={styles.button}
+          onClick={loginWithGoogle}
+        >
+          <LogIn size={14} /> Log in with Google
+        </button>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className={styles.button}
+        onClick={() => setSettingsOpen(true)}
+      >
+        <Settings size={14} /> Account settings
+      </button>
+      <button type="button" className={styles.button} onClick={logout}>
+        <LogOut size={14} /> Log out
+      </button>
+      {/* Gating on `user` (in addition to `settingsOpen`) makes the
+          modal unmount the moment the user logs out, so it can't
+          keep rendering the previous user's cached identity list
+          during the brief window before SWR revalidates. */}
+      {settingsOpen && user && (
+        <AccountSettingsModal
+          onClose={() => {
+            setSettingsOpen(false);
+            setLinkFlash(null);
+          }}
+          initialFlash={linkFlash}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/app/src/components/AccountSettingsModal.module.css
+++ b/packages/app/src/components/AccountSettingsModal.module.css
@@ -203,3 +203,105 @@
 :global([data-color-scheme="dark"]) .allLinkedNote {
   color: #999;
 }
+
+/* `identityDate` already carries `margin-left: auto` to push the
+   right-side group (date + unlink-or-confirm-controls) away from
+   the icon/name. The actions sit next to the date, separated by
+   the parent flex `gap`. */
+.identityActions {
+  display: flex;
+  gap: 6px;
+}
+
+.unlinkButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: none;
+  cursor: pointer;
+  color: #888;
+}
+
+.unlinkButton:hover {
+  background: rgba(0, 0, 0, 0.05);
+  color: #c33;
+  border-color: rgba(204, 51, 51, 0.2);
+}
+
+.unlinkButton:focus-visible {
+  outline: 2px solid #4a90e2;
+  outline-offset: 1px;
+}
+
+.confirmUnlinkButton,
+.cancelUnlinkButton {
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.confirmUnlinkButton {
+  border: 1px solid #c33;
+  background: #c33;
+  color: #fff;
+}
+
+.confirmUnlinkButton:hover:not(:disabled) {
+  background: #a82828;
+}
+
+.confirmUnlinkButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.cancelUnlinkButton {
+  border: 1px solid #ccc;
+  background: none;
+  color: #444;
+}
+
+.cancelUnlinkButton:hover:not(:disabled) {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.cancelUnlinkButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.singleIdentityNote {
+  font-size: 12px;
+  color: #888;
+  margin: 8px 0 0;
+  font-style: italic;
+}
+
+:global([data-color-scheme="dark"]) .unlinkButton {
+  color: #999;
+}
+
+:global([data-color-scheme="dark"]) .unlinkButton:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #f88;
+  border-color: rgba(248, 136, 136, 0.25);
+}
+
+:global([data-color-scheme="dark"]) .cancelUnlinkButton {
+  border-color: #444;
+  color: #ccc;
+}
+
+:global([data-color-scheme="dark"]) .cancelUnlinkButton:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+:global([data-color-scheme="dark"]) .singleIdentityNote {
+  color: #999;
+}

--- a/packages/app/src/components/AccountSettingsModal.test.tsx
+++ b/packages/app/src/components/AccountSettingsModal.test.tsx
@@ -132,4 +132,155 @@ describe("AccountSettingsModal", () => {
       expect(screen.getByText(/could not load/i)).toBeTruthy();
     });
   });
+
+  describe("unlink", () => {
+    it("hides the unlink button and shows a note when only one identity is linked", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        jsonResponse([
+          { provider: "github", provider_id: "gh-1", created_at: 1 },
+        ]),
+      );
+
+      renderModal(<AccountSettingsModal onClose={() => {}} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("GitHub")).toBeTruthy();
+      });
+      expect(
+        screen.queryByRole("button", { name: /unlink github/i }),
+      ).toBeNull();
+      expect(
+        screen.getByText(/link another provider before unlinking/i),
+      ).toBeTruthy();
+    });
+
+    it("offers an unlink button per identity when multiple are linked", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        jsonResponse([
+          { provider: "github", provider_id: "gh-1", created_at: 1 },
+          { provider: "google", provider_id: "go-1", created_at: 2 },
+        ]),
+      );
+
+      renderModal(<AccountSettingsModal onClose={() => {}} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /unlink github/i }),
+        ).toBeTruthy();
+      });
+      expect(
+        screen.getByRole("button", { name: /unlink google/i }),
+      ).toBeTruthy();
+    });
+
+    it("requires a confirm step before sending the DELETE", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        jsonResponse([
+          { provider: "github", provider_id: "gh-1", created_at: 1 },
+          { provider: "google", provider_id: "go-1", created_at: 2 },
+        ]),
+      );
+
+      renderModal(<AccountSettingsModal onClose={() => {}} />);
+
+      const unlinkBtn = await screen.findByRole("button", {
+        name: /unlink github/i,
+      });
+
+      // First click: row enters confirm state, no DELETE yet.
+      act(() => {
+        unlinkBtn.click();
+      });
+
+      expect(screen.getByRole("button", { name: /^confirm$/i })).toBeTruthy();
+      expect(screen.getByRole("button", { name: /^cancel$/i })).toBeTruthy();
+      // Only the original GET — no DELETE yet.
+      expect(vi.mocked(fetch).mock.calls).toHaveLength(1);
+    });
+
+    it("DELETEs the identity and refreshes the list when Confirm is clicked", async () => {
+      // Initial GET with two identities, then DELETE, then refresh GET
+      // with one identity.
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(
+          jsonResponse([
+            { provider: "github", provider_id: "gh-1", created_at: 1 },
+            { provider: "google", provider_id: "go-1", created_at: 2 },
+          ]),
+        )
+        .mockResolvedValueOnce(jsonResponse({ ok: true }))
+        .mockResolvedValueOnce(
+          jsonResponse([
+            { provider: "google", provider_id: "go-1", created_at: 2 },
+          ]),
+        );
+
+      renderModal(<AccountSettingsModal onClose={() => {}} />);
+
+      const unlinkBtn = await screen.findByRole("button", {
+        name: /unlink github/i,
+      });
+      act(() => {
+        unlinkBtn.click();
+      });
+      const confirmBtn = await screen.findByRole("button", {
+        name: /^confirm$/i,
+      });
+      await act(async () => {
+        confirmBtn.click();
+      });
+
+      await waitFor(() => {
+        // After the DELETE + revalidate, GitHub is gone; Google remains.
+        expect(screen.queryByText("GitHub")).toBeNull();
+        expect(screen.getByText("Google")).toBeTruthy();
+      });
+
+      // Inspect the wire: second call should be a DELETE.
+      const deleteCall = vi.mocked(fetch).mock.calls[1];
+      expect(deleteCall[0]).toBe("/auth/identities/github/gh-1");
+      expect(deleteCall[1]?.method).toBe("DELETE");
+    });
+
+    it("surfaces the last-identity error on a 409 response", async () => {
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(
+          jsonResponse([
+            { provider: "github", provider_id: "gh-1", created_at: 1 },
+            { provider: "google", provider_id: "go-1", created_at: 2 },
+          ]),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse(
+            {
+              error: "Cannot remove your last sign-in method.",
+              code: "last_identity",
+            },
+            409,
+          ),
+        );
+
+      renderModal(<AccountSettingsModal onClose={() => {}} />);
+
+      const unlinkBtn = await screen.findByRole("button", {
+        name: /unlink github/i,
+      });
+      act(() => {
+        unlinkBtn.click();
+      });
+      const confirmBtn = await screen.findByRole("button", {
+        name: /^confirm$/i,
+      });
+      await act(async () => {
+        confirmBtn.click();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert").textContent).toMatch(
+          /only sign-in method/i,
+        );
+      });
+    });
+  });
 });

--- a/packages/app/src/components/AccountSettingsModal.tsx
+++ b/packages/app/src/components/AccountSettingsModal.tsx
@@ -1,6 +1,6 @@
-import { Github, LogIn, X } from "lucide-react";
-import { useEffect, useRef } from "react";
-import useSWR from "swr";
+import { Github, LogIn, Trash2, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import useSWR, { useSWRConfig } from "swr";
 import { jsonFetcher } from "../lib/fetcher";
 import styles from "./AccountSettingsModal.module.css";
 
@@ -73,7 +73,18 @@ export function AccountSettingsModal({
     "/auth/identities",
     jsonFetcher,
   );
+  const { mutate: globalMutate } = useSWRConfig();
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Two-click confirm pattern for unlink: first click promotes the row
+  // into a "Confirm / Cancel" state, second click on Confirm fires the
+  // DELETE. Avoids the native window.confirm() (which has uneven UX
+  // across browsers) and a modal-on-modal (which would be heavy for a
+  // small action). `confirmingId` is the row key (`${provider}:${id}`)
+  // currently in the confirm state, or null.
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [unlinkingId, setUnlinkingId] = useState<string | null>(null);
+  const [unlinkError, setUnlinkError] = useState<string | null>(null);
 
   // Focus the close button on mount so Esc-to-close works without
   // the user first having to tab into the dialog.
@@ -82,13 +93,21 @@ export function AccountSettingsModal({
   }, []);
 
   // Esc-to-close. The backdrop click and X button cover mouse users.
+  // If a row is mid-confirm, Esc cancels the confirm instead of
+  // closing the whole modal — the user expects Esc to back out of the
+  // most-recent prompt first.
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key !== "Escape") return;
+      if (confirmingId !== null) {
+        setConfirmingId(null);
+        return;
+      }
+      onClose();
     };
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
-  }, [onClose]);
+  }, [confirmingId, onClose]);
 
   const linkedProviders = new Set(
     (identities ?? []).map((row) => row.provider),
@@ -97,6 +116,7 @@ export function AccountSettingsModal({
     (p) => !linkedProviders.has(p),
   );
   const isLoading = identities === undefined && loadError === undefined;
+  const canUnlinkAny = identities !== undefined && identities.length > 1;
 
   const flashConfig = initialFlash
     ? (FLASH_MESSAGES[initialFlash.code] ?? {
@@ -104,6 +124,43 @@ export function AccountSettingsModal({
         text: "Account linking returned an unrecognized status.",
       })
     : null;
+
+  const handleUnlink = async (provider: string, providerId: string) => {
+    const rowId = `${provider}:${providerId}`;
+    setUnlinkingId(rowId);
+    setUnlinkError(null);
+    try {
+      const res = await fetch(
+        `/auth/identities/${encodeURIComponent(provider)}/${encodeURIComponent(providerId)}`,
+        { method: "DELETE" },
+      );
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as {
+          error?: string;
+          code?: string;
+        };
+        if (res.status === 409 && body.code === "last_identity") {
+          setUnlinkError(
+            "This is your only sign-in method — link another provider first.",
+          );
+        } else {
+          setUnlinkError(body.error ?? `Request failed (${res.status}).`);
+        }
+        return;
+      }
+      // Refresh the SWR cache so the row disappears. mutate() with no
+      // value triggers a revalidation against the server, which is the
+      // right behavior here — we want the canonical post-delete list.
+      await globalMutate("/auth/identities");
+      setConfirmingId(null);
+    } catch (err) {
+      setUnlinkError(
+        err instanceof Error ? err.message : "Could not unlink. Try again.",
+      );
+    } finally {
+      setUnlinkingId(null);
+    }
+  };
 
   return (
     <div
@@ -146,6 +203,12 @@ export function AccountSettingsModal({
           </div>
         )}
 
+        {unlinkError !== null && (
+          <div role="alert" className={`${styles.flash} ${styles.flashError}`}>
+            {unlinkError}
+          </div>
+        )}
+
         {/* Single loading / error gate around both sections. Rendering
             the sections eagerly (with the connect-buttons list filled in
             from an empty `linkedProviders` Set) caused the modal to
@@ -167,22 +230,72 @@ export function AccountSettingsModal({
                 <p className={styles.empty}>No providers linked.</p>
               ) : (
                 <ul className={styles.identityList}>
-                  {identities.map((identity) => (
-                    <li
-                      key={`${identity.provider}:${identity.provider_id}`}
-                      className={styles.identityItem}
-                    >
-                      <ProviderIcon provider={identity.provider} />
-                      <span className={styles.identityProvider}>
-                        {PROVIDER_LABELS[identity.provider as ProviderName] ??
-                          identity.provider}
-                      </span>
-                      <span className={styles.identityDate}>
-                        Connected {formatDate(identity.created_at)}
-                      </span>
-                    </li>
-                  ))}
+                  {identities.map((identity) => {
+                    const rowId = `${identity.provider}:${identity.provider_id}`;
+                    const isConfirming = confirmingId === rowId;
+                    const isUnlinking = unlinkingId === rowId;
+                    return (
+                      <li key={rowId} className={styles.identityItem}>
+                        <ProviderIcon provider={identity.provider} />
+                        <span className={styles.identityProvider}>
+                          {PROVIDER_LABELS[identity.provider as ProviderName] ??
+                            identity.provider}
+                        </span>
+                        <span className={styles.identityDate}>
+                          Connected {formatDate(identity.created_at)}
+                        </span>
+                        {canUnlinkAny &&
+                          (isConfirming ? (
+                            <span className={styles.identityActions}>
+                              <button
+                                type="button"
+                                className={styles.confirmUnlinkButton}
+                                onClick={() =>
+                                  handleUnlink(
+                                    identity.provider,
+                                    identity.provider_id,
+                                  )
+                                }
+                                disabled={isUnlinking}
+                              >
+                                {isUnlinking ? "Unlinking…" : "Confirm"}
+                              </button>
+                              <button
+                                type="button"
+                                className={styles.cancelUnlinkButton}
+                                onClick={() => setConfirmingId(null)}
+                                disabled={isUnlinking}
+                              >
+                                Cancel
+                              </button>
+                            </span>
+                          ) : (
+                            <button
+                              type="button"
+                              className={styles.unlinkButton}
+                              onClick={() => {
+                                setUnlinkError(null);
+                                setConfirmingId(rowId);
+                              }}
+                              aria-label={`Unlink ${
+                                PROVIDER_LABELS[
+                                  identity.provider as ProviderName
+                                ] ?? identity.provider
+                              }`}
+                              title="Unlink"
+                            >
+                              <Trash2 size={14} />
+                            </button>
+                          ))}
+                      </li>
+                    );
+                  })}
                 </ul>
+              )}
+              {identities.length === 1 && (
+                <p className={styles.singleIdentityNote}>
+                  Link another provider before unlinking this one.
+                </p>
               )}
             </section>
 

--- a/packages/app/src/components/DocumentSidebar.module.css
+++ b/packages/app/src/components/DocumentSidebar.module.css
@@ -106,25 +106,6 @@
   gap: 8px;
 }
 
-.authButton {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  width: 100%;
-  padding: 6px 10px;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  background: none;
-  cursor: pointer;
-  font-size: 13px;
-  color: #666;
-}
-
-.authButton:hover {
-  background: rgba(0, 0, 0, 0.05);
-}
-
 :global([data-color-scheme="dark"]) .sidebar {
   background: #1e1e1e;
   border-right-color: #333;
@@ -172,15 +153,6 @@
 
 :global([data-color-scheme="dark"]) .footer {
   border-top-color: #333;
-}
-
-:global([data-color-scheme="dark"]) .authButton {
-  border-color: #444;
-  color: #999;
-}
-
-:global([data-color-scheme="dark"]) .authButton:hover {
-  background: rgba(255, 255, 255, 0.08);
 }
 
 /* Visually hidden but accessible to screen readers. Used for an

--- a/packages/app/src/components/DocumentSidebar.tsx
+++ b/packages/app/src/components/DocumentSidebar.tsx
@@ -1,19 +1,11 @@
-import {
-  Github,
-  LogIn,
-  LogOut,
-  Menu,
-  PanelLeftClose,
-  Plus,
-  Settings,
-} from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { Menu, PanelLeftClose, Plus } from "lucide-react";
+import { useMemo, useState } from "react";
 import { useAuth } from "../auth/useAuth";
 import { getConversionErrorMessage } from "../documents/conversion-error-message";
 import { useDocumentManagerContext } from "../documents/useDocumentManagerContext";
 import type { DocumentMeta } from "../documents/types";
 import type { ColorSchemePreference } from "../hooks/useColorScheme";
-import { AccountSettingsModal } from "./AccountSettingsModal";
+import { AccountFooter } from "./AccountFooter";
 import { ColorSchemeSwitcher } from "./ColorSchemeSwitcher";
 import { DocumentListItem } from "./DocumentListItem";
 import { NetworkStatus } from "./NetworkStatus";
@@ -22,26 +14,6 @@ import styles from "./DocumentSidebar.module.css";
 interface DocumentSidebarProps {
   colorSchemePreference: ColorSchemePreference;
   onColorSchemeChange: (next: ColorSchemePreference) => void;
-}
-
-// Pull the account-link flash from the current URL — set by the
-// worker's redirect after the OAuth callback resolves a link
-// operation. Returns null when neither query param is present
-// (the common case: ordinary navigation, not arriving from a link
-// flow).
-function readLinkFlashFromUrl(): {
-  code: string;
-  kind: "success" | "error";
-} | null {
-  if (typeof window === "undefined") return null;
-  const params = new URLSearchParams(window.location.search);
-  const success = params.get("account_link");
-  const error = params.get("account_link_error");
-  if (!success && !error) return null;
-  return {
-    code: error ?? success ?? "",
-    kind: error ? "error" : "success",
-  };
 }
 
 export function DocumentSidebar({
@@ -60,38 +32,14 @@ export function DocumentSidebar({
     conversionErrors,
   } = useDocumentManagerContext();
 
-  const { user, loginWithGitHub, loginWithGoogle, logout } = useAuth();
+  // The convert action only makes sense when the user is logged in,
+  // i.e. when there is a synced destination to migrate the doc into.
+  // Auth state lives in `AccountFooter`'s subtree for the rest of the
+  // sidebar's account-related UI; the sidebar still needs `user` here
+  // to decide whether to expose the convert affordance per row.
+  const { user } = useAuth();
 
   const [collapsed, setCollapsed] = useState(false);
-
-  // Surface the post-OAuth-callback flash. The worker redirects to
-  // `/?account_link=success|already_linked` on a successful link or
-  // `/?account_link_error=...` on conflict; we read the params at
-  // mount via lazy state init (avoids the React lint trap of
-  // synchronously setting state in an effect), pop the modal open,
-  // and the effect below strips the params from the URL so a refresh
-  // doesn't re-show the flash.
-  const [linkFlash, setLinkFlash] = useState<{
-    code: string;
-    kind: "success" | "error";
-  } | null>(readLinkFlashFromUrl);
-  const [settingsOpen, setSettingsOpen] = useState<boolean>(
-    () => readLinkFlashFromUrl() !== null,
-  );
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    if (!params.has("account_link") && !params.has("account_link_error")) {
-      return;
-    }
-    params.delete("account_link");
-    params.delete("account_link_error");
-    const search = params.toString();
-    const next =
-      window.location.pathname +
-      (search ? `?${search}` : "") +
-      window.location.hash;
-    window.history.replaceState({}, "", next);
-  }, []);
 
   // Announcement string for the convert-to-synced aria-live region.
   // The convert-to-synced button itself updates its `title` /
@@ -147,8 +95,6 @@ export function DocumentSidebar({
     );
   }
 
-  // The convert action only makes sense when the user is logged in,
-  // i.e. when there is a synced destination to migrate the doc into.
   const onConvert = user !== null ? convertToSynced : undefined;
 
   const renderGroup = (docs: DocumentMeta[]) =>
@@ -209,59 +155,12 @@ export function DocumentSidebar({
       </div>
       <div className={styles.footer}>
         <NetworkStatus />
-        {user ? (
-          <>
-            <button
-              type="button"
-              className={styles.authButton}
-              onClick={() => setSettingsOpen(true)}
-            >
-              <Settings size={14} /> Account settings
-            </button>
-            <button
-              type="button"
-              className={styles.authButton}
-              onClick={logout}
-            >
-              <LogOut size={14} /> Log out
-            </button>
-          </>
-        ) : (
-          <>
-            <button
-              type="button"
-              className={styles.authButton}
-              onClick={loginWithGitHub}
-            >
-              <Github size={14} /> Log in with GitHub
-            </button>
-            <button
-              type="button"
-              className={styles.authButton}
-              onClick={loginWithGoogle}
-            >
-              <LogIn size={14} /> Log in with Google
-            </button>
-          </>
-        )}
+        <AccountFooter />
         <ColorSchemeSwitcher
           preference={colorSchemePreference}
           onChange={onColorSchemeChange}
         />
       </div>
-      {/* Gating on `user` (in addition to `settingsOpen`) makes the
-          modal unmount the moment the user logs out, so it can't keep
-          rendering the previous user's cached identity list during
-          the brief window before SWR revalidates. */}
-      {settingsOpen && user && (
-        <AccountSettingsModal
-          onClose={() => {
-            setSettingsOpen(false);
-            setLinkFlash(null);
-          }}
-          initialFlash={linkFlash}
-        />
-      )}
     </div>
   );
 }

--- a/packages/worker/src/auth/index.ts
+++ b/packages/worker/src/auth/index.ts
@@ -1,4 +1,6 @@
 import type { Hono } from "hono";
+import * as v from "valibot";
+import { oauthIdentityRevokeParamSchema } from "../schemas";
 import type { AppBindings } from "../types";
 import { registerGitHubAuth } from "./github";
 import { registerGoogleAuth } from "./google";
@@ -7,6 +9,7 @@ import {
   getCurrentUser,
   listOAuthIdentities,
   requireSession,
+  revokeOAuthIdentity,
 } from "./session";
 
 export function registerAuthRoutes(app: Hono<AppBindings>) {
@@ -33,6 +36,51 @@ export function registerAuthRoutes(app: Hono<AppBindings>) {
     }
     const identities = await listOAuthIdentities(c, userId);
     return c.json(identities);
+  });
+
+  // Detach an OAuth identity from the current user (the unlink
+  // counterpart to the `/auth/{provider}` connect flow). 409 with
+  // `code: "last_identity"` when refused — the server-side guard
+  // refuses to leave a user with zero identities (which would lock
+  // them out, since login resolves users via `(provider,
+  // provider_id)`). The settings UI hides the Unlink button when
+  // there's only one identity, but the server check is the actual
+  // safety guarantee.
+  app.delete("/auth/identities/:provider/:provider_id", async (c) => {
+    const userId = await requireSession(c);
+    if (userId === null) {
+      return c.json({ error: "Not authenticated" }, 401);
+    }
+    const paramsResult = v.safeParse(oauthIdentityRevokeParamSchema, {
+      provider: c.req.param("provider"),
+      provider_id: c.req.param("provider_id"),
+    });
+    if (!paramsResult.success) {
+      return c.json(
+        { error: "Invalid identity", details: paramsResult.issues },
+        400,
+      );
+    }
+    const { provider, provider_id } = paramsResult.output;
+    const outcome = await revokeOAuthIdentity(
+      c,
+      userId,
+      provider,
+      provider_id,
+    );
+    if (outcome === "revoked") {
+      return c.json({ ok: true });
+    }
+    if (outcome === "last_identity") {
+      return c.json(
+        {
+          error: "Cannot remove your last sign-in method.",
+          code: "last_identity",
+        },
+        409,
+      );
+    }
+    return c.json({ error: "Not found" }, 404);
   });
 
   app.post("/auth/logout", (c) => {

--- a/packages/worker/src/auth/session.ts
+++ b/packages/worker/src/auth/session.ts
@@ -216,20 +216,12 @@ export async function getCurrentUser(c: AppContext) {
     return null;
   }
 
-  // `/auth/me` carries a single `provider` string for legacy callers
-  // (the Authenticated header in the sidebar reads it as a label).
-  // Picking the earliest-attached identity gives a stable answer
-  // across linking events: linking a second provider doesn't flip
-  // the displayed provider, only the dedicated `/auth/identities`
-  // endpoint reflects the full multi-identity state.
-  const user = await c.env.DB.prepare(
-    `SELECT u.id AS id, oi.provider AS provider
-     FROM users u
-     LEFT JOIN oauth_identities oi ON oi.user_id = u.id
-     WHERE u.id = ?
-     ORDER BY oi.created_at ASC
-     LIMIT 1`,
-  )
+  // `/auth/me` returns just the `id` — enough for the client to know
+  // "I am logged in" and to bind workspace-scoped queries. The full
+  // multi-identity state (which providers are linked) lives at
+  // `GET /auth/identities` and is fetched only when the
+  // account-settings UI needs it.
+  const user = await c.env.DB.prepare(`SELECT id FROM users WHERE id = ?`)
     .bind(userId)
     .first();
 
@@ -264,4 +256,59 @@ export async function listOAuthIdentities(
     .bind(userId)
     .all<OAuthIdentitySummary>();
   return results;
+}
+
+export type RevokeOAuthIdentityOutcome =
+  | "revoked"
+  | "last_identity"
+  | "not_found";
+
+/**
+ * Detach an OAuth identity from `userId`. Refuses to remove the user's
+ * last identity — leaving a user with zero identities would lock them
+ * out (login resolves the user via `(provider, provider_id)`, so a
+ * user with no identities is unreachable). Three outcomes:
+ *
+ * - `"revoked"` — identity removed.
+ * - `"last_identity"` — the row exists for this user but is the only
+ *   one. Refused; the row stays.
+ * - `"not_found"` — no row matches `(userId, provider, provider_id)`.
+ *
+ * The DELETE is a single atomic statement: the subquery checks the
+ * count of identities for the user as part of the same statement, so
+ * two concurrent revocations from the same user can't both pass the
+ * check. D1 serializes writers, so the second concurrent statement
+ * sees the post-first-delete count.
+ */
+export async function revokeOAuthIdentity(
+  c: AppContext,
+  userId: number,
+  provider: string,
+  providerId: string,
+): Promise<RevokeOAuthIdentityOutcome> {
+  const result = await c.env.DB.prepare(
+    `DELETE FROM oauth_identities
+     WHERE user_id = ?
+       AND provider = ?
+       AND provider_id = ?
+       AND (SELECT COUNT(*) FROM oauth_identities WHERE user_id = ?) > 1`,
+  )
+    .bind(userId, provider, providerId, userId)
+    .run();
+
+  if ((result.meta.changes ?? 0) > 0) {
+    return "revoked";
+  }
+
+  // Disambiguate: the DELETE matched zero rows either because the
+  // identity doesn't exist for this user, or because it does exist
+  // but it's the user's only one (the count guard rejected the
+  // delete). A single SELECT distinguishes them.
+  const exists = await c.env.DB.prepare(
+    `SELECT 1 FROM oauth_identities
+     WHERE user_id = ? AND provider = ? AND provider_id = ?`,
+  )
+    .bind(userId, provider, providerId)
+    .first();
+  return exists ? "last_identity" : "not_found";
 }

--- a/packages/worker/src/schemas.ts
+++ b/packages/worker/src/schemas.ts
@@ -160,3 +160,16 @@ export const assetNameSchema = v.pipe(
   v.string(),
   v.regex(ASSET_NAME_PATTERN, "Invalid asset name"),
 );
+
+// URL-param schema for `DELETE /auth/identities/:provider/:provider_id`.
+// `provider` is closed-set — only the providers we register OAuth flows
+// for can land in `oauth_identities`, so the API surface stays
+// constrained to the same set. `provider_id` comes from the upstream
+// IdP (numeric for GitHub, opaque `sub` for Google); we don't enforce
+// a specific format, just non-empty + bounded length so a pathological
+// client can't smuggle an unbounded string into a parameterized
+// statement.
+export const oauthIdentityRevokeParamSchema = v.object({
+  provider: v.picklist(["github", "google"]),
+  provider_id: v.pipe(v.string(), v.minLength(1), v.maxLength(256)),
+});


### PR DESCRIPTION
## Summary

Two related changes, separate commits:

1. **`feat(auth): disconnect a linked OAuth provider`** — the unlink counterpart to the link flow that landed in #454. Includes a small adjacent cleanup: `User.provider` was unused everywhere in the app, dropped.
2. **`refactor(app): extract AccountFooter from DocumentSidebar`** — the sidebar's name implies "document list," but it had accumulated account-management concerns (URL flash parsing, settings-modal lifecycle, login/logout/settings buttons). Pulled them into a new \`<AccountFooter />\` component sitting in the sidebar's footer next to \`<NetworkStatus />\` and \`<ColorSchemeSwitcher />\`.

## Disconnect — backend

- **\`DELETE /auth/identities/:provider/:provider_id\`** in \`auth/index.ts\`.
- **\`revokeOAuthIdentity\` helper** in \`auth/session.ts\`. The DELETE is one atomic statement with a count guard via subquery, so two concurrent revocations from the same user can't both pass the check (D1 serializes writers; the second statement sees the post-first-delete count). Three outcomes:
  - \`revoked\` → 200
  - \`last_identity\` → 409 with \`code: \"last_identity\"\` for the client
  - \`not_found\` → 404
- **\`oauthIdentityRevokeParamSchema\`** in \`schemas.ts\` validates the URL params. Provider is closed-set (\`{github, google}\`); provider_id is non-empty bounded string.

The server-side last-identity guard is the actual safety guarantee — leaving a user with zero identities would lock them out (login resolves users via \`(provider, provider_id)\`).

## Disconnect — frontend

- **Per-row Unlink button** in \`AccountSettingsModal\`. Two-click in-row Confirm/Cancel pattern instead of \`window.confirm()\` (uneven cross-browser UX) or modal-on-modal (heavy for a small action).
- **Esc** cancels the most-recent confirm before falling through to the modal close.
- **Hidden when there's only one identity** — with an explanatory note ("Link another provider before unlinking this one"). UI gating is just affordance; server is the source of truth.
- **Inline error banner** for the 409 last-identity case.
- **SWR cache refresh** on success so the row disappears from the list.

## \`User.provider\` cleanup

The \`/auth/me\` \`provider\` field was a vestige from before account linking — it returned the *earliest-attached* provider as a single string for "logged in via X" display. Nothing in the app actually read it (verified: only \`OAuthIdentity.provider\` from \`/auth/identities\` is read). Dropped:

- \`User\` type loses \`provider\`
- \`getCurrentUser\` SQL drops the \`LEFT JOIN oauth_identities\` and just selects \`id\`

## AccountFooter extraction

Before: \`DocumentSidebar\` owned the \`linkFlash\` state, the URL-strip useEffect, the \`settingsOpen\` state, the modal mount, and the login/logout/settings buttons. Conceptually misplaced — the sidebar should be a document-list component.

After: \`AccountFooter\` owns all of it. Sidebar just renders \`<AccountFooter />\` in its footer next to the network status and color-scheme switcher. The sidebar still reads \`user\` from \`useAuth\` to decide whether to expose the per-row convert affordance, but everything else moves out.

CSS: the \`authButton\` styling moved to a new \`AccountFooter.module.css\`. Sidebar's CSS module loses the rules.

## Tests

- 5 new modal tests covering the unlink flow:
  - hide-button + note when single identity
  - both buttons offered when multi
  - Confirm step required (DELETE not fired on first click)
  - DELETE wire shape + post-delete list refresh
  - 409 last-identity → inline alert
- App suite: 88 → **93 passing**
- Lint + typecheck clean both packages

## Test plan

- [x] \`pnpm --filter app test\` — 93/93 pass
- [x] \`pnpm --filter app lint\` — clean
- [x] \`pnpm --filter app typecheck\` — clean
- [x] \`pnpm --filter anipres-worker test\` — 42/42 pass
- [x] \`pnpm --filter anipres-worker typecheck\` — clean
- [ ] Manual: log in via GitHub, link Google, then unlink GitHub → row disappears, session continues to work via Google
- [ ] Manual: with only one identity linked, modal shows the explanatory note and no Unlink button
- [ ] Manual: hit \`DELETE /auth/identities/{provider}/{id}\` directly via curl when only one identity exists → 409 with \`code: \"last_identity\"\`
- [ ] Manual: settings panel opens / closes / login / logout cycles cleanly with the AccountFooter extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)