### PR TITLE
docs: sync TODO + design doc to reflect Phase 6 done

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8,15 +8,6 @@ Tasks deferred during development that should be addressed before production rel
 
 - **Google OAuth scope for email-based linking**: Currently requests `openid` only and identifies users by `sub`. The shipped account-linking flow uses an explicit "Connect" entry point (no email matching needed), so this remains as-is. _If_ a future merge / email-based-suggest feature is added, widen to `openid email`.
 
-## Phase 6 (in progress)
-
-Phases 1–5 landed. Phase 6 is partially done — see [design-server-sync.md § Phase 6](./design-server-sync.md#phase-6--anonymous-mode--polish-partial-) for the breakdown of what's complete vs. remaining.
-
-Remaining for Phase 6:
-
-- **Account-settings UI extensions**. The modal opened from the sidebar's "Account settings" button is the home for account-related controls; today it carries linked-providers + connect-another. Future content goes here: disconnect (see Authentication section), workspace name editing once Extension A makes that user-visible, sign-out-from-all-devices.
-- **Convert-to-synced polish** — see the dedicated section below.
-
 ## Before first deploy
 
 Operational items the code can't cover. Each of these must be set before `wrangler deploy` (prod) or `wrangler deploy --env preview` (preview) succeeds against real Cloudflare resources.
@@ -51,14 +42,3 @@ See [Post-Launch Hardening](./design-server-sync.md#post-launch-hardening) in th
 - **R2 storage growth alarm**.
 - **Workers analytics dashboard review** for unusual per-route request volume.
 - **Rate limiting** (Workers Rate Limiting API, per-user, applied to asset upload / snapshot push / doc create with 429 + `Retry-After`).
-
-## Convert-to-synced polish
-
-Follow-ups deferred from the convert-to-synced PRs (#431–#435) — all four shipped together.
-
-Done:
-
-- **Friendly error-message mapping**: `getConversionErrorMessage` in `documents/conversion-error-message.ts` maps `Asset upload failed: 413` → "This file is too large", `AbortError`/`TimeoutError` → "Upload timed out…", network `TypeError` → "Couldn't reach the server…", etc. Used by both the per-doc button title/aria-label and the new `aria-live` region.
-- **`aria-live` region for screen readers**: `<div role="status" aria-live="polite">` rendered above the sidebar footer (visually hidden via `srOnly`). Announces "Uploading {title}…" on convert start and "Failed to upload {title}: {friendly}" on failure.
-- **Asset-upload concurrency cap**: `uploadAssetDataUrls` now uses a `pooledMap` helper with `ASSET_UPLOAD_CONCURRENCY = 4`. Keeps the pool full (work-stealing pattern, not batched) so the slowest upload in a wave doesn't gate the next wave.
-- **Tighten internal `composeWithTimeout` / default-helper signatures**: Internal `composeWithTimeout` and `defaultUploadAsset` / `defaultPushSnapshot` use `AbortSignal | undefined` instead of `?: AbortSignal`. Public `ConvertLocalDocToSyncedParams` keeps `?` for consumer ergonomics.

--- a/docs/design-server-sync.md
+++ b/docs/design-server-sync.md
@@ -9,7 +9,7 @@
 
 ## Status
 
-Phases 1–5 are landed on `feature/sync-server`. Phase 6 is partial — online/offline indicator, reconnect UX, input validation, anonymous-mode preservation are done; user profile/settings and account linking are pending. See [`TODO.md`](./TODO.md) for the residual list.
+All six implementation phases are landed on `feature/sync-server`. The remaining work is operational (deploy to real Cloudflare resources — see [`TODO.md`](./TODO.md) § Before first deploy) plus deferred follow-ups (merge two accounts on conflict, post-launch hardening). The OAuth flow has been exercised end-to-end locally; the next milestone is a preview deploy.
 
 The implementation diverged from the original spec in a few load-bearing places — workspaces between users and documents (pre-positions Extension A), `oauth_identities` as a separate table for future account linking, INTEGER PKs for server-allocated entities (users, workspaces) but TEXT UUID v7 for documents (client-allocated), `initializing_at` / `deleting_at` lifecycle columns, an `assets` GC table, and a single-endpoint PUT-as-upsert document API. The "Database Schema", "API Design", and "Worker Structure" sections below have been rewritten to match the as-built; the philosophy sections (Dual-Mode, Offline, etc.) describe decisions that survived intact.
 
@@ -450,23 +450,22 @@ The `packages/anipres` library exports the shape schema descriptors via `anipres
 - Offline cold-start path: `GET /api/documents/:id/offline-cache` falls back to local IDB cache when the network is unreachable
 - Reconnect (`reconcileOfflineEdits` in `reconnect.ts`): push-or-fork against the server's snapshot version. Fork mints a new UUID v7 client-side and lands past the synced list's tail.
 
-### Phase 6 — Anonymous mode + polish (partial) 🟡
-
-Done:
+### Phase 6 — Anonymous mode + polish ✅
 
 - Anonymous mode (IDB-only) preserved alongside synced mode; `DocumentManagerProvider` accepts an optional `syncedRepository`
 - Online/offline indicator + reconnect banner (`NetworkStatus`)
-- Convert-to-synced UX with per-doc spinner / error / retry
+- Convert-to-synced UX: per-doc spinner / error / retry; friendly error-message mapping (`getConversionErrorMessage` in `documents/conversion-error-message.ts`); polite `aria-live` region for screen-reader announcements; asset-upload concurrency cap (`ASSET_UPLOAD_CONCURRENCY = 4`, work-stealing pattern)
 - Input validation: valibot schemas at the worker boundary, with worker-side test pipeline
 - Workspace-discovery error UI (visible message instead of blank screen)
-- Account-settings modal opened from the sidebar's `AccountFooter`; lists linked OAuth identities (`GET /auth/identities`)
-- Account linking — the existing OAuth callbacks branch on the session cookie: a logged-in user completing the OAuth dance attaches the new `(provider, provider_id)` to the current `user_id` (via `attachIdentityToCurrentUser` in `auth/session.ts`); a logged-out user follows the existing login flow. Conflict ("provider account is already linked to a different user") surfaces as a redirect-flash error.
+- Account-settings modal opened from the sidebar's `AccountFooter`; lists linked OAuth identities (`GET /auth/identities`); fetches via SWR with focus-revalidation
+- Account linking — existing OAuth callbacks branch on the session cookie: a logged-in user completing the OAuth dance attaches the new `(provider, provider_id)` to the current `user_id` (via `attachIdentityToCurrentUser` in `auth/session.ts`); a logged-out user follows the existing login flow. Conflict ("provider account already linked to a different user") surfaces as a redirect-flash error.
 - Disconnect a linked provider — `DELETE /auth/identities/:provider/:provider_id` with a server-side "can't remove your last sign-in method" guard (atomic single-statement check via subquery); two-click in-row Confirm/Cancel UI in the settings modal
+- SWR migration of all auth-context fetches (`/auth/me`, `/auth/identities`, `/api/workspaces`); cache-wipe on logout via `globalMutate(() => true, …)` so no auth-scoped data lingers post-session
+- OAuth cookie / redirect_uri robustness: cookies use conditional `secure` attribute (HTTPS-only in prod, accepted on HTTP localhost); Google `redirect_uri` derived from explicit `PUBLIC_BASE_URL` env var (per-environment, see `.dev.vars.example` for local setup); per-failure-path logging in the Google callback for debuggable misconfigurations
 
-Remaining (see [TODO.md](./TODO.md)):
+Deferred (see [TODO.md](./TODO.md)):
 
 - Merge two accounts on conflict (a meaningfully bigger feature; tracked separately)
-- Convert-to-synced polish (friendly error mapping, `aria-live` announce, asset-upload concurrency cap)
 
 (Rate limiting was originally listed under Phase 6; see [Post-Launch Hardening](./TODO.md#post-launch-hardening) in TODO.md for why it moved.)
 


### PR DESCRIPTION
## Summary

Pure docs update. Phase 6 finished landing across PRs #454–#459; the docs were still saying "Phase 6 (in progress)" with stale Remaining lists.

## What changed

**\`docs/TODO.md\`**:
- Drop the \"Phase 6 (in progress)\" section. Its \"Remaining\" items either shipped (disconnect, in #458) or were speculative future content (workspace renaming, sign-out-from-all-devices) that doesn't need TODO tracking yet.
- Drop the \"Convert-to-synced polish\" section. All four sub-items shipped in #457; keeping a fully-Done section is git-history territory, not TODO.
- Active sections kept: Authentication follow-ups (merge accounts, Google scope), Before first deploy (operational), Preview architecture (A5-ii → A4 audit), Post-launch hardening.

**\`docs/design-server-sync.md\`**:
- Status preface: \"Phases 1–5 are landed... Phase 6 is partial\" → \"All six implementation phases are landed. Remaining work is operational + deferred follow-ups\".
- Phase 6 detail section: \`(partial) 🟡\` → \`✅\`. Done list expanded to include the convert-to-synced polish, disconnect, SWR migration of all auth fetches + cache-wipe-on-logout, and the OAuth cookie / redirect_uri robustness work shipped in #455–#459. Only \"merge two accounts\" remains in Deferred.

## Test plan

- [x] No code changes
- [ ] Spot-check: rendered TOC anchors still resolve, no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)