### PR TITLE
fix(app): tighten doc-switch and active-session reconnect races

### DIFF
--- a/packages/app/src/components/OfflineAwareSyncedContainer.tsx
+++ b/packages/app/src/components/OfflineAwareSyncedContainer.tsx
@@ -71,8 +71,8 @@ export function OfflineAwareSyncedContainer({
   );
   // Exponential backoff state for "another client holds the room"
   // (`active-session`) reconnect retries: 3 s × 2^attempt, capped at
-  // 60 s. Reset whenever the loop exits (success, fork, non-active
-  // error) or `documentId` changes — see effect below.
+  // 60 s. Reset on every loop-exit path in handleOnline and on
+  // documentId change in the load effect.
   const activeSessionRetryAttemptRef = useRef(0);
   const resetOfflineEditor = useCallback(() => {
     offlineEditorRef.current = null;
@@ -180,6 +180,7 @@ export function OfflineAwareSyncedContainer({
       });
     } catch (error) {
       console.error("Offline reconciliation threw unexpectedly:", error);
+      activeSessionRetryAttemptRef.current = 0;
       setMode({ type: "offline", snapshot, recovery });
       return;
     }

--- a/packages/app/src/components/OfflineAwareSyncedContainer.tsx
+++ b/packages/app/src/components/OfflineAwareSyncedContainer.tsx
@@ -69,6 +69,11 @@ export function OfflineAwareSyncedContainer({
   const reconnectRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  // Exponential backoff state for "another client holds the room"
+  // (`active-session`) reconnect retries: 3 s × 2^attempt, capped at
+  // 60 s. Reset whenever the loop exits (success, fork, non-active
+  // error) or `documentId` changes — see effect below.
+  const activeSessionRetryAttemptRef = useRef(0);
   const resetOfflineEditor = useCallback(() => {
     offlineEditorRef.current = null;
     setOfflineEditor(null);
@@ -78,6 +83,7 @@ export function OfflineAwareSyncedContainer({
   // recovery session that belongs to this tab; otherwise the cache remains a
   // plain offline fallback and normal sync starts immediately.
   useEffect(() => {
+    activeSessionRetryAttemptRef.current = 0;
     let cancelled = false;
     Promise.all([
       getSyncCache(documentId),
@@ -179,12 +185,14 @@ export function OfflineAwareSyncedContainer({
     }
 
     if (result.action === "noop") {
+      activeSessionRetryAttemptRef.current = 0;
       await deleteSyncRecovery(documentId, currentSessionId);
       setMode({ type: "synced" });
       return;
     }
 
     if (result.action === "pushed") {
+      activeSessionRetryAttemptRef.current = 0;
       const pushedSnapshotState = {
         snapshot,
         snapshotVersion: snapshotVersionRef.current,
@@ -207,6 +215,7 @@ export function OfflineAwareSyncedContainer({
       await deleteSyncRecovery(documentId, currentSessionId);
       setMode({ type: "synced" });
     } else if (result.action === "forked") {
+      activeSessionRetryAttemptRef.current = 0;
       await deleteSyncRecovery(documentId, currentSessionId);
       await refreshDocuments();
       await selectDocument(result.forkedDocumentId);
@@ -220,9 +229,12 @@ export function OfflineAwareSyncedContainer({
         if (reconnectRetryTimerRef.current) {
           clearTimeout(reconnectRetryTimerRef.current);
         }
+        const attempt = activeSessionRetryAttemptRef.current;
+        const delay = Math.min(3000 * 2 ** attempt, 60000);
+        activeSessionRetryAttemptRef.current = attempt + 1;
         reconnectRetryTimerRef.current = setTimeout(() => {
           retryHandleOnlineRef.current?.();
-        }, 3000);
+        }, delay);
         setMode({
           type: "reconnecting",
           snapshot,
@@ -230,6 +242,7 @@ export function OfflineAwareSyncedContainer({
         });
         return;
       }
+      activeSessionRetryAttemptRef.current = 0;
       setMode({
         type: "offline",
         snapshot,

--- a/packages/app/src/components/SyncedAnipresContainer.tsx
+++ b/packages/app/src/components/SyncedAnipresContainer.tsx
@@ -130,10 +130,21 @@ export function SyncedAnipresContainer({
     const currentDocumentId = documentId;
     baselineSnapshotRef.current ??= getSnapshot(store).document;
     let retryRefreshTimer: ReturnType<typeof setTimeout> | undefined;
+    // Async work in this effect (snapshot-status fetches, the
+    // offline-cache bootstrap, the debounced flush) can resolve after
+    // `documentId` changes and the effect has been cleaned up. IDB
+    // writes use the closed-over `currentDocumentId` so they hit the
+    // correct cache key, but two paths leak past cleanup without a
+    // gate: the writes to component refs (which the next effect's
+    // re-init has already reset) and `onSnapshotUpdate` (which the
+    // parent stores in refs not keyed by docId). The flag short-
+    // circuits both at each post-await checkpoint.
+    let cancelled = false;
 
     const refreshSnapshotVersion = async () => {
       const { snapshotVersion, snapshotFingerprint } =
         await fetchSnapshotStatus(currentDocumentId);
+      if (cancelled) return false;
       const localSnapshot = getSnapshot(store).document;
       const localSnapshotFingerprint = getSnapshotFingerprint(localSnapshot);
 
@@ -167,6 +178,7 @@ export function SyncedAnipresContainer({
     };
 
     const publishSnapshot = () => {
+      if (cancelled) return;
       const snapshot = getSnapshot(store).document;
       const recovery = {
         baselineSnapshot:
@@ -269,6 +281,7 @@ export function SyncedAnipresContainer({
       try {
         const { snapshot, snapshotVersion } =
           await fetchOfflineCache(currentDocumentId);
+        if (cancelled) return;
         const localSnapshot = getSnapshot(store).document;
 
         if (!snapshotsEqual(localSnapshot, snapshot)) {
@@ -323,6 +336,7 @@ export function SyncedAnipresContainer({
     window.addEventListener("pagehide", handlePageHide);
 
     return () => {
+      cancelled = true;
       clearTimeout(timer);
       clearTimeout(retryRefreshTimer);
       stopListening();


### PR DESCRIPTION
## Summary

Two narrow race fixes in the synced editor lifecycle, both surfaced in a focused review of `feature/sync-server`. Atomic per file; details in each commit message.

- **`SyncedAnipresContainer`** — async work scheduled in the main effect (offline-cache bootstrap, snapshot-status fetch, debounced flush) can resolve after the effect has been cleaned up by a `documentId` change. IDB writes are keyed by the closed-over `currentDocumentId` so those land correctly, but two paths leak past cleanup without a gate: ref writes that the next effect's re-init has already reset, and `onSnapshotUpdate` calls that pollute the parent's `liveSyncedSnapshotStateRef` (which is read later by `handleOffline`). Add a `cancelled` flag and check it at each post-await checkpoint.
- **`OfflineAwareSyncedContainer`** — the `active-session` reconnect retry fired every 3 s with no backoff and no cap. Switch to `min(3000 * 2 ** attempt, 60000)` so intervals grow 3 → 6 → 12 → 24 → 48 → 60 s and stay capped. Counter resets on every non-retry exit path (success, fork, non-active-session error) and on `documentId` change.

## Test plan

- [x] `pnpm -F app typecheck` — passes
- [x] `pnpm -F app lint` — passes
- [x] `pnpm -F app test --run` — 111 / 111
- [ ] Manual: switch documents quickly while a synced doc has a pending debounce in flight; the new doc's editor should not inherit the previous doc's snapshot.
- [ ] Manual: provoke an `active-session` rejection (open the same synced doc in two tabs and force one offline mid-edit, then reconnect); verify the retry interval grows and caps at 60 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)