### PR TITLE
chore(worker): wire real prod D1 database_id into wrangler.toml

### DIFF
--- a/packages/worker/wrangler.toml
+++ b/packages/worker/wrangler.toml
@@ -52,11 +52,7 @@ bindings = [
 [[d1_databases]]
 binding = "DB"
 database_name = "anipres-db"
-# TODO: replace with the real id from `wrangler d1 list` (or
-# `wrangler d1 create anipres-db`) before the first prod deploy. The
-# literal "local" is the convention for `wrangler dev`; `wrangler deploy`
-# (and `pnpm migrate:remote`) need the real production id.
-database_id = "local"
+database_id = "3d3ad7c3-d28a-4df6-8452-0d2d137e50be"
 
 [[migrations]]
 tag = "v1"


### PR DESCRIPTION
## Summary

Replaces the prod D1 `database_id` placeholder (`"local"`) with the actual id returned by `wrangler d1 create anipres-db`. Removes the accompanying TODO comment that was telling future-us to do exactly this.

This closes the last prod-specific config TODO from `docs/TODO.md`'s "Before first deploy" section. (The other items — `JWT_SECRET`, OAuth credentials, OAuth callback URLs in the GitHub / Google consoles — are operational steps outside the repo, not config in `wrangler.toml`.)

Preview was wired up earlier (`c1655b3`); this change brings prod to the same state.

## Test plan

- [x] `pnpm -F anipres-worker test --run` — 51 / 51 (worker tests don't depend on the real D1 id; this is a deploy-time-only value).
- [ ] On merge: `pnpm deploy` runs `migrate:remote && wrangler deploy` — D1 migrations `0001` and `0002` will apply to the real prod database for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
