### PR TITLE
feat: cross-client + cross-tab sync (SSE workspace feed + BroadcastChannel)

### DIFF
--- a/docs/design-server-sync.md
+++ b/docs/design-server-sync.md
@@ -267,6 +267,7 @@ DELETE /auth/identities/:provider/:provider_id  -> Unlink an OAuth identity (ref
 
 # Workspaces (Phase 1 invariant: 1:1 user ↔ workspace)
 GET    /api/workspaces                -> List workspaces the user owns
+GET    /api/workspaces/:id/events     -> SSE feed of workspace-scoped events ({"type":"documents:changed"})
 
 # Documents (workspace-scoped; PUT-as-upsert)
 GET    /api/documents?workspace_id=:wsid     -> List active docs in a workspace
@@ -295,6 +296,7 @@ Notes:
 - **`/api/connect/:documentId`** runs through the same `requireSession` middleware as the REST routes — only logged-in users can open a sync session.
 - **Typed client** — every JSON endpoint above is consumed via Hono's `hc<AppType>()` so the app reads response shapes from the worker's compiled `.d.ts`. The worker emits its declarations through a TypeScript project reference (`packages/worker/tsconfig.build.json`); the app's `tsc -b` builds the worker first.
 - **CSRF protection** — Hono's `csrf()` middleware allowlists `Origin` against `PUBLIC_BASE_URL` for state-changing requests. JSON requests are protected by browser-level CORS preflight (the worker emits no `Access-Control-Allow-Origin`); WebSocket upgrades are blocked by `SameSite=Lax` on the session cookie.
+- **Workspace SSE feed (`/api/workspaces/:id/events`)** — connects through a `WorkspaceFeedRoom` Durable Object (one DO per workspace, in-memory subscriber set, no persisted storage). Document mutation routes call `bumpWorkspaceFeed` after committing, which fires `c.executionCtx.waitUntil(stub.broadcast(...))` so the response doesn't block on RPC. Subscribers receive `data: {"type":"documents:changed"}` and refetch the doc list. The client provides a per-tab id via `?client_id=` and the matching `X-Anipres-Client-Id` header on mutations; the DO suppresses fanOut to the originating tab so it doesn't refetch its own write. EventSource auto-retry plus a 30 s polling backstop on the client cover stream drops and DO restarts. Snapshot pushes during active editing intentionally don't bump (only the initializing → visible transition does); the doc-list output doesn't change beyond `updated_at` between live edits, and the editor itself syncs via WebSocket.
 
 ---
 
@@ -378,6 +380,7 @@ packages/worker/
     worker.ts                # Hono entry: mounts middleware (csrf, oauth, api-auth) and the chained sub-routers; AppType export for the typed RPC client
     api-types.ts             # Type-only re-export for the app's hc<AppType>() consumer
     DocumentSyncRoom.ts      # DurableObject wrapping TLSocketRoom + SQLiteSyncStorage; soft-delete timeline
+    WorkspaceFeedRoom.ts     # Per-workspace DurableObject backing the SSE feed (subscribers list + fanOut, no persisted storage); bumpWorkspaceFeed helper for mutation routes
     tldraw-assets.ts         # Asset lifecycle helpers (GC sweeps, snapshot/asset reconciliation, startDocumentDeletion)
     tldraw-asset-policy.ts   # Cross-package MAX_ASSET_SIZE constant
     cleanup.ts               # sweepInitializingDocuments — runs from the scheduled cron

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -113,6 +113,7 @@ function AuthenticatedApp() {
         <DocumentManagerProvider
           localRepository={localRepository}
           syncedRepository={syncedRepository}
+          workspaceId={workspaceId}
         >
           <AppContent />
         </DocumentManagerProvider>

--- a/packages/app/src/auth/AuthContext.tsx
+++ b/packages/app/src/auth/AuthContext.tsx
@@ -1,6 +1,7 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import useSWR, { useSWRConfig } from "swr";
 import { apiClient } from "../lib/api-client";
+import { broadcastLogout, subscribeToAuthBroadcasts } from "./auth-broadcast";
 import { fetchMe } from "./me-fetcher";
 import { AuthContext } from "./useAuth";
 
@@ -10,7 +11,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // SWR handles cancellation, dedup, and focus revalidation. The
   // focus-revalidation behavior covers a real case here: a user who
   // logs out in another tab gets reflected in this tab on focus
-  // without needing a cross-tab broadcast.
+  // without needing a cross-tab broadcast. The BroadcastChannel
+  // listener wired up below makes that propagation immediate so
+  // tabs don't sit on stale auth state until the user clicks them.
   const { data, isLoading: loading } = useSWR(ME_KEY, fetchMe);
   const user = data ?? null;
 
@@ -21,6 +24,28 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // linger in any open UI surface that read them — see the comment
   // on logout below.
   const { mutate: globalMutate } = useSWRConfig();
+
+  const wipeAllCaches = useCallback(async () => {
+    // Wipe every SWR cache key, not just `/auth/me`. After logout,
+    // any data fetched while authenticated (workspaces, identities,
+    // future endpoints) belongs to the previous session; the server
+    // would now return 401, so any subsequent UI that reads the
+    // cache is showing stale prior-session data. `revalidate:false`
+    // skips a flurry of immediate refetches that would all 401
+    // anyway. Background revalidation on the next focus event will
+    // refresh whatever the new logged-out state needs.
+    //
+    // `() => true` is the SWR-canonical match-all-keys filter.
+    await globalMutate(() => true, undefined, { revalidate: false });
+  }, [globalMutate]);
+
+  useEffect(() => {
+    return subscribeToAuthBroadcasts((message) => {
+      if (message.type === "logout") {
+        void wipeAllCaches();
+      }
+    });
+  }, [wipeAllCaches]);
 
   const loginWithGitHub = useCallback(() => {
     window.location.href = "/auth/github";
@@ -33,19 +58,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const logout = useCallback(async () => {
     const res = await apiClient.auth.logout.$post();
     if (res.ok) {
-      // Wipe every SWR cache key, not just `/auth/me`. After logout,
-      // any data fetched while authenticated (workspaces, identities,
-      // future endpoints) belongs to the previous session; the server
-      // would now return 401, so any subsequent UI that reads the
-      // cache is showing stale prior-session data. `revalidate:false`
-      // skips a flurry of immediate refetches that would all 401
-      // anyway. Background revalidation on the next focus event will
-      // refresh whatever the new logged-out state needs.
-      //
-      // `() => true` is the SWR-canonical match-all-keys filter.
-      await globalMutate(() => true, undefined, { revalidate: false });
+      await wipeAllCaches();
+      broadcastLogout();
     }
-  }, [globalMutate]);
+  }, [wipeAllCaches]);
 
   return (
     <AuthContext.Provider

--- a/packages/app/src/auth/auth-broadcast.test.ts
+++ b/packages/app/src/auth/auth-broadcast.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { broadcastLogout, subscribeToAuthBroadcasts } from "./auth-broadcast";
+
+describe("auth broadcast", () => {
+  it("delivers a logout message from another sender", async () => {
+    const handler = vi.fn();
+    const unsubscribe = subscribeToAuthBroadcasts(handler);
+
+    const externalChannel = new BroadcastChannel("anipres:auth");
+    externalChannel.postMessage({ type: "logout", senderId: "other-tab" });
+    externalChannel.close();
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0]).toMatchObject({ type: "logout" });
+    unsubscribe();
+  });
+
+  it("ignores broadcasts originated by the same tab", async () => {
+    const handler = vi.fn();
+    const unsubscribe = subscribeToAuthBroadcasts(handler);
+
+    broadcastLogout();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(handler).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it("removes the listener on unsubscribe", async () => {
+    const handler = vi.fn();
+    const unsubscribe = subscribeToAuthBroadcasts(handler);
+    unsubscribe();
+
+    const externalChannel = new BroadcastChannel("anipres:auth");
+    externalChannel.postMessage({ type: "logout", senderId: "other-tab" });
+    externalChannel.close();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/auth/auth-broadcast.ts
+++ b/packages/app/src/auth/auth-broadcast.ts
@@ -1,11 +1,6 @@
-const CHANNEL_NAME = "anipres:auth";
+import { CLIENT_ID } from "../lib/client-id";
 
-// Stable per-tab id used to filter the listener's own posts. Same
-// pattern as local-docs-broadcast — see that file for the rationale.
-const TAB_ID =
-  typeof crypto !== "undefined" && "randomUUID" in crypto
-    ? crypto.randomUUID()
-    : `${Date.now()}-${Math.random()}`;
+const CHANNEL_NAME = "anipres:auth";
 
 interface AuthBroadcastMessage {
   type: "logout";
@@ -14,7 +9,7 @@ interface AuthBroadcastMessage {
 
 export function broadcastLogout(): void {
   const channel = new BroadcastChannel(CHANNEL_NAME);
-  const payload: AuthBroadcastMessage = { type: "logout", senderId: TAB_ID };
+  const payload: AuthBroadcastMessage = { type: "logout", senderId: CLIENT_ID };
   channel.postMessage(payload);
   channel.close();
 }
@@ -25,7 +20,7 @@ export function subscribeToAuthBroadcasts(
   const channel = new BroadcastChannel(CHANNEL_NAME);
   channel.onmessage = (event: MessageEvent<AuthBroadcastMessage>) => {
     const data = event.data;
-    if (!data || data.senderId === TAB_ID) return;
+    if (!data || data.senderId === CLIENT_ID) return;
     handler(data);
   };
   return () => channel.close();

--- a/packages/app/src/auth/auth-broadcast.ts
+++ b/packages/app/src/auth/auth-broadcast.ts
@@ -1,5 +1,13 @@
 import { CLIENT_ID } from "../lib/client-id";
 
+// Logout-only by intent. Logout is urgent: once the cookie is
+// cleared, every other tab's API calls 401 — stale "logged in"
+// state is harmful. Login is the reverse: stale "logged out" is
+// benign (shows the login button, no 401s) and SWR's focus
+// revalidation picks up the new session on next tab focus. Login
+// also lacks a clean trigger to broadcast from — it arrives via a
+// full-page redirect, not a programmatic call.
+
 const CHANNEL_NAME = "anipres:auth";
 
 interface AuthBroadcastMessage {

--- a/packages/app/src/auth/auth-broadcast.ts
+++ b/packages/app/src/auth/auth-broadcast.ts
@@ -1,0 +1,32 @@
+const CHANNEL_NAME = "anipres:auth";
+
+// Stable per-tab id used to filter the listener's own posts. Same
+// pattern as local-docs-broadcast — see that file for the rationale.
+const TAB_ID =
+  typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random()}`;
+
+interface AuthBroadcastMessage {
+  type: "logout";
+  senderId: string;
+}
+
+export function broadcastLogout(): void {
+  const channel = new BroadcastChannel(CHANNEL_NAME);
+  const payload: AuthBroadcastMessage = { type: "logout", senderId: TAB_ID };
+  channel.postMessage(payload);
+  channel.close();
+}
+
+export function subscribeToAuthBroadcasts(
+  handler: (message: AuthBroadcastMessage) => void,
+): () => void {
+  const channel = new BroadcastChannel(CHANNEL_NAME);
+  channel.onmessage = (event: MessageEvent<AuthBroadcastMessage>) => {
+    const data = event.data;
+    if (!data || data.senderId === TAB_ID) return;
+    handler(data);
+  };
+  return () => channel.close();
+}

--- a/packages/app/src/documents/DocumentManagerContext.tsx
+++ b/packages/app/src/documents/DocumentManagerContext.tsx
@@ -2,17 +2,21 @@ import type { ReactNode } from "react";
 import type { DocumentRepository } from "./repository";
 import { useDocumentManager } from "./useDocumentManager";
 import { DocumentManagerContext } from "./useDocumentManagerContext";
+import { useWorkspaceFeed } from "./useWorkspaceFeed";
 
 export function DocumentManagerProvider({
   localRepository,
   syncedRepository,
+  workspaceId,
   children,
 }: {
   localRepository: DocumentRepository;
   syncedRepository?: DocumentRepository;
+  workspaceId: string | null;
   children: ReactNode;
 }) {
   const manager = useDocumentManager({ localRepository, syncedRepository });
+  useWorkspaceFeed(workspaceId, manager.refreshDocuments);
   return (
     <DocumentManagerContext.Provider value={manager}>
       {children}

--- a/packages/app/src/documents/local-docs-broadcast.test.ts
+++ b/packages/app/src/documents/local-docs-broadcast.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  broadcastLocalDocsChanged,
+  subscribeToLocalDocsChanges,
+} from "./local-docs-broadcast";
+
+// Same-realm BroadcastChannel cross-instance behavior is what's
+// being exercised: a message posted on a fresh "anipres:local-docs"
+// channel should reach a subscriber on a separate channel of the
+// same name, except when the sender id matches.
+describe("local-docs broadcast", () => {
+  it("delivers to a subscriber when the broadcast comes from another sender", async () => {
+    const handler = vi.fn();
+    const unsubscribe = subscribeToLocalDocsChanges(handler);
+
+    // Simulate "another tab" by posting raw on the same channel name
+    // — that channel has a different sender id by construction.
+    const externalChannel = new BroadcastChannel("anipres:local-docs");
+    externalChannel.postMessage({ senderId: "other-tab" });
+    externalChannel.close();
+
+    // BroadcastChannel delivery is asynchronous; yield once.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  it("ignores broadcasts originated by the same tab", async () => {
+    const handler = vi.fn();
+    const unsubscribe = subscribeToLocalDocsChanges(handler);
+
+    broadcastLocalDocsChanged();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(handler).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it("removes the listener on unsubscribe", async () => {
+    const handler = vi.fn();
+    const unsubscribe = subscribeToLocalDocsChanges(handler);
+    unsubscribe();
+
+    const externalChannel = new BroadcastChannel("anipres:local-docs");
+    externalChannel.postMessage({ senderId: "other-tab" });
+    externalChannel.close();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/documents/local-docs-broadcast.ts
+++ b/packages/app/src/documents/local-docs-broadcast.ts
@@ -1,0 +1,31 @@
+const CHANNEL_NAME = "anipres:local-docs";
+
+// Stable per-tab id used to filter the listener's own posts. Without
+// this, broadcasting from one channel and listening on another in
+// the same tab (which subscribe + broadcast must do, since
+// BroadcastChannel only suppresses echoes on the *same* instance)
+// would loop the sender's own message back into its receiver.
+const TAB_ID =
+  typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random()}`;
+
+interface LocalDocsMessage {
+  senderId: string;
+}
+
+export function broadcastLocalDocsChanged(): void {
+  const channel = new BroadcastChannel(CHANNEL_NAME);
+  const payload: LocalDocsMessage = { senderId: TAB_ID };
+  channel.postMessage(payload);
+  channel.close();
+}
+
+export function subscribeToLocalDocsChanges(handler: () => void): () => void {
+  const channel = new BroadcastChannel(CHANNEL_NAME);
+  channel.onmessage = (event: MessageEvent<LocalDocsMessage>) => {
+    if (event.data?.senderId === TAB_ID) return;
+    handler();
+  };
+  return () => channel.close();
+}

--- a/packages/app/src/documents/local-docs-broadcast.ts
+++ b/packages/app/src/documents/local-docs-broadcast.ts
@@ -1,14 +1,11 @@
+import { CLIENT_ID } from "../lib/client-id";
+
 const CHANNEL_NAME = "anipres:local-docs";
 
-// Stable per-tab id used to filter the listener's own posts. Without
-// this, broadcasting from one channel and listening on another in
-// the same tab (which subscribe + broadcast must do, since
-// BroadcastChannel only suppresses echoes on the *same* instance)
-// would loop the sender's own message back into its receiver.
-const TAB_ID =
-  typeof crypto !== "undefined" && "randomUUID" in crypto
-    ? crypto.randomUUID()
-    : `${Date.now()}-${Math.random()}`;
+// BroadcastChannel only suppresses echoes on the *same* instance,
+// but subscribe + broadcast use separate instances (one is long-lived
+// in the listener, one is opened per post). The per-tab CLIENT_ID
+// stamps every payload so the listener can drop its own posts.
 
 interface LocalDocsMessage {
   senderId: string;
@@ -16,7 +13,7 @@ interface LocalDocsMessage {
 
 export function broadcastLocalDocsChanged(): void {
   const channel = new BroadcastChannel(CHANNEL_NAME);
-  const payload: LocalDocsMessage = { senderId: TAB_ID };
+  const payload: LocalDocsMessage = { senderId: CLIENT_ID };
   channel.postMessage(payload);
   channel.close();
 }
@@ -24,7 +21,7 @@ export function broadcastLocalDocsChanged(): void {
 export function subscribeToLocalDocsChanges(handler: () => void): () => void {
   const channel = new BroadcastChannel(CHANNEL_NAME);
   channel.onmessage = (event: MessageEvent<LocalDocsMessage>) => {
-    if (event.data?.senderId === TAB_ID) return;
+    if (event.data?.senderId === CLIENT_ID) return;
     handler();
   };
   return () => channel.close();

--- a/packages/app/src/documents/migration.ts
+++ b/packages/app/src/documents/migration.ts
@@ -1,5 +1,6 @@
 import type { TLStoreSnapshot } from "tldraw";
 import { apiClient } from "../lib/api-client";
+import { broadcastLocalDocsChanged } from "./local-docs-broadcast";
 import type { DocumentRepository } from "./repository";
 import { nextTailSortOrder } from "./sort-order";
 
@@ -324,4 +325,5 @@ export async function convertLocalDocToSynced(
   abortSignal?.throwIfAborted();
 
   await localRepository.delete(documentId);
+  broadcastLocalDocsChanged();
 }

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -9,6 +9,10 @@ import type {
   DocumentSource,
 } from "./types";
 import {
+  broadcastLocalDocsChanged,
+  subscribeToLocalDocsChanges,
+} from "./local-docs-broadcast";
+import {
   convertLocalDocToSynced,
   type ConvertLocalDocToSyncedParams,
 } from "./migration";
@@ -215,6 +219,8 @@ export function useDocumentManager(params: {
         if (defaultSource === "synced") {
           await finalizeSyncedDocument(saved.meta.id);
           if (cancelled) return;
+        } else {
+          broadcastLocalDocsChanged();
         }
         commitDocuments([saved.meta]);
         commitActiveDocumentId(saved.meta.id);
@@ -245,6 +251,16 @@ export function useDocumentManager(params: {
     const metas = await listAllDocuments();
     commitDocuments(metas);
   }, [commitDocuments, listAllDocuments]);
+
+  // Other tabs in the same browser broadcast on local IDB writes
+  // (create / rename / reorder / delete / convert-to-synced). The
+  // IDB store itself is shared, so receiving the signal is all this
+  // tab needs to pick up the change.
+  useEffect(() => {
+    return subscribeToLocalDocsChanges(() => {
+      void refreshDocuments();
+    });
+  }, [refreshDocuments]);
 
   // When the syncedRepository identity changes — login, logout, or a
   // logout-then-login cycle — any in-flight migration state is about to
@@ -303,6 +319,8 @@ export function useDocumentManager(params: {
         const saved = await repo.save(input);
         if (source === "synced") {
           await finalizeSyncedDocument(saved.meta.id);
+        } else {
+          broadcastLocalDocsChanged();
         }
 
         editorRef.current = null;
@@ -338,6 +356,9 @@ export function useDocumentManager(params: {
       }
 
       await repo.delete(id);
+      if (repo === localRepository) {
+        broadcastLocalDocsChanged();
+      }
 
       // If the migration's POST already landed before we aborted
       // (step 3 of convertLocalDocToSynced), the server holds a
@@ -397,6 +418,8 @@ export function useDocumentManager(params: {
           saved = await defaultRepo.save(input);
           if (defaultSource === "synced") {
             await finalizeSyncedDocument(saved.meta.id);
+          } else {
+            broadcastLocalDocsChanged();
           }
         } catch (error) {
           console.error(
@@ -410,6 +433,7 @@ export function useDocumentManager(params: {
             );
             try {
               saved = await localRepository.save(localInput);
+              broadcastLocalDocsChanged();
             } catch (localError) {
               console.error(
                 "Failed to create replacement local document",
@@ -463,9 +487,12 @@ export function useDocumentManager(params: {
         ...data,
         meta: { ...data.meta, title },
       });
+      if (repo === localRepository) {
+        broadcastLocalDocsChanged();
+      }
       await refreshDocuments();
     },
-    [findRepositoryForId, refreshDocuments, saveCurrentEditor],
+    [findRepositoryForId, localRepository, refreshDocuments, saveCurrentEditor],
   );
 
   const reorderDocument = useCallback(
@@ -481,9 +508,12 @@ export function useDocumentManager(params: {
         ...data,
         meta: { ...data.meta, sortOrder: newSortOrder },
       });
+      if (repo === localRepository) {
+        broadcastLocalDocsChanged();
+      }
       await refreshDocuments();
     },
-    [findRepositoryForId, refreshDocuments, saveCurrentEditor],
+    [findRepositoryForId, localRepository, refreshDocuments, saveCurrentEditor],
   );
 
   const convertToSynced = useCallback(

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -356,6 +356,11 @@ export function useDocumentManager(params: {
       }
 
       await repo.delete(id);
+      // Identity comparison rather than a `meta.source` lookup: this
+      // hook controls both branches of `getRepository`, and the local
+      // branch always returns the `localRepository` prop unchanged.
+      // Cross-tab sync for synced docs is handled server-side via the
+      // SSE feed, so the synced branch deliberately skips this.
       if (repo === localRepository) {
         broadcastLocalDocsChanged();
       }

--- a/packages/app/src/documents/useWorkspaceFeed.test.ts
+++ b/packages/app/src/documents/useWorkspaceFeed.test.ts
@@ -1,0 +1,107 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useWorkspaceFeed } from "./useWorkspaceFeed";
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  url: string;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  closed = false;
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+  emit(data: string) {
+    this.onmessage?.(new MessageEvent("message", { data }));
+  }
+  close() {
+    this.closed = true;
+  }
+}
+
+let originalEventSource: typeof EventSource;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  FakeEventSource.instances = [];
+  originalEventSource = globalThis.EventSource;
+  // @ts-expect-error — minimal stub for the API surface the hook uses
+  globalThis.EventSource = FakeEventSource;
+});
+
+afterEach(() => {
+  globalThis.EventSource = originalEventSource;
+  vi.useRealTimers();
+});
+
+describe("useWorkspaceFeed", () => {
+  it("opens EventSource on the workspace events URL and forwards messages", () => {
+    const onChange = vi.fn();
+    renderHook(() => useWorkspaceFeed("42", onChange));
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0].url).toBe("/api/workspaces/42/events");
+
+    FakeEventSource.instances[0].emit('{"type":"documents:changed"}');
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("polls the onChange callback as a backstop", () => {
+    const onChange = vi.fn();
+    renderHook(() => useWorkspaceFeed("42", onChange));
+
+    expect(onChange).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(30_000);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(30_000);
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("calls onChange on window focus", () => {
+    const onChange = vi.fn();
+    renderHook(() => useWorkspaceFeed("42", onChange));
+
+    window.dispatchEvent(new Event("focus"));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not subscribe when workspaceId is null", () => {
+    const onChange = vi.fn();
+    renderHook(() => useWorkspaceFeed(null, onChange));
+
+    expect(FakeEventSource.instances).toHaveLength(0);
+    vi.advanceTimersByTime(30_000);
+    window.dispatchEvent(new Event("focus"));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("closes EventSource and stops polling on unmount", () => {
+    const onChange = vi.fn();
+    const { unmount } = renderHook(() => useWorkspaceFeed("42", onChange));
+
+    const es = FakeEventSource.instances[0];
+    unmount();
+
+    expect(es.closed).toBe(true);
+    vi.advanceTimersByTime(30_000);
+    window.dispatchEvent(new Event("focus"));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("uses the latest onChange reference without re-subscribing", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(({ cb }) => useWorkspaceFeed("42", cb), {
+      initialProps: { cb: first },
+    });
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+    rerender({ cb: second });
+    // No new connection — same instance, same close state.
+    expect(FakeEventSource.instances).toHaveLength(1);
+
+    FakeEventSource.instances[0].emit('{"type":"documents:changed"}');
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/src/documents/useWorkspaceFeed.test.ts
+++ b/packages/app/src/documents/useWorkspaceFeed.test.ts
@@ -40,10 +40,22 @@ describe("useWorkspaceFeed", () => {
     renderHook(() => useWorkspaceFeed("42", onChange));
 
     expect(FakeEventSource.instances).toHaveLength(1);
-    expect(FakeEventSource.instances[0].url).toBe("/api/workspaces/42/events");
+    // The URL also carries the per-tab client id as a query param —
+    // tested separately below; here we just match the path portion.
+    expect(FakeEventSource.instances[0].url).toMatch(
+      /^\/api\/workspaces\/42\/events\?/u,
+    );
 
     FakeEventSource.instances[0].emit('{"type":"documents:changed"}');
     expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("includes the client id in the EventSource query string", () => {
+    const onChange = vi.fn();
+    renderHook(() => useWorkspaceFeed("42", onChange));
+
+    const url = new URL(FakeEventSource.instances[0].url, "http://example.com");
+    expect(url.searchParams.get("client_id")).toMatch(/^[0-9a-f-]+$/u);
   });
 
   it("polls the onChange callback as a backstop", () => {
@@ -103,5 +115,25 @@ describe("useWorkspaceFeed", () => {
     FakeEventSource.instances[0].emit('{"type":"documents:changed"}');
     expect(first).not.toHaveBeenCalled();
     expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("tears down the old EventSource and opens a new one when workspaceId changes", () => {
+    const onChange = vi.fn();
+    const { rerender } = renderHook(
+      ({ id }: { id: string | null }) => useWorkspaceFeed(id, onChange),
+      { initialProps: { id: "1" as string | null } },
+    );
+
+    const first = FakeEventSource.instances[0];
+    expect(first.url).toMatch(/^\/api\/workspaces\/1\/events\?/u);
+    expect(first.closed).toBe(false);
+
+    rerender({ id: "2" });
+
+    expect(first.closed).toBe(true);
+    expect(FakeEventSource.instances).toHaveLength(2);
+    expect(FakeEventSource.instances[1].url).toMatch(
+      /^\/api\/workspaces\/2\/events\?/u,
+    );
   });
 });

--- a/packages/app/src/documents/useWorkspaceFeed.ts
+++ b/packages/app/src/documents/useWorkspaceFeed.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { CLIENT_ID } from "../lib/client-id";
 
 const POLLING_INTERVAL_MS = 30_000;
 
@@ -32,7 +33,12 @@ export function useWorkspaceFeed(
   useEffect(() => {
     if (workspaceId === null) return;
 
-    const url = `/api/workspaces/${workspaceId}/events`;
+    // EventSource has no custom-header API, so the client id rides
+    // on the URL — the worker uses it to suppress same-client
+    // echoes on its own bumps.
+    const url = `/api/workspaces/${workspaceId}/events?client_id=${encodeURIComponent(
+      CLIENT_ID,
+    )}`;
     const es = new EventSource(url);
     es.onmessage = () => {
       onChangeRef.current();

--- a/packages/app/src/documents/useWorkspaceFeed.ts
+++ b/packages/app/src/documents/useWorkspaceFeed.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from "react";
+
+const POLLING_INTERVAL_MS = 30_000;
+
+/**
+ * Trigger `onChange` when the workspace's document list might have
+ * changed on the server. Three signals feed in:
+ *
+ * - **SSE** — `GET /api/workspaces/:id/events` streams `data: {...}`
+ *   lines whenever a document mutation commits in the workspace.
+ *   Provides near-instant cross-client updates while connected.
+ * - **Polling** — every 30 s, regardless of SSE state. Catches
+ *   anything missed during a stream drop or worker DO restart.
+ * - **Focus** — refetches on tab focus. Covers the "switched away
+ *   for a while, came back" path without waiting for the next tick.
+ *
+ * `workspaceId` of `null` (logged out, or workspace not yet
+ * resolved) wires up nothing.
+ */
+export function useWorkspaceFeed(
+  workspaceId: string | null,
+  onChange: () => void,
+) {
+  // Latest-callback ref pattern — keeps the long-lived EventSource
+  // callback pointing at the current `onChange` without tearing the
+  // stream down on every render.
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  });
+
+  useEffect(() => {
+    if (workspaceId === null) return;
+
+    const url = `/api/workspaces/${workspaceId}/events`;
+    const es = new EventSource(url);
+    es.onmessage = () => {
+      onChangeRef.current();
+    };
+
+    const interval = window.setInterval(() => {
+      onChangeRef.current();
+    }, POLLING_INTERVAL_MS);
+
+    const onFocus = () => {
+      onChangeRef.current();
+    };
+    window.addEventListener("focus", onFocus);
+
+    return () => {
+      es.close();
+      window.clearInterval(interval);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [workspaceId]);
+}

--- a/packages/app/src/lib/api-client.ts
+++ b/packages/app/src/lib/api-client.ts
@@ -1,5 +1,6 @@
 import { hc } from "hono/client";
 import type { AppType } from "anipres-worker/api-types";
+import { CLIENT_ID, CLIENT_ID_HEADER } from "./client-id";
 
 // `/` base — client uses relative URLs. Dev proxies API paths to
 // wrangler (see `vite.config.ts`); prod serves the bundled SPA from
@@ -13,4 +14,6 @@ import type { AppType } from "anipres-worker/api-types";
 // ahead-of-time `tsc -b` does the heavy instantiation work off the
 // editor's hot path.
 export type ApiClient = ReturnType<typeof hc<AppType>>;
-export const apiClient: ApiClient = hc<AppType>("/");
+export const apiClient: ApiClient = hc<AppType>("/", {
+  headers: { [CLIENT_ID_HEADER]: CLIENT_ID },
+});

--- a/packages/app/src/lib/client-id.ts
+++ b/packages/app/src/lib/client-id.ts
@@ -1,10 +1,12 @@
-// Per-tab client identifier sent on every API request and on the
-// EventSource handshake. The worker stamps it onto each
-// "documents:changed" SSE broadcast and the WorkspaceFeedRoom DO
-// suppresses fanOut to subscribers whose id matches — so a tab
-// doesn't get its own mutations echoed back as a redundant doc-list
-// refetch a moment after the mutation response already updated
-// local state.
+// Per-tab identifier used wherever a self-echo needs to be
+// filtered:
+//
+// - On every API request (header) + the EventSource handshake
+//   (`?client_id=`), so the WorkspaceFeedRoom DO can skip fanOut
+//   to the originating tab on its own bumps.
+// - On BroadcastChannel posts (local-docs-broadcast,
+//   auth-broadcast), so a tab listening on the same channel name
+//   it just posted to ignores its own message.
 //
 // Generated once at module load — fresh tab → fresh id. Generic
 // uniqueness is enough; this is not a security boundary.

--- a/packages/app/src/lib/client-id.ts
+++ b/packages/app/src/lib/client-id.ts
@@ -1,0 +1,16 @@
+// Per-tab client identifier sent on every API request and on the
+// EventSource handshake. The worker stamps it onto each
+// "documents:changed" SSE broadcast and the WorkspaceFeedRoom DO
+// suppresses fanOut to subscribers whose id matches — so a tab
+// doesn't get its own mutations echoed back as a redundant doc-list
+// refetch a moment after the mutation response already updated
+// local state.
+//
+// Generated once at module load — fresh tab → fresh id. Generic
+// uniqueness is enough; this is not a security boundary.
+export const CLIENT_ID =
+  typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random()}`;
+
+export const CLIENT_ID_HEADER = "X-Anipres-Client-Id";

--- a/packages/worker/src/WorkspaceFeedRoom.test.ts
+++ b/packages/worker/src/WorkspaceFeedRoom.test.ts
@@ -1,0 +1,130 @@
+import { runInDurableObject } from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+import type { WorkspaceFeedRoom } from "./WorkspaceFeedRoom";
+
+function getRoom(name: string) {
+  const id = env.WORKSPACE_FEED_ROOM.idFromName(name);
+  return env.WORKSPACE_FEED_ROOM.get(id);
+}
+
+async function readNextChunk(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<string> {
+  const { value, done } = await reader.read();
+  if (done || value === undefined) {
+    throw new Error("stream ended unexpectedly");
+  }
+  return new TextDecoder().decode(value);
+}
+
+// All test bodies run inside `runInDurableObject` so the streams
+// stay within the DO instance. Reading streams across the RPC
+// boundary works for the production fetch handler but tears down
+// noisily when a test exits — keeping the read loop in-DO sidesteps
+// the "Network connection lost" tail.
+
+describe("WorkspaceFeedRoom", () => {
+  it("delivers a broadcast event to a subscribed stream", async () => {
+    const room = getRoom("delivers-event");
+    const result = await runInDurableObject(
+      room,
+      async (instance: WorkspaceFeedRoom) => {
+        const stream = await instance.subscribe(null);
+        const reader = stream.getReader();
+        const initial = await readNextChunk(reader);
+        await instance.broadcast({ type: "documents:changed" }, null);
+        const event = await readNextChunk(reader);
+        await reader.cancel();
+        return { initial, event };
+      },
+    );
+
+    expect(result.initial).toBe(":ok\n\n");
+    expect(result.event).toBe('data: {"type":"documents:changed"}\n\n');
+  });
+
+  it("filters out broadcasts whose senderId matches the subscriber's clientId", async () => {
+    const room = getRoom("self-echo-filter");
+    const events = await runInDurableObject(
+      room,
+      async (instance: WorkspaceFeedRoom) => {
+        const stream = await instance.subscribe("client-A");
+        const reader = stream.getReader();
+        await readNextChunk(reader); // discard ":ok"
+
+        // External, self, external. The middle one must not appear.
+        await instance.broadcast({ type: "documents:changed" }, "client-B");
+        await instance.broadcast({ type: "documents:changed" }, "client-A");
+        await instance.broadcast({ type: "documents:changed" }, "client-C");
+
+        const first = await readNextChunk(reader);
+        const second = await readNextChunk(reader);
+        await reader.cancel();
+        return [first, second];
+      },
+    );
+
+    expect(events).toEqual([
+      'data: {"type":"documents:changed"}\n\n',
+      'data: {"type":"documents:changed"}\n\n',
+    ]);
+  });
+
+  it("delivers broadcasts to multiple subscribers", async () => {
+    const room = getRoom("fanout-multi");
+    const result = await runInDurableObject(
+      room,
+      async (instance: WorkspaceFeedRoom) => {
+        const streamA = await instance.subscribe("client-A");
+        const streamB = await instance.subscribe("client-B");
+        const readerA = streamA.getReader();
+        const readerB = streamB.getReader();
+        await readNextChunk(readerA);
+        await readNextChunk(readerB);
+
+        await instance.broadcast({ type: "documents:changed" }, null);
+
+        const eventA = await readNextChunk(readerA);
+        const eventB = await readNextChunk(readerB);
+        await readerA.cancel();
+        await readerB.cancel();
+        return { eventA, eventB };
+      },
+    );
+
+    expect(result.eventA).toBe('data: {"type":"documents:changed"}\n\n');
+    expect(result.eventB).toBe('data: {"type":"documents:changed"}\n\n');
+  });
+
+  it("does not echo self-broadcasts but still reaches sibling subscribers", async () => {
+    const room = getRoom("fanout-self-and-others");
+    const result = await runInDurableObject(
+      room,
+      async (instance: WorkspaceFeedRoom) => {
+        const streamA = await instance.subscribe("client-A");
+        const streamB = await instance.subscribe("client-B");
+        const readerA = streamA.getReader();
+        const readerB = streamB.getReader();
+        await readNextChunk(readerA);
+        await readNextChunk(readerB);
+
+        // From A — reaches B, not A.
+        await instance.broadcast({ type: "documents:changed" }, "client-A");
+        const bFirst = await readNextChunk(readerB);
+
+        // External anchor that A does see — landing on this chunk
+        // proves A skipped the self-echo without needing a timeout.
+        await instance.broadcast({ type: "documents:changed" }, "client-C");
+        const aFirst = await readNextChunk(readerA);
+
+        await readerA.cancel();
+        await readerB.cancel();
+        return { aFirst, bFirst };
+      },
+    );
+
+    expect(result.aFirst).toBe('data: {"type":"documents:changed"}\n\n');
+    expect(result.bFirst).toBe('data: {"type":"documents:changed"}\n\n');
+  });
+});

--- a/packages/worker/src/WorkspaceFeedRoom.ts
+++ b/packages/worker/src/WorkspaceFeedRoom.ts
@@ -1,0 +1,95 @@
+import { DurableObject } from "cloudflare:workers";
+import type { AppContext, Env as WorkerEnv } from "./types";
+
+// Idle keepalive cadence. EventSource through any of the usual
+// proxies (Cloudflare's own edge, customer proxies, mobile carriers)
+// can drop a stream that has been silent for a few minutes; sending
+// an SSE comment line ":\n\n" every 30s keeps the path warm without
+// reaching the user-facing onmessage handler.
+const KEEPALIVE_MS = 30_000;
+
+export type WorkspaceFeedEvent = { type: "documents:changed" };
+
+/**
+ * Per-workspace transient pubsub. One DO instance per workspace
+ * holds the live SSE subscriber list in memory. Mutation routes call
+ * `broadcast()` after committing changes; subscribers receive a
+ * "documents:changed" event and refetch the list.
+ *
+ * No persisted storage — if the DO restarts, subscribers reconnect
+ * via EventSource's built-in retry, and the client's polling
+ * backstop covers anything missed in the gap.
+ */
+export class WorkspaceFeedRoom extends DurableObject<WorkerEnv> {
+  private subscribers = new Set<
+    ReadableStreamDefaultController<Uint8Array>
+  >();
+  private encoder = new TextEncoder();
+  private keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+
+  async subscribe(): Promise<ReadableStream<Uint8Array>> {
+    let myController: ReadableStreamDefaultController<Uint8Array> | null = null;
+    const stream = new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        myController = controller;
+        this.subscribers.add(controller);
+        // Initial SSE comment flushes headers immediately and lets
+        // the client know the stream is open.
+        controller.enqueue(this.encoder.encode(":ok\n\n"));
+        this.ensureKeepalive();
+      },
+      cancel: () => {
+        if (myController) {
+          this.subscribers.delete(myController);
+          this.maybeStopKeepalive();
+        }
+      },
+    });
+    return stream;
+  }
+
+  async broadcast(event: WorkspaceFeedEvent): Promise<void> {
+    const payload = this.encoder.encode(
+      `data: ${JSON.stringify(event)}\n\n`,
+    );
+    this.fanOut(payload);
+  }
+
+  private fanOut(payload: Uint8Array) {
+    const dead: ReadableStreamDefaultController<Uint8Array>[] = [];
+    for (const controller of this.subscribers) {
+      try {
+        controller.enqueue(payload);
+      } catch {
+        dead.push(controller);
+      }
+    }
+    for (const controller of dead) {
+      this.subscribers.delete(controller);
+    }
+    this.maybeStopKeepalive();
+  }
+
+  private ensureKeepalive() {
+    if (this.keepaliveTimer !== null) return;
+    this.keepaliveTimer = setInterval(() => {
+      this.fanOut(this.encoder.encode(`:ka\n\n`));
+    }, KEEPALIVE_MS);
+  }
+
+  private maybeStopKeepalive() {
+    if (this.subscribers.size === 0 && this.keepaliveTimer !== null) {
+      clearInterval(this.keepaliveTimer);
+      this.keepaliveTimer = null;
+    }
+  }
+}
+
+export function bumpWorkspaceFeed(c: AppContext, workspaceId: number) {
+  const ns = c.env.WORKSPACE_FEED_ROOM;
+  const stub = ns.get(ns.idFromName(`workspace:${workspaceId}`));
+  // Fire-and-forget: a dropped notification is recoverable via the
+  // client's refreshInterval polling backstop, so don't make the
+  // mutation response wait on the DO RPC.
+  c.executionCtx.waitUntil(stub.broadcast({ type: "documents:changed" }));
+}

--- a/packages/worker/src/WorkspaceFeedRoom.ts
+++ b/packages/worker/src/WorkspaceFeedRoom.ts
@@ -10,6 +10,15 @@ const KEEPALIVE_MS = 30_000;
 
 export type WorkspaceFeedEvent = { type: "documents:changed" };
 
+interface Subscriber {
+  controller: ReadableStreamDefaultController<Uint8Array>;
+  // Per-tab id from the EventSource handshake (`?client_id=`). When
+  // a mutation route bumps with a senderId equal to this, the
+  // broadcast skips this subscriber — the originating tab already
+  // updated its view via the mutation response.
+  clientId: string | null;
+}
+
 /**
  * Per-workspace transient pubsub. One DO instance per workspace
  * holds the live SSE subscriber list in memory. Mutation routes call
@@ -21,26 +30,24 @@ export type WorkspaceFeedEvent = { type: "documents:changed" };
  * backstop covers anything missed in the gap.
  */
 export class WorkspaceFeedRoom extends DurableObject<WorkerEnv> {
-  private subscribers = new Set<
-    ReadableStreamDefaultController<Uint8Array>
-  >();
+  private subscribers = new Set<Subscriber>();
   private encoder = new TextEncoder();
   private keepaliveTimer: ReturnType<typeof setInterval> | null = null;
 
-  async subscribe(): Promise<ReadableStream<Uint8Array>> {
-    let myController: ReadableStreamDefaultController<Uint8Array> | null = null;
+  async subscribe(clientId: string | null): Promise<ReadableStream<Uint8Array>> {
+    let mySubscriber: Subscriber | null = null;
     const stream = new ReadableStream<Uint8Array>({
       start: (controller) => {
-        myController = controller;
-        this.subscribers.add(controller);
+        mySubscriber = { controller, clientId };
+        this.subscribers.add(mySubscriber);
         // Initial SSE comment flushes headers immediately and lets
         // the client know the stream is open.
         controller.enqueue(this.encoder.encode(":ok\n\n"));
         this.ensureKeepalive();
       },
       cancel: () => {
-        if (myController) {
-          this.subscribers.delete(myController);
+        if (mySubscriber) {
+          this.subscribers.delete(mySubscriber);
           this.maybeStopKeepalive();
         }
       },
@@ -48,24 +55,31 @@ export class WorkspaceFeedRoom extends DurableObject<WorkerEnv> {
     return stream;
   }
 
-  async broadcast(event: WorkspaceFeedEvent): Promise<void> {
-    const payload = this.encoder.encode(
-      `data: ${JSON.stringify(event)}\n\n`,
-    );
-    this.fanOut(payload);
+  async broadcast(
+    event: WorkspaceFeedEvent,
+    senderId: string | null,
+  ): Promise<void> {
+    const payload = this.encoder.encode(`data: ${JSON.stringify(event)}\n\n`);
+    this.fanOut(payload, senderId);
   }
 
-  private fanOut(payload: Uint8Array) {
-    const dead: ReadableStreamDefaultController<Uint8Array>[] = [];
-    for (const controller of this.subscribers) {
+  // A subscriber that disconnects without firing `cancel` (network
+  // drop, suspended mobile tab) leaves itself in the set until the
+  // next enqueue throws. The keepalive's periodic fanOut bounds that
+  // linger window to ~KEEPALIVE_MS so dead subscribers get culled on
+  // a regular cadence even when no real broadcasts are in flight.
+  private fanOut(payload: Uint8Array, senderId: string | null) {
+    const dead: Subscriber[] = [];
+    for (const subscriber of this.subscribers) {
+      if (senderId !== null && subscriber.clientId === senderId) continue;
       try {
-        controller.enqueue(payload);
+        subscriber.controller.enqueue(payload);
       } catch {
-        dead.push(controller);
+        dead.push(subscriber);
       }
     }
-    for (const controller of dead) {
-      this.subscribers.delete(controller);
+    for (const subscriber of dead) {
+      this.subscribers.delete(subscriber);
     }
     this.maybeStopKeepalive();
   }
@@ -73,7 +87,10 @@ export class WorkspaceFeedRoom extends DurableObject<WorkerEnv> {
   private ensureKeepalive() {
     if (this.keepaliveTimer !== null) return;
     this.keepaliveTimer = setInterval(() => {
-      this.fanOut(this.encoder.encode(`:ka\n\n`));
+      // Keepalive is a comment line (no `senderId` filtering needed
+      // — comments don't reach `onmessage` anyway) sent to every
+      // active subscriber.
+      this.fanOut(this.encoder.encode(`:ka\n\n`), null);
     }, KEEPALIVE_MS);
   }
 
@@ -85,11 +102,20 @@ export class WorkspaceFeedRoom extends DurableObject<WorkerEnv> {
   }
 }
 
+// Header set by the app's API client on every request. Mutation
+// routes pass this through to the DO so the originating tab's SSE
+// subscriber doesn't get its own bump echoed back as a redundant
+// doc-list refetch.
+export const CLIENT_ID_HEADER = "X-Anipres-Client-Id";
+
 export function bumpWorkspaceFeed(c: AppContext, workspaceId: number) {
+  const senderId = c.req.header(CLIENT_ID_HEADER) ?? null;
   const ns = c.env.WORKSPACE_FEED_ROOM;
   const stub = ns.get(ns.idFromName(`workspace:${workspaceId}`));
   // Fire-and-forget: a dropped notification is recoverable via the
   // client's refreshInterval polling backstop, so don't make the
   // mutation response wait on the DO RPC.
-  c.executionCtx.waitUntil(stub.broadcast({ type: "documents:changed" }));
+  c.executionCtx.waitUntil(
+    stub.broadcast({ type: "documents:changed" }, senderId),
+  );
 }

--- a/packages/worker/src/routes/documents.ts
+++ b/packages/worker/src/routes/documents.ts
@@ -5,6 +5,7 @@ import * as v from "valibot";
 import { documentIdParamSchema } from "../schemas";
 import { startDocumentDeletion } from "../tldraw-assets";
 import type { AppBindings, AppContext } from "../types";
+import { bumpWorkspaceFeed } from "../WorkspaceFeedRoom";
 
 const nonNegativeFiniteInteger = v.pipe(
   v.number(),
@@ -274,6 +275,13 @@ export const documentsRoutes = new Hono<AppBindings>()
           // the workspace it asked for.
           return c.json({ error: "Not found" }, 404);
         }
+        // Initializing rows aren't visible in /api/documents, so an
+        // update on one doesn't change list output for any
+        // subscriber yet. Skip the bump until /finalize or the
+        // finalizing snapshot push transitions the row into view.
+        if (existing.initializing_at === null) {
+          bumpWorkspaceFeed(c, workspaceId);
+        }
         return c.json(row, 200);
       }
 
@@ -346,13 +354,14 @@ export const documentsRoutes = new Hono<AppBindings>()
       const userId = c.get("userId");
       const { id } = c.req.valid("param");
       const document = await c.env.DB.prepare(
-        `SELECT deleting_at, initializing_at
+        `SELECT workspace_id, deleting_at, initializing_at
          FROM documents
          WHERE id = ?
            AND workspace_id IN (SELECT id FROM workspaces WHERE owner_user_id = ?)`,
       )
         .bind(id, userId)
         .first<{
+          workspace_id: number;
           deleting_at: number | null;
           initializing_at: number | null;
         }>();
@@ -378,6 +387,7 @@ export const documentsRoutes = new Hono<AppBindings>()
       }
 
       await startDocumentDeletion(c, userId, id);
+      bumpWorkspaceFeed(c, document.workspace_id);
       return c.json({ ok: true as const }, 200);
     },
   )
@@ -406,35 +416,39 @@ export const documentsRoutes = new Hono<AppBindings>()
       // update path: we don't want a finalize call to revive a
       // soft-deleted doc, and we want a clean 404 for foreign /
       // non-existent ids.
-      const result = await c.env.DB.prepare(
+      const finalized = await c.env.DB.prepare(
         `UPDATE documents
             SET initializing_at = NULL
           WHERE id = ?
             AND workspace_id IN (SELECT id FROM workspaces WHERE owner_user_id = ?)
             AND deleting_at IS NULL
-            AND initializing_at IS NOT NULL`,
+            AND initializing_at IS NOT NULL
+        RETURNING workspace_id`,
       )
         .bind(id, userId)
-        .run();
+        .first<{ workspace_id: number }>();
 
-      if ((result.meta.changes ?? 0) === 0) {
-        // Either the doc doesn't exist for this user, or it's already
-        // finalized. Both cases respond with 200 — the caller's intent
-        // ("make sure this doc is finalized") is satisfied either way.
-        // Distinguish the not-found case so the client can surface a
-        // genuine error if the row really doesn't exist.
-        const exists = await c.env.DB.prepare(
-          `SELECT 1
-           FROM documents
-           WHERE id = ?
-             AND workspace_id IN (SELECT id FROM workspaces WHERE owner_user_id = ?)
-             AND deleting_at IS NULL`,
-        )
-          .bind(id, userId)
-          .first();
-        if (!exists) {
-          return c.json({ error: "Not found" }, 404);
-        }
+      if (finalized) {
+        bumpWorkspaceFeed(c, finalized.workspace_id);
+        return c.json({ ok: true as const }, 200);
+      }
+
+      // Either the doc doesn't exist for this user, or it's already
+      // finalized. Both cases respond with 200 — the caller's intent
+      // ("make sure this doc is finalized") is satisfied either way.
+      // Distinguish the not-found case so the client can surface a
+      // genuine error if the row really doesn't exist.
+      const exists = await c.env.DB.prepare(
+        `SELECT 1
+         FROM documents
+         WHERE id = ?
+           AND workspace_id IN (SELECT id FROM workspaces WHERE owner_user_id = ?)
+           AND deleting_at IS NULL`,
+      )
+        .bind(id, userId)
+        .first();
+      if (!exists) {
+        return c.json({ error: "Not found" }, 404);
       }
 
       return c.json({ ok: true as const }, 200);
@@ -488,14 +502,14 @@ export const documentsRoutes = new Hono<AppBindings>()
       // finalizing it. Only soft-deleting rows are off-limits (their
       // DO state is being torn down).
       const row = await c.env.DB.prepare(
-        `SELECT 1
+        `SELECT workspace_id, initializing_at
          FROM documents
          WHERE id = ?
            AND workspace_id IN (SELECT id FROM workspaces WHERE owner_user_id = ?)
            AND deleting_at IS NULL`,
       )
         .bind(id, userId)
-        .first();
+        .first<{ workspace_id: number; initializing_at: number | null }>();
       if (!row) {
         return c.json({ error: "Not found" }, 404);
       }
@@ -537,6 +551,15 @@ export const documentsRoutes = new Hono<AppBindings>()
       )
         .bind(now, id, userId)
         .run();
+
+      // Bump only on the initializing → visible transition. Bumping
+      // on every snapshot push (which the editor issues every few
+      // seconds during active drawing) would flood subscribers with
+      // doc-list refetches that wouldn't see any change in the list
+      // output beyond updated_at.
+      if (row.initializing_at !== null) {
+        bumpWorkspaceFeed(c, row.workspace_id);
+      }
 
       return c.json({ ok: true as const }, 200);
     },

--- a/packages/worker/src/routes/workspaces.ts
+++ b/packages/worker/src/routes/workspaces.ts
@@ -1,4 +1,6 @@
+import { vValidator } from "@hono/valibot-validator";
 import { Hono } from "hono";
+import * as v from "valibot";
 import type { AppBindings } from "../types";
 
 type WorkspaceRow = {
@@ -8,9 +10,16 @@ type WorkspaceRow = {
   updated_at: number;
 };
 
-export const workspacesRoutes = new Hono<AppBindings>().get(
-  "/api/workspaces",
-  async (c) => {
+const workspaceIdParamSchema = v.object({
+  id: v.pipe(
+    v.string(),
+    v.regex(/^[1-9]\d*$/u, "Invalid workspace id"),
+    v.transform(Number),
+  ),
+});
+
+export const workspacesRoutes = new Hono<AppBindings>()
+  .get("/api/workspaces", async (c) => {
     const userId = c.get("userId");
     const { results } = await c.env.DB.prepare(
       `SELECT id, name, created_at, updated_at
@@ -24,7 +33,49 @@ export const workspacesRoutes = new Hono<AppBindings>().get(
       results.map((row) => ({ ...row, id: String(row.id) })),
       200,
     );
-  },
-);
+  })
+  // SSE feed of workspace-scoped events. The only event today is
+  // {"type":"documents:changed"} — the receiver re-fetches
+  // /api/documents to get the current list. The stream stays open
+  // for the lifetime of the EventSource; the client's auto-retry +
+  // refreshInterval polling backstop covers any drop.
+  .get(
+    "/api/workspaces/:id/events",
+    vValidator("param", workspaceIdParamSchema, (result, c) => {
+      if (!result.success) {
+        return c.json(
+          { error: "Invalid workspace id", details: result.issues },
+          400,
+        );
+      }
+    }),
+    async (c) => {
+      const userId = c.get("userId");
+      const { id: workspaceId } = c.req.valid("param");
+
+      const owns = await c.env.DB.prepare(
+        "SELECT 1 FROM workspaces WHERE id = ? AND owner_user_id = ?",
+      )
+        .bind(workspaceId, userId)
+        .first();
+      if (!owns) {
+        return c.json({ error: "Not found" }, 404);
+      }
+
+      const ns = c.env.WORKSPACE_FEED_ROOM;
+      const stub = ns.get(ns.idFromName(`workspace:${workspaceId}`));
+      const stream = await stub.subscribe();
+
+      return new Response(stream, {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache, no-transform",
+          // Counter Cloudflare's response buffering for SSE so each
+          // event line reaches the client immediately.
+          "X-Accel-Buffering": "no",
+        },
+      });
+    },
+  );
 
 export type WorkspacesRoutes = typeof workspacesRoutes;

--- a/packages/worker/src/routes/workspaces.ts
+++ b/packages/worker/src/routes/workspaces.ts
@@ -62,9 +62,14 @@ export const workspacesRoutes = new Hono<AppBindings>()
         return c.json({ error: "Not found" }, 404);
       }
 
+      // Per-tab id from the client (`?client_id=`). Used by the DO
+      // to suppress fanOut to the originating tab on its own bumps.
+      // EventSource has no header API, hence the query string.
+      const clientId = c.req.query("client_id") ?? null;
+
       const ns = c.env.WORKSPACE_FEED_ROOM;
       const stub = ns.get(ns.idFromName(`workspace:${workspaceId}`));
-      const stream = await stub.subscribe();
+      const stream = await stub.subscribe(clientId);
 
       return new Response(stream, {
         headers: {

--- a/packages/worker/src/types.ts
+++ b/packages/worker/src/types.ts
@@ -1,8 +1,10 @@
 import type { Context } from "hono";
 import type { DocumentSyncRoom } from "./DocumentSyncRoom";
+import type { WorkspaceFeedRoom } from "./WorkspaceFeedRoom";
 
 export interface Env {
   DOCUMENT_SYNC_ROOM: DurableObjectNamespace<DocumentSyncRoom>;
+  WORKSPACE_FEED_ROOM: DurableObjectNamespace<WorkspaceFeedRoom>;
   DB: D1Database;
   GITHUB_ID: string;
   GITHUB_SECRET: string;

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -10,6 +10,7 @@ import { workspacesRoutes } from "./routes/workspaces";
 import type { AppBindings, Env } from "./types";
 
 export { DocumentSyncRoom } from "./DocumentSyncRoom";
+export { WorkspaceFeedRoom } from "./WorkspaceFeedRoom";
 
 const app = new Hono<AppBindings>();
 

--- a/packages/worker/wrangler.toml
+++ b/packages/worker/wrangler.toml
@@ -45,7 +45,8 @@ PUBLIC_BASE_URL = "https://anipres.app"
 
 [durable_objects]
 bindings = [
-  { name = "DOCUMENT_SYNC_ROOM", class_name = "DocumentSyncRoom" }
+  { name = "DOCUMENT_SYNC_ROOM", class_name = "DocumentSyncRoom" },
+  { name = "WORKSPACE_FEED_ROOM", class_name = "WorkspaceFeedRoom" }
 ]
 
 [[d1_databases]]
@@ -60,6 +61,10 @@ database_id = "local"
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["DocumentSyncRoom"]
+
+[[migrations]]
+tag = "v2"
+new_classes = ["WorkspaceFeedRoom"]
 
 [[r2_buckets]]
 binding = "ASSETS"
@@ -104,15 +109,20 @@ run_worker_first = ["/api/*", "/auth/*"]
 
 [env.preview.durable_objects]
 bindings = [
-  { name = "DOCUMENT_SYNC_ROOM", class_name = "DocumentSyncRoom" }
+  { name = "DOCUMENT_SYNC_ROOM", class_name = "DocumentSyncRoom" },
+  { name = "WORKSPACE_FEED_ROOM", class_name = "WorkspaceFeedRoom" }
 ]
 
 # DO migrations apply to the script's class definitions, but wrangler
-# tracks them per-env, so the preview env needs its own copy of the v1
-# tag.
+# tracks them per-env, so the preview env needs its own copy of the
+# tags.
 [[env.preview.migrations]]
 tag = "v1"
 new_sqlite_classes = ["DocumentSyncRoom"]
+
+[[env.preview.migrations]]
+tag = "v2"
+new_classes = ["WorkspaceFeedRoom"]
 
 [[env.preview.d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## Summary

Three layers of "the other tab / device just changed something — pick it up" sync, none of which existed before this PR:

1. **Synced docs across clients (server-mediated)** — A per-workspace \`WorkspaceFeedRoom\` Durable Object holds the live SSE subscriber list in memory. \`GET /api/workspaces/:id/events\` streams \`{type:"documents:changed"}\` events. Mutation routes (\`PUT /api/documents/:id\`, \`DELETE\`, \`/finalize\`, the finalizing snapshot push) call \`bumpWorkspaceFeed\` after committing. The DO has no persisted storage — drops are recovered by EventSource auto-retry plus the client's polling backstop.
2. **Local docs across tabs (BroadcastChannel)** — Local IDB is already shared across tabs in the same browser, so the data is already consistent; what's missing is the *signal*. \`anipres:local-docs\` carries a "changed" message at every list-affecting local write. Per-tab-id filter prevents self-echo.
3. **Logout across tabs (BroadcastChannel)** — \`anipres:auth\` carries a \`{type:"logout"}\` message after a successful \`POST /auth/logout\`. Listening tabs call the same \`wipeAllCaches\` helper that the local logout uses. Login is full-page redirect → no broadcast needed; focus revalidation handles it.

The client doc-list subscription is wired in \`DocumentManagerProvider\` via a new \`useWorkspaceFeed(workspaceId, refreshDocuments)\` hook that combines SSE + 30 s polling + window-focus revalidation. SSE provides instant updates; the polling backstop catches anything missed during a stream drop or DO restart.

## Commits

- \`d3404b4\` — feat(worker): WorkspaceFeedRoom DO + SSE endpoint + bumps on doc mutations
- \`0879ff2\` — feat(app): subscribe doc-list to the workspace SSE feed + polling backstop
- \`2990d16\` — feat(app): broadcast local doc list changes across tabs in the same browser
- \`8e62bfa\` — feat(app): broadcast logout across tabs in the same browser

## Test plan

- [x] \`pnpm -F app typecheck\` — passes
- [x] \`pnpm -F app lint\` — passes
- [x] \`pnpm -F app test --run\` — 109 / 109 (added: 6 \`useWorkspaceFeed\`, 3 local-docs-broadcast, 3 auth-broadcast)
- [x] \`pnpm -F anipres-worker typecheck\` — passes
- [x] \`pnpm -F anipres-worker test --run\` — 47 / 47
- [ ] Manual cross-client check on preview: open the app in two browsers (or one browser + one incognito) signed into the same account; create / rename / delete a synced doc in A; verify B's sidebar updates within ~1 s (SSE) and within ~30 s if SSE is somehow blocked.
- [ ] Manual cross-tab check: open two tabs in the same browser; create / rename / delete a *local* doc in A; verify B's sidebar updates within ~ms.
- [ ] Manual logout-across-tabs check: open two tabs in the same browser, signed in; click logout in A; verify B drops to the logged-out state without needing to refocus.

## Notes

- DO has no persisted storage. A DO restart drops in-flight subscribers; \`EventSource\` reconnects automatically and the client's polling backstop covers anything missed in the gap.
- Snapshot pushes during active drawing are *not* broadcast — only the initializing→visible transition is. Otherwise every few-second snapshot tick would flood subscribers with refetches whose list output doesn't change beyond \`updated_at\`.
- Base is \`feature/sync-server\` (PR #409). Once that lands in \`main\`, GitHub will rebase this PR's base automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)