### PR TITLE
ci(worker): reset preview D1 before deploy when migrations changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          # Need history back to the PR base to diff
+          # `packages/worker/migrations/` for the reset gate below.
+          # Only needed on the PR path; harmless on main pushes.
+          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
@@ -344,6 +348,28 @@ jobs:
         with:
           name: app-dist
           path: packages/app/dist
+
+      # Wrangler tracks applied D1 migrations by filename in the
+      # internal `d1_migrations` table. If a migration file is edited
+      # mid-review (or renamed, squashed), the next apply sees the tag
+      # as done and silently skips the new contents — preview's schema
+      # then drifts permanently from the file. When this PR's
+      # `migrations/` differs from the base, wipe preview D1 first so
+      # the subsequent `migrate:remote:preview` rebuilds from scratch.
+      # Skipped on main pushes (preview isn't deployed there).
+      - name: Reset preview D1 if migrations changed
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if git diff --name-only "$BASE_SHA"...HEAD -- migrations/ | grep -q .; then
+            echo "Migrations changed since $BASE_SHA — resetting preview D1."
+            pnpm reset:remote:preview
+          else
+            echo "Migrations unchanged since $BASE_SHA — skipping preview D1 reset."
+          fi
 
       - name: Deploy worker
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,13 +363,23 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        # `git diff --quiet` distinguishes the three outcomes by exit
+        # code (0 unchanged, 1 changed, >1 error), so a real failure
+        # surfaces instead of being silently routed to "skip reset" —
+        # which `if git diff … | grep -q .` would do under `set -e`,
+        # since `if` disables errexit for the condition.
         run: |
-          if git diff --name-only "$BASE_SHA"...HEAD -- migrations/ | grep -q .; then
-            echo "Migrations changed since $BASE_SHA — resetting preview D1."
-            pnpm reset:remote:preview
-          else
-            echo "Migrations unchanged since $BASE_SHA — skipping preview D1 reset."
-          fi
+          set +e
+          git diff --quiet "$BASE_SHA"...HEAD -- migrations/
+          rc=$?
+          set -e
+          case "$rc" in
+            0) echo "Migrations unchanged since $BASE_SHA — skipping preview D1 reset." ;;
+            1) echo "Migrations changed since $BASE_SHA — resetting preview D1."
+               pnpm reset:remote:preview ;;
+            *) echo "git diff failed (exit $rc); refusing to deploy."
+               exit "$rc" ;;
+          esac
 
       - name: Deploy worker
         env:

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -17,6 +17,7 @@
     "migrate:local": "wrangler d1 migrations apply DB --local",
     "migrate:remote": "wrangler d1 migrations apply DB --remote",
     "migrate:remote:preview": "wrangler d1 migrations apply DB --remote --env preview",
+    "reset:remote:preview": "node ./scripts/reset-preview-d1.mjs",
     "build:types": "tsc -b tsconfig.build.json",
     "typecheck": "tsc",
     "test": "vitest"

--- a/packages/worker/scripts/reset-preview-d1.mjs
+++ b/packages/worker/scripts/reset-preview-d1.mjs
@@ -24,15 +24,31 @@ function wrangler(args, opts = {}) {
   );
 }
 
