### PR TITLE
feat(app): per-section + buttons for choosing local vs synced on create

### DIFF
--- a/packages/app/src/components/DocumentSidebar.module.css
+++ b/packages/app/src/components/DocumentSidebar.module.css
@@ -16,6 +16,11 @@
   border-bottom: 1px solid #e8e8e8;
 }
 
+.headerActions {
+  display: flex;
+  gap: 4px;
+}
+
 .headerTitle {
   font-size: 12px;
   font-weight: 600;
@@ -40,6 +45,43 @@
 
 .newButton:hover {
   background: rgba(0, 0, 0, 0.05);
+}
+
+.newMenuContainer {
+  position: relative;
+  display: inline-block;
+}
+
+.newMenu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 600;
+  display: flex;
+  flex-direction: column;
+  min-width: 120px;
+  padding: 4px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: #fff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+
+.newMenuItem {
+  padding: 6px 10px;
+  border: none;
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+  font-size: 13px;
+  color: #333;
+  text-align: left;
+}
+
+.newMenuItem:hover,
+.newMenuItem:focus-visible {
+  background: rgba(0, 0, 0, 0.06);
+  outline: none;
 }
 
 .collapseButton {
@@ -73,6 +115,13 @@
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: #888;
+}
+
+.emptyGroup {
+  padding: 4px 8px 8px;
+  font-size: 12px;
+  font-style: italic;
+  color: #aaa;
 }
 
 .toggleButton {
@@ -131,6 +180,25 @@
 
 :global([data-color-scheme="dark"]) .newButton:hover {
   background: rgba(255, 255, 255, 0.08);
+}
+
+:global([data-color-scheme="dark"]) .newMenu {
+  background: #2a2a2a;
+  border-color: #444;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+:global([data-color-scheme="dark"]) .newMenuItem {
+  color: #ccc;
+}
+
+:global([data-color-scheme="dark"]) .newMenuItem:hover,
+:global([data-color-scheme="dark"]) .newMenuItem:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+:global([data-color-scheme="dark"]) .emptyGroup {
+  color: #666;
 }
 
 :global([data-color-scheme="dark"]) .collapseButton {

--- a/packages/app/src/components/DocumentSidebar.module.css
+++ b/packages/app/src/components/DocumentSidebar.module.css
@@ -16,72 +16,12 @@
   border-bottom: 1px solid #e8e8e8;
 }
 
-.headerActions {
-  display: flex;
-  gap: 4px;
-}
-
 .headerTitle {
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: #666;
-}
-
-.newButton {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  padding: 6px 10px;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  background: none;
-  cursor: pointer;
-  font-size: 13px;
-  color: #666;
-}
-
-.newButton:hover {
-  background: rgba(0, 0, 0, 0.05);
-}
-
-.newMenuContainer {
-  position: relative;
-  display: inline-block;
-}
-
-.newMenu {
-  position: absolute;
-  top: calc(100% + 4px);
-  right: 0;
-  z-index: 600;
-  display: flex;
-  flex-direction: column;
-  min-width: 120px;
-  padding: 4px;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  background: #fff;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
-}
-
-.newMenuItem {
-  padding: 6px 10px;
-  border: none;
-  border-radius: 4px;
-  background: none;
-  cursor: pointer;
-  font-size: 13px;
-  color: #333;
-  text-align: left;
-}
-
-.newMenuItem:hover,
-.newMenuItem:focus-visible {
-  background: rgba(0, 0, 0, 0.06);
-  outline: none;
 }
 
 .collapseButton {
@@ -109,12 +49,39 @@
 }
 
 .groupHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: 8px 6px 4px;
+}
+
+.groupHeaderLabel {
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: #888;
+}
+
+.groupAddButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+  color: #888;
+}
+
+.groupAddButton:hover,
+.groupAddButton:focus-visible {
+  background: rgba(0, 0, 0, 0.06);
+  color: #333;
+  outline: none;
 }
 
 .emptyGroup {
@@ -169,32 +136,18 @@
   color: #999;
 }
 
