### PR TITLE
fix(ci): rename worker deploy script to avoid pnpm built-in collision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: pnpm ${{ github.event_name == 'pull_request' && 'deploy:preview' || 'deploy' }}
+        run: pnpm ${{ github.event_name == 'pull_request' && 'deploy:preview' || 'deploy:prod' }}
 
   release:
     needs: [build-anipres, test-slidev-addon-anipres, build-slidev-addon-anipres-preview]

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "dev": "pnpm run migrate:local && wrangler dev",
-    "deploy": "pnpm run migrate:remote && wrangler deploy",
+    "deploy:prod": "pnpm run migrate:remote && wrangler deploy",
     "deploy:preview": "pnpm run migrate:remote:preview && wrangler deploy --env preview",
     "migrate:local": "wrangler d1 migrations apply DB --local",
     "migrate:remote": "wrangler d1 migrations apply DB --remote",


### PR DESCRIPTION
## Summary

The first prod deploy from `main` (after merging #409) failed with:

```
ERR_PNPM_NOTHING_TO_DEPLOY  No project was selected for deployment
```

(<https://github.com/whitphx/anipres/actions/runs/25325330244/job/74244860706>)

`pnpm deploy` is a built-in pnpm subcommand that copies a pruned workspace package to a target directory — it doesn't fall through to the `"deploy"` script in `packages/worker/package.json`. The preview path doesn't hit this because `deploy:preview` isn't a reserved name.

Rename the script `deploy` → `deploy:prod` (symmetric with the existing `deploy:preview`) and update the CI step accordingly. The renamed script doesn't collide with any pnpm built-in.

Reference for the built-in: <https://pnpm.io/cli/deploy>.

## Test plan

- [x] `actionlint .github/workflows/ci.yml` — clean.
- [x] `pnpm -F anipres-worker test --run` — 51 / 51.
- [x] `cd packages/worker && pnpm run` — lists `deploy:prod` and `deploy:preview` (no `deploy`).
- [ ] CI: PR run exercises the preview path (unchanged). On merge to main, prod deploy will run `pnpm deploy:prod` for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized deployment scripts for improved clarity between production and preview environments in the CI/CD workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->