### PR TITLE
fix(ci): quote fetch-depth ternary so PRs actually full-clone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,10 @@ jobs:
           # Need history back to the PR base to diff
           # `packages/worker/migrations/` for the reset gate below.
           # Only needed on the PR path; harmless on main pushes.
-          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
+          # Quoted: GHA `&&`/`||` short-circuit like JS, and numeric `0`
+          # is falsy, so `… && 0 || 1` always yields `1`. Strings `'0'`
+          # / `'1'` are both truthy and pass through unchanged.
+          fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:


### PR DESCRIPTION
## Summary

- Fixes the `deploy-worker` job failing with `fatal: Invalid symmetric difference expression <BASE_SHA>...HEAD` ([example run](https://github.com/whitphx/anipres/actions/runs/25247006339/job/74032976666)).
- Root cause: `fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}` always resolves to `1`. GHA `&&`/`||` short-circuit like JS, and numeric `0` is falsy, so the truthy-side `0` gets replaced by `1` via `||`. The runner's clone is then shallow on PR events too, and the migration-diff gate's `git diff "$BASE_SHA"...HEAD` can't resolve `pull_request.base.sha`.
- Quoting both operands (`'0'` / `'1'`) makes them truthy strings, preserving the intended branch. Added a comment so the next reader doesn't drop the quotes.

## Test plan

- [ ] CI on this PR runs the `deploy-worker` job with `fetch-depth: 0` on the `pull_request` event (visible in the checkout step's logs).
- [ ] Migration-diff gate resolves the base SHA and either skips or runs `pnpm reset:remote:preview` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)