### PR TITLE
fix(worker/auth): recover from orphan sessions when the user row is gone

### DIFF
--- a/packages/worker/src/auth/index.ts
+++ b/packages/worker/src/auth/index.ts
@@ -19,6 +19,17 @@ export function registerAuthRoutes(app: Hono<AppBindings>) {
   app.get("/auth/me", async (c) => {
     const user = await getCurrentUser(c);
     if (!user) {
+      // Self-heal stale cookies: a JWT can outlive its underlying
+      // user row (DB reset in dev, or an account deletion once that
+      // ships). Without this, the browser keeps replaying the orphan
+      // cookie on every load — `getCurrentUser` returns null, the
+      // client stays in a logged-out state with a still-present
+      // cookie, and the next OAuth attempt would land in link mode
+      // against a missing user (now caught in `session.ts`, but the
+      // cookie itself is the root cause and worth clearing here).
+      // Safe to call unconditionally: when there's no cookie or the
+      // signature failed, `clearSession` is a no-op for the client.
+      clearSession(c);
       return c.json({ error: "Not authenticated" }, 401);
     }
 

--- a/packages/worker/src/auth/session.ts
+++ b/packages/worker/src/auth/session.ts
@@ -44,20 +44,29 @@ export function clearSession(c: AppContext) {
  * Resolve the post-OAuth-callback action.
  *
  * Two modes, distinguished only by whether the caller already has a
- * valid session cookie:
+ * valid session cookie pointing at an existing user:
  *
- * - **Login** (no session): existing flow — find or create the user
- *   keyed by `(provider, provider_id)`, issue a fresh session cookie,
- *   redirect to `/`.
- * - **Link** (session present): attach this `(provider, provider_id)`
- *   to the existing user. The session cookie stays as-is. Redirect
- *   carries a query param so the client can surface the result.
+ * - **Login** (no session, or session points at a user that no longer
+ *   exists): existing flow — find or create the user keyed by
+ *   `(provider, provider_id)`, issue a fresh session cookie, redirect
+ *   to `/`.
+ * - **Link** (session present, user still exists): attach this
+ *   `(provider, provider_id)` to the existing user. The session
+ *   cookie stays as-is. Redirect carries a query param so the client
+ *   can surface the result.
  *
  * The session cookie *is* the intent — the production UI never sends
  * a logged-in user through OAuth except via the settings "Connect"
  * button, so "logged-in user completes the OAuth dance" is
  * unambiguously a link operation. A separate intent cookie was
  * considered but adds plumbing without buying anything.
+ *
+ * The "session points at a user that no longer exists" path covers
+ * orphan-session recovery: a JWT remains valid until expiry, but if
+ * the underlying user row is gone (DB reset in dev, or — once
+ * account deletion ships — a deleted account), the link path would
+ * trip the `oauth_identities.user_id` FK. Detect by SELECT, clear
+ * the stale cookie, and proceed as a fresh login.
  */
 export async function upsertUserAndIssueSession(
   c: AppContext,
@@ -66,7 +75,18 @@ export async function upsertUserAndIssueSession(
 ): Promise<Response> {
   const currentUserId = await requireSession(c);
   if (currentUserId !== null) {
-    return attachIdentityToCurrentUser(c, currentUserId, provider, providerId);
+    if (await userExists(c, currentUserId)) {
+      return attachIdentityToCurrentUser(
+        c,
+        currentUserId,
+        provider,
+        providerId,
+      );
+    }
+    // Orphan session — JWT is valid but the user is gone. Clear the
+    // cookie before falling through so the new session cookie issued
+    // below replaces it cleanly.
+    clearSession(c);
   }
 
   const userId = await resolveUserIdForOAuthIdentity(c, provider, providerId);
@@ -77,6 +97,13 @@ export async function upsertUserAndIssueSession(
   const jwt = await issueSessionJwt(c, userId);
   setSessionCookie(c, jwt);
   return c.redirect("/");
+}
+
+async function userExists(c: AppContext, userId: number): Promise<boolean> {
+  const row = await c.env.DB.prepare("SELECT 1 FROM users WHERE id = ?")
+    .bind(userId)
+    .first();
+  return row !== null;
 }
 
 async function issueSessionJwt(


### PR DESCRIPTION
## Summary

A JWT session can outlive its underlying user — DB reset in dev today, account deletion later. With the cookie still present but `users.id` gone:

- `upsertUserAndIssueSession` reads the cookie, drops into **link** mode, and the `INSERT INTO oauth_identities` trips the `user_id REFERENCES users(id)` FK, redirecting with `?account_link_error=server_error`.
- `/auth/me` returns 401 because `getCurrentUser` finds no `users` row, but the browser keeps the cookie, so every reload repeats the same 401.

This PR detects the orphan in both places and clears the cookie:

- **`session.ts`** — `upsertUserAndIssueSession` checks `userExists(currentUserId)` before entering link mode. If the row is gone, it `clearSession`s and falls through to the fresh-login path (which creates a new user).
- **`auth/index.ts`** — `/auth/me` calls `clearSession` on the 401 path, so the very next request the client makes after a DB wipe self-heals (no OAuth round-trip required to recover).

Repro for the original issue:
1. Sign in.
2. `wrangler d1 execute … --command "DELETE FROM users; DELETE FROM oauth_identities; DELETE FROM workspaces"` (or wipe the local SQLite).
3. Without this fix: 401 loop on `/auth/me`; OAuth re-login redirects with `account_link_error=server_error`.

## Test plan

- [ ] `pnpm --filter anipres-worker typecheck` (passes locally)
- [ ] `pnpm --filter anipres-worker test` (passes locally)
- [ ] Manual: log in, wipe local D1, reload — client returns to logged-out state without the cookie; subsequent OAuth login succeeds and creates a new user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)