### PR TITLE
fix(worker): switch v2 DO migration to new_sqlite_classes (free plan)

### DIFF
--- a/packages/worker/wrangler.toml
+++ b/packages/worker/wrangler.toml
@@ -64,10 +64,16 @@ new_sqlite_classes = ["DocumentSyncRoom"]
 
 # `WorkspaceFeedRoom` itself doesn't use `ctx.storage.sql`, but
 # Cloudflare's free Workers plan only allows new DO classes
-# registered with `new_sqlite_classes` (error code 10097: "In order
-# to use Durable Objects with a free plan, you must create a
-# namespace using a `new_sqlite_classes` migration"). The unused
-# SQLite backend is harmless.
+# registered with `new_sqlite_classes` (deploy error code 10097).
+# The unused SQLite backend is harmless.
+#
+# Reference:
+# https://developers.cloudflare.com/durable-objects/platform/pricing/
+#   "Workers Free plan: Only Durable Objects with SQLite storage
+#    backend are available."
+# https://developers.cloudflare.com/durable-objects/reference/durable-objects-migrations/
+#   maps `new_sqlite_classes` → SQLite backend,
+#        `new_classes`        → legacy key-value backend.
 [[migrations]]
 tag = "v2"
 new_sqlite_classes = ["WorkspaceFeedRoom"]

--- a/packages/worker/wrangler.toml
+++ b/packages/worker/wrangler.toml
@@ -62,9 +62,15 @@ database_id = "local"
 tag = "v1"
 new_sqlite_classes = ["DocumentSyncRoom"]
 
+# `WorkspaceFeedRoom` itself doesn't use `ctx.storage.sql`, but
+# Cloudflare's free Workers plan only allows new DO classes
+# registered with `new_sqlite_classes` (error code 10097: "In order
+# to use Durable Objects with a free plan, you must create a
+# namespace using a `new_sqlite_classes` migration"). The unused
+# SQLite backend is harmless.
 [[migrations]]
 tag = "v2"
-new_classes = ["WorkspaceFeedRoom"]
+new_sqlite_classes = ["WorkspaceFeedRoom"]
 
 [[r2_buckets]]
 binding = "ASSETS"
@@ -122,7 +128,7 @@ new_sqlite_classes = ["DocumentSyncRoom"]
 
 [[env.preview.migrations]]
 tag = "v2"
-new_classes = ["WorkspaceFeedRoom"]
+new_sqlite_classes = ["WorkspaceFeedRoom"]
 
 [[env.preview.d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## Summary

The preview deploy on \`feature/sync-server\` is failing with Cloudflare error 10097:

> In order to use Durable Objects with a free plan, you must create a namespace using a \`new_sqlite_classes\` migration.

CI run: <https://github.com/whitphx/anipres/actions/runs/25248062574/job/74035650199>

\`WorkspaceFeedRoom\` is in-memory pubsub only (no \`ctx.storage.sql\` usage), but Cloudflare's free Workers plan rejects new DO classes registered with the legacy \`new_classes\` directive regardless. The unused SQLite backend is harmless — the class doesn't touch it.

The v2 migration has not been applied anywhere yet (the deploy attempt that triggered this CI failure was its first run), so this is a clean fresh registration in both prod and preview.

## Test plan

- [x] \`pnpm -F anipres-worker test --run\` — 51 / 51 still pass (no behavior change in the DO; the directive only affects how Cloudflare provisions the namespace).
- [ ] CI deploy step — should now pass on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)