-:global([data-color-scheme="dark"]) .groupHeader {
+:global([data-color-scheme="dark"]) .groupHeaderLabel {
   color: #888;
 }
 
-:global([data-color-scheme="dark"]) .newButton {
-  border-color: #444;
-  color: #999;
+:global([data-color-scheme="dark"]) .groupAddButton {
+  color: #888;
 }
 
-:global([data-color-scheme="dark"]) .newButton:hover {
+:global([data-color-scheme="dark"]) .groupAddButton:hover,
+:global([data-color-scheme="dark"]) .groupAddButton:focus-visible {
   background: rgba(255, 255, 255, 0.08);
-}
-
-:global([data-color-scheme="dark"]) .newMenu {
-  background: #2a2a2a;
-  border-color: #444;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
-}
-
-:global([data-color-scheme="dark"]) .newMenuItem {
   color: #ccc;
-}
-
-:global([data-color-scheme="dark"]) .newMenuItem:hover,
-:global([data-color-scheme="dark"]) .newMenuItem:focus-visible {
-  background: rgba(255, 255, 255, 0.08);
 }
 
 :global([data-color-scheme="dark"]) .emptyGroup {

--- a/packages/app/src/components/DocumentSidebar.tsx
+++ b/packages/app/src/components/DocumentSidebar.tsx
@@ -1,9 +1,9 @@
-import { Menu, PanelLeftClose, Plus } from "lucide-react";
-import { useMemo, useState } from "react";
+import { ChevronDown, Menu, PanelLeftClose, Plus } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "../auth/useAuth";
 import { getConversionErrorMessage } from "../documents/conversion-error-message";
 import { useDocumentManagerContext } from "../documents/useDocumentManagerContext";
-import type { DocumentMeta } from "../documents/types";
+import type { DocumentMeta, DocumentSource } from "../documents/types";
 import type { ColorSchemePreference } from "../hooks/useColorScheme";
 import { AccountFooter } from "./AccountFooter";
 import { ColorSchemeSwitcher } from "./ColorSchemeSwitcher";
@@ -32,28 +32,31 @@ export function DocumentSidebar({
     conversionErrors,
   } = useDocumentManagerContext();
 
-  // The convert action only makes sense when the user is logged in,
-  // i.e. when there is a synced destination to migrate the doc into.
-  // Auth state lives in `AccountFooter`'s subtree for the rest of the
-  // sidebar's account-related UI; the sidebar still needs `user` here
-  // to decide whether to expose the convert affordance per row.
   const { user } = useAuth();
+  const loggedIn = user !== null;
 
   const [collapsed, setCollapsed] = useState(false);
+  const [newMenuOpen, setNewMenuOpen] = useState(false);
+  const newMenuContainerRef = useRef<HTMLDivElement>(null);
 
-  // Announcement string for the convert-to-synced aria-live region.
-  // The convert-to-synced button itself updates its `title` /
-  // `aria-label` in place, but those only get re-announced when the
-  // button receives focus. The polite live region below announces
-  // start / failure transitions to screen readers as they happen,
-  // without taking focus.
-  //
-  // Errors take precedence over in-flight state: when a doc fails
-  // mid-conversion, useDocumentManager moves it from `converting`
-  // into `conversionErrors`, so the error branch fires on the
-  // failure transition. Successful completions don't appear here
-  // (the doc just moves out of `converting` into the synced group);
-  // the visible badge change is enough.
+  useEffect(() => {
+    if (!newMenuOpen) return;
+    const onPointerDown = (e: MouseEvent) => {
+      if (!newMenuContainerRef.current?.contains(e.target as Node)) {
+        setNewMenuOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setNewMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [newMenuOpen]);
+
   const conversionAnnouncement = useMemo(() => {
     for (const [id, err] of conversionErrors) {
       const doc = documents.find((d) => d.id === id);
@@ -79,8 +82,6 @@ export function DocumentSidebar({
     return { syncedDocs: synced, localDocs: local };
   }, [documents]);
 
-  const showGroupHeaders = syncedDocs.length > 0 && localDocs.length > 0;
-
   if (collapsed) {
     return (
       <button
@@ -95,7 +96,12 @@ export function DocumentSidebar({
     );
   }
 
-  const onConvert = user !== null ? convertToSynced : undefined;
+  const onConvert = loggedIn ? convertToSynced : undefined;
+
+  const handleCreate = (source: DocumentSource) => {
+    setNewMenuOpen(false);
+    void createDocument({ source });
+  };
 
   const renderGroup = (docs: DocumentMeta[]) =>
     docs.map((doc) => (
@@ -116,14 +122,48 @@ export function DocumentSidebar({
     <div className={styles.sidebar}>
       <div className={styles.header}>
         <span className={styles.headerTitle}>Documents</span>
-        <div style={{ display: "flex", gap: 4 }}>
-          <button
-            type="button"
-            className={styles.newButton}
-            onClick={() => createDocument()}
-          >
-            <Plus size={14} /> New
-          </button>
+        <div className={styles.headerActions}>
+          {loggedIn ? (
+            <div ref={newMenuContainerRef} className={styles.newMenuContainer}>
+              <button
+                type="button"
+                className={styles.newButton}
+                onClick={() => setNewMenuOpen((v) => !v)}
+                aria-haspopup="menu"
+                aria-expanded={newMenuOpen}
+              >
+                <Plus size={14} /> New <ChevronDown size={12} />
+              </button>
+              {newMenuOpen && (
+                <div role="menu" className={styles.newMenu}>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={styles.newMenuItem}
+                    onClick={() => handleCreate("synced")}
+                  >
+                    Synced
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={styles.newMenuItem}
+                    onClick={() => handleCreate("local")}
+                  >
+                    Local
+                  </button>
+                </div>
+              )}
+            </div>
+          ) : (
+            <button
+              type="button"
+              className={styles.newButton}
+              onClick={() => handleCreate("local")}
+            >
+              <Plus size={14} /> New
+            </button>
+          )}
           <button
             type="button"
             className={styles.collapseButton}
@@ -136,14 +176,24 @@ export function DocumentSidebar({
         </div>
       </div>
       <div className={styles.list}>
-        {showGroupHeaders && syncedDocs.length > 0 && (
-          <div className={styles.groupHeader}>Synced</div>
+        {loggedIn ? (
+          <>
+            <div className={styles.groupHeader}>Synced</div>
+            {syncedDocs.length > 0 ? (
+              renderGroup(syncedDocs)
+            ) : (
+              <div className={styles.emptyGroup}>No synced documents</div>
+            )}
+            <div className={styles.groupHeader}>Local</div>
+            {localDocs.length > 0 ? (
+              renderGroup(localDocs)
+            ) : (
+              <div className={styles.emptyGroup}>No local documents</div>
+            )}
+          </>
+        ) : (
+          renderGroup(documents)
         )}
-        {renderGroup(syncedDocs)}
-        {showGroupHeaders && localDocs.length > 0 && (
-          <div className={styles.groupHeader}>Local</div>
-        )}
-        {renderGroup(localDocs)}
       </div>
       <div
         role="status"

--- a/packages/app/src/components/DocumentSidebar.tsx
+++ b/packages/app/src/components/DocumentSidebar.tsx
@@ -1,5 +1,5 @@
-import { ChevronDown, Menu, PanelLeftClose, Plus } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Menu, PanelLeftClose, Plus } from "lucide-react";
+import { useMemo, useState } from "react";
 import { useAuth } from "../auth/useAuth";
 import { getConversionErrorMessage } from "../documents/conversion-error-message";
 import { useDocumentManagerContext } from "../documents/useDocumentManagerContext";
@@ -36,26 +36,6 @@ export function DocumentSidebar({
   const loggedIn = user !== null;
 
   const [collapsed, setCollapsed] = useState(false);
-  const [newMenuOpen, setNewMenuOpen] = useState(false);
-  const newMenuContainerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!newMenuOpen) return;
-    const onPointerDown = (e: MouseEvent) => {
-      if (!newMenuContainerRef.current?.contains(e.target as Node)) {
-        setNewMenuOpen(false);
-      }
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setNewMenuOpen(false);
-    };
-    document.addEventListener("mousedown", onPointerDown);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onPointerDown);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [newMenuOpen]);
 
   const conversionAnnouncement = useMemo(() => {
     for (const [id, err] of conversionErrors) {
@@ -99,7 +79,6 @@ export function DocumentSidebar({
   const onConvert = loggedIn ? convertToSynced : undefined;
 
   const handleCreate = (source: DocumentSource) => {
-    setNewMenuOpen(false);
     void createDocument({ source });
   };
 
@@ -118,82 +97,51 @@ export function DocumentSidebar({
       />
     ));
 
+  const renderSection = (
+    label: string,
+    source: DocumentSource,
+    docs: DocumentMeta[],
+    emptyMessage: string,
+  ) => (
+    <>
+      <div className={styles.groupHeader}>
+        <span className={styles.groupHeaderLabel}>{label}</span>
+        <button
+          type="button"
+          className={styles.groupAddButton}
+          onClick={() => handleCreate(source)}
+          title={`New ${label.toLowerCase()} document`}
+          aria-label={`New ${label.toLowerCase()} document`}
+        >
+          <Plus size={12} />
+        </button>
+      </div>
+      {docs.length > 0 ? (
+        renderGroup(docs)
+      ) : (
+        <div className={styles.emptyGroup}>{emptyMessage}</div>
+      )}
+    </>
+  );
+
   return (
     <div className={styles.sidebar}>
       <div className={styles.header}>
         <span className={styles.headerTitle}>Documents</span>
-        <div className={styles.headerActions}>
-          {loggedIn ? (
-            <div ref={newMenuContainerRef} className={styles.newMenuContainer}>
-              <button
-                type="button"
-                className={styles.newButton}
-                onClick={() => setNewMenuOpen((v) => !v)}
-                aria-haspopup="menu"
-                aria-expanded={newMenuOpen}
-              >
-                <Plus size={14} /> New <ChevronDown size={12} />
-              </button>
-              {newMenuOpen && (
-                <div role="menu" className={styles.newMenu}>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className={styles.newMenuItem}
-                    onClick={() => handleCreate("synced")}
-                  >
-                    Synced
-                  </button>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className={styles.newMenuItem}
-                    onClick={() => handleCreate("local")}
-                  >
-                    Local
-                  </button>
-                </div>
-              )}
-            </div>
-          ) : (
-            <button
-              type="button"
-              className={styles.newButton}
-              onClick={() => handleCreate("local")}
-            >
-              <Plus size={14} /> New
-            </button>
-          )}
-          <button
-            type="button"
-            className={styles.collapseButton}
-            onClick={() => setCollapsed(true)}
-            title="Hide sidebar"
-            aria-label="Hide sidebar"
-          >
-            <PanelLeftClose size={14} />
-          </button>
-        </div>
+        <button
+          type="button"
+          className={styles.collapseButton}
+          onClick={() => setCollapsed(true)}
+          title="Hide sidebar"
+          aria-label="Hide sidebar"
+        >
+          <PanelLeftClose size={14} />
+        </button>
       </div>
       <div className={styles.list}>
-        {loggedIn ? (
-          <>
-            <div className={styles.groupHeader}>Synced</div>
-            {syncedDocs.length > 0 ? (
-              renderGroup(syncedDocs)
-            ) : (
-              <div className={styles.emptyGroup}>No synced documents</div>
-            )}
-            <div className={styles.groupHeader}>Local</div>
-            {localDocs.length > 0 ? (
-              renderGroup(localDocs)
-            ) : (
-              <div className={styles.emptyGroup}>No local documents</div>
-            )}
-          </>
-        ) : (
-          renderGroup(documents)
-        )}
+        {loggedIn &&
+          renderSection("Synced", "synced", syncedDocs, "No synced documents")}
+        {renderSection("Local", "local", localDocs, "No local documents")}
       </div>
       <div
         role="status"


### PR DESCRIPTION
## Summary

- Each section header in the sidebar — **Synced** and **Local** — gets its own "+" button. The section the button sits in is the source the new doc is created with, so the local-vs-synced choice is implicit in which "+" you click. Replaces the original top-level "+ New" button.
- The **Local** section always renders, logged in or out. The **Synced** section only renders when logged in (no synced destination otherwise). Empty groups show a small placeholder ("No synced documents" / "No local documents").
- Logged-out users keep a working create button under the **Local** header without needing a separate top-level fallback.

The underlying \`createDocument({ source })\` API already accepted an explicit source; only the UI was wired.

## Test plan

- [x] \`pnpm typecheck\` — passes
- [x] \`pnpm lint\` — passes
- [x] \`pnpm test\` (97 / 97) — passes
- [ ] Manual browser sanity check on the preview deploy:
  - [x] Logged out: only the **Local** section renders; its "+" creates a local doc
  - [x] Logged in: both **Synced** and **Local** sections render; each "+" creates a doc of that source
  - [ ] Empty sections show their placeholder text
  - [x] Section "+" buttons are reachable and operable via keyboard (Tab + Enter)

## Notes

- Base is \`feature/sync-server\` (PR #409). Once that lands in \`main\`, GitHub will rebase this PR's base automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)