### PR TITLE
fix(worker): make PUT /api/documents/:id idempotent on initializing rows

### DIFF
--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -253,17 +253,26 @@ app.put("/api/documents/:id", async (c) => {
 
   if (existing) {
     // Update path. Reject any state that means "this row isn't a
-    // user-visible doc right now":
-    //   - soft-deleting: row is on its way out
-    //   - initializing:  row is mid-create, finalizing snapshot push
-    //                    pending. Updating metadata would race with
-    //                    the multi-step finalization.
-    //   - workspace_id mismatch: doc lives in another workspace
-    //                            (we don't allow cross-workspace moves).
-    // All three collapse to 404 from the client's perspective.
+    // user-visible doc the caller can address right now":
+    //   - soft-deleting: row is on its way out.
+    //   - workspace_id mismatch: doc lives in another workspace (we
+    //     don't allow cross-workspace moves).
+    // Both collapse to 404 from the client's perspective.
+    //
+    // `initializing_at` is deliberately *not* a rejection condition.
+    // PUT-as-upsert needs to be replayable: the convert-to-synced
+    // flow does PUT → upload assets → push snapshot, and any failure
+    // between PUT and snapshot push leaves a row stuck initializing.
+    // The retry replays the same PUT with the same body; if we
+    // rejected initializing rows, the retry would 404 forever (the
+    // sweep eventually cleans up after a 10-minute grace window, but
+    // interactive retry is a minute-zero need). Letting the metadata
+    // UPDATE through is harmless — the row stays initializing, the
+    // snapshot push remains the sole finalizer (worker.ts ~554), and
+    // any orphan tldraw_assets rows from the prior attempt get GC'd
+    // by the asset sweep at the next push.
     if (
       existing.deleting_at !== null ||
-      existing.initializing_at !== null ||
       existing.workspace_id !== workspaceId
     ) {
       return c.json({ error: "Not found" }, 404);
@@ -273,32 +282,31 @@ app.put("/api/documents/:id", async (c) => {
     // updated_at trigger in 0001_initial_schema.sql. created_at on
     // the body is ignored: backdating is only meaningful at insert.
     //
-    // The WHERE clause re-asserts every condition the pre-SELECT
-    // checked (workspace match, not deleting, not initializing). The
-    // SELECT alone isn't enough — between it and this UPDATE another
-    // request could soft-delete the row, finalize-then-delete it, or
-    // (in some future Extension B world) move it across workspaces.
-    // With these guards on the UPDATE itself, a state transition in
-    // that window safely flips the result to 0 changes → 404 instead
-    // of writing title/sort_order onto a row in a state we just
-    // rejected. The pre-SELECT still drives the insert-vs-update
-    // branch decision; it just no longer carries the safety contract.
+    // The WHERE clause re-asserts the rejection conditions the
+    // pre-SELECT checked (workspace match, not deleting). The SELECT
+    // alone isn't enough — between it and this UPDATE another request
+    // could soft-delete the row or (in some future Extension B
+    // world) move it across workspaces. With these guards on the
+    // UPDATE itself, a state transition in that window safely flips
+    // the result to 0 changes → 404 instead of writing title/sort_order
+    // onto a row in a state we just rejected. The pre-SELECT still
+    // drives the insert-vs-update branch decision; it just no longer
+    // carries the safety contract.
     const row = await c.env.DB.prepare(
       `UPDATE documents
        SET title = ?, sort_order = ?
        WHERE id = ?
          AND workspace_id = ?
          AND deleting_at IS NULL
-         AND initializing_at IS NULL
        RETURNING id, slug, title, sort_order, created_at, updated_at`,
     )
       .bind(body.title, body.sort_order, id, workspaceId)
       .first<DocumentRow>();
     if (!row) {
       // The row's state changed between the SELECT and the UPDATE
-      // (delete, finalize-then-delete, etc.). 404 is the right code
-      // — from the client's point of view the doc is no longer
-      // updatable in the workspace it asked for.
+      // (delete, etc.). 404 is the right code — from the client's
+      // point of view the doc is no longer updatable in the workspace
+      // it asked for.
       return c.json({ error: "Not found" }, 404);
     }
     return c.json(row);


### PR DESCRIPTION
## Summary

The convert-to-synced flow is multi-step on the wire:

1. `PUT /api/documents/:id` — server INSERTs with `initializing_at = now`.
2. `POST /api/documents/:id/assets` — upload referenced assets to R2.
3. `PUT /api/documents/:id/snapshot` — push the snapshot to the DO; this clears `initializing_at`.

If anything between step 1 and step 3 fails (network drop, conflict, asset upload error), the row is left in `initializing` state. Today the retry replays step 1, the existing branch in the PUT handler sees `initializing_at IS NOT NULL` and returns 404, and the doc is locked out until `sweepInitializingDocuments` runs (10-minute grace + cron cadence). For an interactive retry this is effectively "the convert button stops working for ten minutes."

This PR drops the `initializing_at IS NOT NULL` rejection in the existing-row branch:

- The metadata UPDATE now runs against initializing rows.
- The row stays initializing — the snapshot push remains the sole finalizer (worker.ts ~554).
- Race-safe vs. an in-progress legitimate first attempt: both the original attempt's snapshot push and the retry's snapshot push converge on the same UPDATE that clears `initializing_at`. Snapshot-version conflicts are already handled by the existing 409 path.
- Orphan `tldraw_assets` rows from the prior attempt are GC'd by the asset sweep at the next snapshot push (the existing mechanism already handles unreferenced assets).
- `deleting_at` and workspace mismatch still collapse to 404 — unchanged.

The 10-minute initializing-doc sweep is unaffected and still cleans up genuinely-abandoned rows.

## Repro (before this PR)

1. Sign in, create a local doc.
2. Open DevTools → Network → throttle / fail one of the asset uploads during convert.
3. D1 has `documents.initializing_at IS NOT NULL` for that id.
4. Click "Convert to synced" again → PUT returns 404. The doc remains stuck for the full grace window.

## Test plan

- [ ] `pnpm --filter anipres-worker typecheck` (passes locally)
- [ ] `pnpm --filter anipres-worker test` (passes locally)
- [ ] Manual: leave a row in `initializing` state (e.g. `pnpm exec wrangler d1 execute anipres-db --local --command "UPDATE documents SET initializing_at = strftime('%s','now')*1000 WHERE id='<id>'"`), retry the convert, confirm the row finalizes (`initializing_at` clears) and the doc becomes visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)