-const listSQL =
-  "SELECT type, name FROM sqlite_master " +
-  "WHERE name NOT LIKE 'sqlite_%' " +
-  "AND type IN ('table','index','trigger','view')";
+// `wrangler --json` is meant to emit JSON-only on stdout. Try the
+// straight parse first; fall back to extracting from the first line
+// that starts with `[` or `{` if a banner ever sneaks in (vs the
+// looser `indexOf('[')`, which would match a stray `[` inside such a
+// banner and slice at the wrong byte).
+function parseWranglerJSON(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    const match = raw.match(/^[[{]/m);
+    if (!match) {
+      throw new Error(`wrangler stdout did not contain JSON:\n${raw}`);
+    }
+    return JSON.parse(raw.slice(match.index));
+  }
+}
+
+const listSQL = `
+  SELECT type, name FROM sqlite_master
+  WHERE name NOT LIKE 'sqlite_%'
+    AND type IN ('table','index','trigger','view')
+`;
 
 const raw = wrangler(["--json", "--command", listSQL]);
-const jsonStart = raw.indexOf("[");
-const objects =
-  (jsonStart >= 0 ? JSON.parse(raw.slice(jsonStart)) : [])[0]?.results ?? [];
+const objects = parseWranglerJSON(raw)[0]?.results ?? [];
 
 if (objects.length === 0) {
   console.log("Preview D1 is already empty — nothing to drop.");

--- a/packages/worker/scripts/reset-preview-d1.mjs
+++ b/packages/worker/scripts/reset-preview-d1.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Wipe the shared preview D1 so the next `wrangler d1 migrations apply`
+// runs the full set from scratch — applied tags and all.
+//
+// Why: wrangler tracks applied migration tags by filename in the
+// internal `d1_migrations` table. If a migration file is edited
+// mid-review (or renamed, squashed), the next apply sees the tag as
+// done and silently skips the new contents — preview's schema then
+// drifts permanently from the file. CI calls this script before
+// `migrate:remote:preview` whenever `packages/worker/migrations/`
+// differs from the PR base, so the rebuild is always from-scratch and
+// the edited content actually lands.
+//
+// Hardcoded to `--remote --env preview` so it cannot be aimed at prod
+// by passing the wrong flag.
+
+import { execFileSync } from "node:child_process";
+
+function wrangler(args, opts = {}) {
+  return execFileSync(
+    "wrangler",
+    ["d1", "execute", "DB", "--remote", "--env", "preview", ...args],
+    { encoding: "utf8", ...opts },
+  );
+}
+
+const listSQL =
+  "SELECT type, name FROM sqlite_master " +
+  "WHERE name NOT LIKE 'sqlite_%' " +
+  "AND type IN ('table','index','trigger','view')";
+
+const raw = wrangler(["--json", "--command", listSQL]);
+const jsonStart = raw.indexOf("[");
+const objects =
+  (jsonStart >= 0 ? JSON.parse(raw.slice(jsonStart)) : [])[0]?.results ?? [];
+
+if (objects.length === 0) {
+  console.log("Preview D1 is already empty — nothing to drop.");
+  process.exit(0);
+}
+
+// Drop triggers/views first (they reference tables but nothing
+// references them), then indexes, then tables. Indexes vanish with
+// their parent tables, but explicit DROPs make the order obvious and
+// keep the script independent of D1's FK-enforcement default.
+const order = { trigger: 0, view: 1, index: 2, table: 3 };
+const dropSQL = objects
+  .filter((o) => o.name !== "sqlite_sequence") // SQLite-internal
+  .sort((a, b) => order[a.type] - order[b.type])
+  .map((o) => `DROP ${o.type.toUpperCase()} IF EXISTS "${o.name}";`)
+  .join("\n");
+
+console.log("Dropping preview D1 objects:");
+console.log(dropSQL);
+
+wrangler(["--command", dropSQL], { stdio: "inherit" });
+
+console.log("Preview D1 reset complete.");


### PR DESCRIPTION
## Motivation

Preview hits a single shared D1 (`anipres-db-preview`), and `deploy:preview` runs `wrangler d1 migrations apply DB --remote --env preview` on every PR push. Wrangler tracks applied migrations by **filename** in the internal `d1_migrations` table — which has three sharp edges on this setup:

1. **Edit-after-apply.** `0003_foo.sql` is applied, then edited during review. Next run sees the tag as already-applied and silently skips the new contents. Preview's schema is now permanently out of sync with the file.
2. **Rename / squash during review.** Renaming `0003_foo.sql` → `0003_bar.sql` makes wrangler think `0003_foo` was applied (it was) and `0003_bar` is new — it stacks the rewrite on top of the original, not in place of it.
3. **Cross-PR contamination.** "Last push wins" means PR-B's migration applies on top of whatever schema PR-A left behind. Two unrelated schema PRs produce a Frankenstein DB.

All three reduce to: preview D1 accumulates state across pushes that the migration files in the current commit don't fully describe.

## Approach

When a PR's `packages/worker/migrations/` differs from its base, wipe preview D1 — every user object plus `d1_migrations` itself — before the migrate step. The subsequent `migrate:remote:preview` then rebuilds from scratch and the edited content actually lands. PRs that don't touch migrations keep the existing DB to avoid wiping preview data on every code-only push.

- `packages/worker/scripts/reset-preview-d1.mjs`: enumerates `sqlite_master` (so it stays correct as the schema evolves) and DROPs everything. Hardcoded to `--remote --env preview` so the wrong flag can't aim it at prod.
- `packages/worker/package.json`: new `reset:remote:preview` script.
- `.github/workflows/ci.yml`: PR-only step before `Deploy worker` — `git diff "\$BASE_SHA"...HEAD -- migrations/` gates the call. Needs `fetch-depth: 0` on the checkout to see the base SHA.

## Tradeoff

Considered always-reset (every PR push wipes preview D1). Cleaner logic and bulletproof against any case the diff misses, but wipes preview data unnecessarily on code-only PRs. Going with conditional; can flip to always-reset if the diff approach hits an edge case in practice.

## Test plan

- [ ] Open a follow-up PR that adds a no-op migration; confirm CI runs the reset step and `migrate:remote:preview` completes.
- [ ] Open a code-only PR; confirm CI logs "Migrations unchanged — skipping preview D1 reset."
- [ ] Edit a migration file in an open PR; confirm the edited content lands in preview D1 (not silently skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)