### PR TITLE
chore(anipres): drop CJS build, ship ESM-only

### DIFF
--- a/.changeset/anipres-esm-only.md
+++ b/.changeset/anipres-esm-only.md
@@ -1,0 +1,17 @@
+---
+"anipres": minor
+---
+
+ESM-only — drop the CJS build.
+
+The package now ships only an ESM build. The `./schema` subpath was already ESM-only (no `require` branch in `exports`) since it was added; consolidating the main entry to match.
+
+Drops from `package.json`:
+
+- `main` field (was the `.cjs` artifact)
+- `module` field (redundant now that `exports` is the single source)
+- The `require` branch in `exports."."`
+
+The `vite.config.ts` lib config now pins `formats: ["es"]` so vite stops emitting `.cjs` outputs alongside the ESM ones.
+
+This is a breaking change for consumers using `require("anipres")` from a CJS context. ESM consumers (the dominant pattern in modern React tooling — Vite, Next.js 13+, Webpack 5+, Cloudflare Workers, etc.) are unaffected. Internal consumers in this repo (`packages/app` via Vite, `packages/worker` via workerd) already use ESM.

--- a/packages/anipres/package.json
+++ b/packages/anipres/package.json
@@ -2,25 +2,18 @@
   "name": "anipres",
   "version": "0.12.0",
   "type": "module",
-  "main": "./dist/anipres.cjs",
-  "module": "./dist/anipres.js",
   "files": [
     "dist"
   ],
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/anipres.js"
-      },
-      "require": "./dist/anipres.cjs"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/anipres.js"
     },
     "./anipres.css": "./dist/anipres.css",
     "./schema": {
-      "import": {
-        "types": "./dist/schema.d.ts",
-        "default": "./dist/schema.js"
-      }
+      "types": "./dist/schema.d.ts",
+      "default": "./dist/schema.js"
     }
   },
   "types": "./dist/index.d.ts",

--- a/packages/anipres/vite.config.ts
+++ b/packages/anipres/vite.config.ts
@@ -17,6 +17,11 @@ export default defineConfig({
         anipres: path.resolve(__dirname, "src/index.ts"),
         schema: path.resolve(__dirname, "src/schema.ts"),
       },
+      // ESM-only. Vite's default for multi-entry libs is `["es", "cjs"]`,
+      // which would emit `.cjs` artifacts despite `package.json` no
+      // longer declaring a `require` resolution. Pin to `["es"]` so
+      // the build matches the package's `exports` map.
+      formats: ["es"],
       name: "Anipres",
     },
     rollupOptions: {


### PR DESCRIPTION
## Summary

The \`anipres\` package's \`./schema\` subpath was already ESM-only (no \`require\` branch in \`exports\`) since it was added. Keeping CJS for the main entry while the schema subpath was ESM-only is an inconsistent posture; consolidating to ESM-only across the whole package.

## What changed

**\`packages/anipres/package.json\`**:
- Drop \`main\` (was \`./dist/anipres.cjs\`)
- Drop \`module\` (redundant with \`exports\`)
- Drop the \`require\` branch in \`exports.\".\"\`

**\`packages/anipres/vite.config.ts\`**:
- Pin \`lib.formats: [\"es\"]\` so vite stops emitting \`.cjs\` outputs alongside the ESM ones (vite's default for multi-entry libs is \`[\"es\", \"cjs\"]\`).

**\`.changeset/anipres-esm-only.md\`**: declares a \`minor\` bump (pre-1.0 convention; flags as breaking for \`require()\` consumers).

## Why minor and not major

The package is at \`0.12.0\`; semver-pre-1.0 lets minor versions carry breaking changes by convention. Existing changesets in this repo follow the same pattern. The changeset description explicitly notes the breaking change so the published changelog is honest.

## Internal impact

- \`packages/app\` consumes \`anipres\` via Vite (ESM-native): unaffected
- \`packages/worker\` consumes \`anipres/schema\` via workerd (ESM): already ESM-only, unaffected

## External impact

Any consumer using \`require(\"anipres\")\` from a CJS context will need to switch to \`import\`. Most modern React tooling (Vite, Next.js 13+, Webpack 5+, Rollup, esbuild, etc.) supports ESM natively, so this should be a non-issue for the typical consumer.

## Test plan

- [x] \`pnpm --filter anipres build\` — produces \`anipres.js\`, \`schema.js\`, no \`.cjs\` artifacts
- [x] \`pnpm --filter anipres test\` — 21/21 pass
- [x] \`pnpm --filter anipres typecheck\` — clean
- [x] \`pnpm --filter app test\` — 93/93 pass (consumer)
- [x] \`pnpm --filter app typecheck/lint\` — clean
- [x] \`pnpm --filter anipres-worker test\` — 42/42 pass (consumer)
- [x] \`pnpm --filter anipres-worker typecheck\` — clean

## Targeting note

PR'd against \`feature/sync-server\` to match the recent PR pattern, but this change is independent of the sync work and could equally target \`main\` directly. Easy to retarget if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)