### PR TITLE
worker: migrate valibot → zod

### DIFF
--- a/packages/agent-core/src/format/focused-color.ts
+++ b/packages/agent-core/src/format/focused-color.ts
@@ -3,7 +3,7 @@
 // The Anipres palette is a subset of tldraw's; the upstream's wider
 // palette is the reference. See THIRD_PARTY_NOTICES.md at the repo
 // root.
-import { z } from "zod";
+import * as z from "zod";
 
 /**
  * The set of tldraw colors the agent is allowed to use. A subset of tldraw's

--- a/packages/agent-core/src/format/focused-easing.ts
+++ b/packages/agent-core/src/format/focused-easing.ts
@@ -3,7 +3,7 @@
 // concept lives in Anipres' presentation/animation layer. Kept under
 // `format/` for symmetry with the other focused-* primitives the
 // agent-template style organises here.
-import { z } from "zod";
+import * as z from "zod";
 
 /**
  * Tldraw easing curves the agent may pick. A small subset chosen to cover

--- a/packages/agent-core/src/format/focused-frame-action.ts
+++ b/packages/agent-core/src/format/focused-frame-action.ts
@@ -3,7 +3,7 @@
 // agent-template has no equivalent because their canvas is not
 // presentation-aware. Kept under `format/` for symmetry with the
 // other focused-* primitives.
-import { z } from "zod";
+import * as z from "zod";
 import { FocusedEasingSchema } from "./focused-easing.js";
 
 /**

--- a/packages/agent-core/src/format/focused-shape.ts
+++ b/packages/agent-core/src/format/focused-shape.ts
@@ -6,7 +6,7 @@
 // shape vocabulary distinct from tldraw's full schema, with a
 // discriminated union by `_type`, is upstream's. See
 // THIRD_PARTY_NOTICES.md at the repo root.
-import { z } from "zod";
+import * as z from "zod";
 import { FocusedColorSchema } from "./focused-color.js";
 
 const FocusedPointSchema = z.object({

--- a/packages/agent-core/src/schemas/agent-action.ts
+++ b/packages/agent-core/src/schemas/agent-action.ts
@@ -4,7 +4,7 @@
 // JSON-Schema vocabulary" pattern is from upstream. The Anipres
 // schemas (slide-aware create, attachCueFrame for the presentation
 // timeline) are original. See THIRD_PARTY_NOTICES.md at the repo root.
-import { z } from "zod";
+import * as z from "zod";
 import { FocusedColorSchema } from "../format/focused-color.js";
 import { FocusedFrameActionSchema } from "../format/focused-frame-action.js";
 import { CreatableShapeSchema } from "../format/focused-shape.js";

--- a/packages/agent-core/src/schemas/build-response-schema.ts
+++ b/packages/agent-core/src/schemas/build-response-schema.ts
@@ -7,7 +7,7 @@
 // the JSON Schema; Anipres has a single mode and no internal meta
 // keys yet, so neither parameterisation is needed here. See
 // THIRD_PARTY_NOTICES.md at the repo root.
-import { z } from "zod";
+import * as z from "zod";
 import { AgentActionSchema } from "./agent-action.js";
 
 /**

--- a/packages/agent-core/src/schemas/prompt-part.ts
+++ b/packages/agent-core/src/schemas/prompt-part.ts
@@ -5,15 +5,13 @@
 // discriminator, plus an `AgentPrompt` envelope object, is upstream's.
 // See THIRD_PARTY_NOTICES.md at the repo root.
 //
-// Why zod (and not valibot like the rest of the worker)?
 // The action schemas are exported as JSON Schema and embedded in the
-// LLM's system prompt — `.meta({ description })` annotations carry the
-// human-readable docs each action shows the model. zod has first-class
-// JSON-Schema export, that's the upstream pattern in tldraw's
-// agent-template we mirror, and the model's vocabulary is the single
-// most load-bearing artefact in this package, so it dictates the tool
-// choice. Worker callers don't need to know — they import a typed
-// helper (`parseAgentPrompt` below), not `z` itself.
+// LLM's system prompt — `.meta({ description })` annotations carry
+// the human-readable docs each action shows the model. zod's
+// first-class JSON-Schema export is what makes this package commit to
+// zod (the upstream pattern in tldraw/agent-template uses it for the
+// same reason). Worker callers don't need to know — they import a
+// typed helper (`parseAgentPrompt` below), not `z` itself.
 import { z } from "zod";
 import { FocusedFrameActionSchema } from "../format/focused-frame-action.js";
 import { FocusedShapeSchema } from "../format/focused-shape.js";

--- a/packages/agent-core/src/schemas/prompt-part.ts
+++ b/packages/agent-core/src/schemas/prompt-part.ts
@@ -12,7 +12,7 @@
 // zod (the upstream pattern in tldraw/agent-template uses it for the
 // same reason). Worker callers don't need to know — they import a
 // typed helper (`parseAgentPrompt` below), not `z` itself.
-import { z } from "zod";
+import * as z from "zod";
 import { FocusedFrameActionSchema } from "../format/focused-frame-action.js";
 import { FocusedShapeSchema } from "../format/focused-shape.js";
 

--- a/packages/agent-mcp/src/server.ts
+++ b/packages/agent-mcp/src/server.ts
@@ -12,7 +12,7 @@ import {
   type AgentEnv,
   type AgentModelProvider,
 } from "@anipres/agent-core";
-import { z } from "zod";
+import * as z from "zod";
 
 const REQUIRED_ENV_VAR: Record<AgentModelProvider, keyof AgentEnv> = {
   anthropic: "ANTHROPIC_API_KEY",

--- a/packages/worker/migrations/0001_initial_schema.sql
+++ b/packages/worker/migrations/0001_initial_schema.sql
@@ -135,8 +135,9 @@ CREATE TABLE documents (
   slug                TEXT    NOT NULL UNIQUE CHECK (length(slug) > 0),
   -- title and `workspaces.name` use `length(trim(...)) > 0` (vs the
   -- plain length CHECK on slug/sort_order) because they're user-
-  -- typed: whitespace-only inputs are a real hazard. valibot rejects
-  -- these at the API layer too; this is the schema-layer backstop.
+  -- typed: whitespace-only inputs are a real hazard. The API-layer
+  -- schema validator rejects these too; this is the schema-layer
+  -- backstop.
   title               TEXT    NOT NULL DEFAULT 'Untitled' CHECK (length(trim(title)) > 0),
   -- sort_order is a fractional-indexing key (the `fractional-indexing`
   -- npm package). Non-empty by construction; the CHECK enforces the

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -26,13 +26,13 @@
   "dependencies": {
     "@anipres/agent-core": "workspace:*",
     "@hono/oauth-providers": "^0.8.5",
-    "@hono/valibot-validator": "^0.6.1",
+    "@hono/zod-validator": "^0.7.6",
     "@tldraw/sync-core": "3.15.5",
     "anipres": "workspace:*",
     "hono": "^4.12.15",
     "nanoid": "^5.1.9",
     "tldraw": "3.15.5",
-    "valibot": "^1.3.1"
+    "zod": "^4.1.8"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.15.2",

--- a/packages/worker/src/routes/agent.ts
+++ b/packages/worker/src/routes/agent.ts
@@ -1,6 +1,6 @@
-import { vValidator } from "@hono/valibot-validator";
+import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
-import * as v from "valibot";
+import { z } from "zod";
 import {
   getAgentModelDefinition,
   isValidModelName,
@@ -12,12 +12,10 @@ import type { AppBindings } from "../types";
 
 // Outer envelope only — the inner `prompt` is handed off to
 // `parseAgentPrompt`, which re-uses the zod schema agent-core already
-// owns for LLM JSON-Schema export. Keeps the worker on valibot for
-// every other route while letting the prompt schema live next to the
-// rest of the model vocabulary.
-const AgentStreamRequestEnvelope = v.object({
-  prompt: v.unknown(),
-  modelName: v.optional(v.string()),
+// owns for LLM JSON-Schema export.
+const AgentStreamRequestEnvelope = z.object({
+  prompt: z.unknown(),
+  modelName: z.string().optional(),
 });
 
 /**
@@ -34,10 +32,10 @@ const AgentStreamRequestEnvelope = v.object({
  */
 export const agentRoutes = new Hono<AppBindings>().post(
   "/api/agent/stream",
-  vValidator("json", AgentStreamRequestEnvelope, (result, c) => {
+  zValidator("json", AgentStreamRequestEnvelope, (result, c) => {
     if (!result.success) {
       return c.json(
-        { error: "Invalid request body", issues: result.issues },
+        { error: "Invalid request body", issues: result.error.issues },
         400,
       );
     }

--- a/packages/worker/src/routes/agent.ts
+++ b/packages/worker/src/routes/agent.ts
@@ -1,6 +1,6 @@
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
-import { z } from "zod";
+import * as z from "zod";
 import {
   getAgentModelDefinition,
   isValidModelName,

--- a/packages/worker/src/routes/auth.ts
+++ b/packages/worker/src/routes/auth.ts
@@ -1,6 +1,6 @@
-import { vValidator } from "@hono/valibot-validator";
+import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
-import * as v from "valibot";
+import { z } from "zod";
 import {
   clearSession,
   getCurrentUser,
@@ -15,9 +15,9 @@ import type { AppBindings } from "../types";
 // upstream IdP and formats vary, so no specific format is enforced
 // — just a length bound so a pathological client can't smuggle an
 // unbounded string into the parameterized statement.
-const oauthIdentityRevokeParamSchema = v.object({
-  provider: v.picklist(["github", "google"]),
-  provider_id: v.pipe(v.string(), v.minLength(1), v.maxLength(256)),
+const oauthIdentityRevokeParamSchema = z.object({
+  provider: z.enum(["github", "google"]),
+  provider_id: z.string().min(1).max(256),
 });
 
 export const authRoutes = new Hono<AppBindings>()
@@ -61,10 +61,10 @@ export const authRoutes = new Hono<AppBindings>()
   // safety guarantee.
   .delete(
     "/auth/identities/:provider/:provider_id",
-    vValidator("param", oauthIdentityRevokeParamSchema, (result, c) => {
+    zValidator("param", oauthIdentityRevokeParamSchema, (result, c) => {
       if (!result.success) {
         return c.json(
-          { error: "Invalid identity", details: result.issues },
+          { error: "Invalid identity", details: result.error.issues },
           400,
         );
       }

--- a/packages/worker/src/routes/auth.ts
+++ b/packages/worker/src/routes/auth.ts
@@ -1,6 +1,6 @@
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
-import { z } from "zod";
+import * as z from "zod";
 import {
   clearSession,
   getCurrentUser,

--- a/packages/worker/src/routes/connect.ts
+++ b/packages/worker/src/routes/connect.ts
@@ -1,10 +1,10 @@
-import { vValidator } from "@hono/valibot-validator";
+import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
-import * as v from "valibot";
+import { z } from "zod";
 import { documentIdSchema } from "../schemas";
 import type { AppBindings } from "../types";
 
-const documentConnectParamSchema = v.object({
+const documentConnectParamSchema = z.object({
   documentId: documentIdSchema,
 });
 
@@ -13,10 +13,10 @@ const documentConnectParamSchema = v.object({
 // rather than through the typed client.
 export const connectRoutes = new Hono<AppBindings>().get(
   "/api/connect/:documentId",
-  vValidator("param", documentConnectParamSchema, (result, c) => {
+  zValidator("param", documentConnectParamSchema, (result, c) => {
     if (!result.success) {
       return c.json(
-        { error: "Invalid document id", details: result.issues },
+        { error: "Invalid document id", details: result.error.issues },
         400,
       );
     }

--- a/packages/worker/src/routes/connect.ts
+++ b/packages/worker/src/routes/connect.ts
@@ -1,6 +1,6 @@
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
-import { z } from "zod";
+import * as z from "zod";
 import { documentIdSchema } from "../schemas";
 import type { AppBindings } from "../types";
 

--- a/packages/worker/src/routes/document-assets.test.ts
+++ b/packages/worker/src/routes/document-assets.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import * as v from "valibot";
 import {
   documentAssetUploadFieldsSchema,
   documentAssetUploadFileSchema,
@@ -7,19 +6,19 @@ import {
 
 describe("documentAssetUploadFieldsSchema", () => {
   it("accepts a body with a File field", () => {
-    const result = v.safeParse(documentAssetUploadFieldsSchema, {
+    const result = documentAssetUploadFieldsSchema.safeParse({
       file: new File(["hello"], "x.txt", { type: "text/plain" }),
     });
     expect(result.success).toBe(true);
   });
 
   it("rejects a missing file field", () => {
-    const result = v.safeParse(documentAssetUploadFieldsSchema, {});
+    const result = documentAssetUploadFieldsSchema.safeParse({});
     expect(result.success).toBe(false);
   });
 
   it("rejects a non-File value in the file field", () => {
-    const result = v.safeParse(documentAssetUploadFieldsSchema, {
+    const result = documentAssetUploadFieldsSchema.safeParse({
       file: "not a file",
     });
     expect(result.success).toBe(false);
@@ -29,7 +28,7 @@ describe("documentAssetUploadFieldsSchema", () => {
 describe("documentAssetUploadFileSchema", () => {
   it("accepts a small image with an allowed MIME type", () => {
     const file = new File(["x"], "tiny.png", { type: "image/png" });
-    const result = v.safeParse(documentAssetUploadFileSchema, file);
+    const result = documentAssetUploadFileSchema.safeParse(file);
     expect(result.success).toBe(true);
   });
 
@@ -37,7 +36,7 @@ describe("documentAssetUploadFileSchema", () => {
     const file = new File(["x"], "evil.exe", {
       type: "application/octet-stream",
     });
-    const result = v.safeParse(documentAssetUploadFileSchema, file);
+    const result = documentAssetUploadFileSchema.safeParse(file);
     expect(result.success).toBe(false);
   });
 
@@ -46,7 +45,7 @@ describe("documentAssetUploadFileSchema", () => {
     // actually allocating the bytes by passing a typed-array view.
     const oversized = new Uint8Array(10 * 1024 * 1024 + 1);
     const file = new File([oversized], "big.png", { type: "image/png" });
-    const result = v.safeParse(documentAssetUploadFileSchema, file);
+    const result = documentAssetUploadFileSchema.safeParse(file);
     expect(result.success).toBe(false);
   });
 });

--- a/packages/worker/src/routes/document-assets.ts
+++ b/packages/worker/src/routes/document-assets.ts
@@ -1,6 +1,6 @@
-import { vValidator } from "@hono/valibot-validator";
+import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
-import * as v from "valibot";
+import { z } from "zod";
 import {
   SUPPORTED_ASSET_CONTENT_TYPES,
   assetNameSchema,
@@ -11,20 +11,27 @@ import { MAX_ASSET_SIZE } from "../tldraw-asset-policy";
 import { getDocumentAssetKey } from "../tldraw-assets";
 import type { AppBindings, AppContext } from "../types";
 
-const documentAssetParamSchema = v.object({
+const documentAssetParamSchema = z.object({
   id: documentIdSchema,
   assetName: assetNameSchema,
 });
 
-export const documentAssetUploadFieldsSchema = v.object({
-  file: v.file("Missing file field"),
+export const documentAssetUploadFieldsSchema = z.object({
+  file: z.instanceof(File, { message: "Missing file field" }),
 });
 
-export const documentAssetUploadFileSchema = v.pipe(
-  v.file(),
-  v.mimeType(SUPPORTED_ASSET_CONTENT_TYPES),
-  v.maxSize(MAX_ASSET_SIZE),
+const SUPPORTED_ASSET_CONTENT_TYPE_SET = new Set<string>(
+  SUPPORTED_ASSET_CONTENT_TYPES,
 );
+
+export const documentAssetUploadFileSchema = z
+  .instanceof(File)
+  .refine((file) => SUPPORTED_ASSET_CONTENT_TYPE_SET.has(file.type), {
+    message: "Unsupported asset content type",
+  })
+  .refine((file) => file.size <= MAX_ASSET_SIZE, {
+    message: "File too large",
+  });
 
 const ASSET_EXTENSION_BY_CONTENT_TYPE = {
   "image/jpeg": ".jpg",
@@ -317,10 +324,10 @@ async function scheduleDocumentAssetGc(
 export const assetRoutes = new Hono<AppBindings>()
   .post(
     "/api/documents/:id/assets",
-    vValidator("param", documentIdParamSchema, (result, c) => {
+    zValidator("param", documentIdParamSchema, (result, c) => {
       if (!result.success) {
         return c.json(
-          { error: "Invalid document id", details: result.issues },
+          { error: "Invalid document id", details: result.error.issues },
           400,
         );
       }
@@ -355,27 +362,22 @@ export const assetRoutes = new Hono<AppBindings>()
         throw error;
       }
 
-      const uploadFieldsResult = v.safeParse(
-        documentAssetUploadFieldsSchema,
-        {
-          file: formData.get("file"),
-        },
-      );
+      const uploadFieldsResult = documentAssetUploadFieldsSchema.safeParse({
+        file: formData.get("file"),
+      });
       if (!uploadFieldsResult.success) {
         return c.json(
           {
             error: "Invalid asset upload fields",
-            details: uploadFieldsResult.issues,
+            details: uploadFieldsResult.error.issues,
           },
           400,
         );
       }
 
-      const { file: uploadFile } = uploadFieldsResult.output;
-      const uploadFileResult = v.safeParse(
-        documentAssetUploadFileSchema,
-        uploadFile,
-      );
+      const { file: uploadFile } = uploadFieldsResult.data;
+      const uploadFileResult =
+        documentAssetUploadFileSchema.safeParse(uploadFile);
       if (!uploadFileResult.success) {
         return c.json(
           {
@@ -383,7 +385,7 @@ export const assetRoutes = new Hono<AppBindings>()
               uploadFile.size > MAX_ASSET_SIZE
                 ? "File too large"
                 : "Unsupported asset type",
-            details: uploadFileResult.issues,
+            details: uploadFileResult.error.issues,
           },
           uploadFile.size > MAX_ASSET_SIZE ? 413 : 400,
         );
@@ -438,7 +440,7 @@ export const assetRoutes = new Hono<AppBindings>()
     // 404 not 400 on validator failure: a malformed asset name can't
     // address an asset, so "not found" matches the route's external
     // contract better than "bad request".
-    vValidator("param", documentAssetParamSchema, (result, c) => {
+    zValidator("param", documentAssetParamSchema, (result, c) => {
       if (!result.success) {
         return c.json({ error: "Not found" }, 404);
       }

--- a/packages/worker/src/routes/document-assets.ts
+++ b/packages/worker/src/routes/document-assets.ts
@@ -1,6 +1,6 @@
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
-import { z } from "zod";
+import * as z from "zod";
 import {
   SUPPORTED_ASSET_CONTENT_TYPES,
   assetNameSchema,

--- a/packages/worker/src/routes/documents.test.ts
+++ b/packages/worker/src/routes/documents.test.ts
@@ -32,6 +32,16 @@ describe("documentListQuerySchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it("rejects a workspace_id larger than Number.MAX_SAFE_INTEGER", () => {
+    // 2^53 itself is the first integer that round-trips through
+    // Number lossily — its string form is still all digits, so the
+    // regex passes; only the safe-integer refine rejects it.
+    const result = documentListQuerySchema.safeParse({
+      workspace_id: "9007199254740993",
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("documentUpsertSchema", () => {

--- a/packages/worker/src/routes/documents.test.ts
+++ b/packages/worker/src/routes/documents.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import * as v from "valibot";
 import {
   documentListQuerySchema,
   documentUpsertSchema,
@@ -8,27 +7,27 @@ import {
 
 describe("documentListQuerySchema", () => {
   it("accepts a positive integer workspace_id", () => {
-    const result = v.safeParse(documentListQuerySchema, {
+    const result = documentListQuerySchema.safeParse({
       workspace_id: "7",
     });
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.output.workspace_id).toBe(7);
+      expect(result.data.workspace_id).toBe(7);
     }
   });
 
   it("rejects a missing workspace_id", () => {
-    const result = v.safeParse(documentListQuerySchema, {});
+    const result = documentListQuerySchema.safeParse({});
     expect(result.success).toBe(false);
   });
 
   it("rejects zero", () => {
-    const result = v.safeParse(documentListQuerySchema, { workspace_id: "0" });
+    const result = documentListQuerySchema.safeParse({ workspace_id: "0" });
     expect(result.success).toBe(false);
   });
 
   it("rejects a non-numeric workspace_id", () => {
-    const result = v.safeParse(documentListQuerySchema, {
+    const result = documentListQuerySchema.safeParse({
       workspace_id: "personal",
     });
     expect(result.success).toBe(false);
@@ -47,12 +46,12 @@ describe("documentUpsertSchema", () => {
   };
 
   it("accepts a minimal body", () => {
-    const result = v.safeParse(documentUpsertSchema, validBody);
+    const result = documentUpsertSchema.safeParse(validBody);
     expect(result.success).toBe(true);
   });
 
   it("accepts a body with the optional created_at override", () => {
-    const result = v.safeParse(documentUpsertSchema, {
+    const result = documentUpsertSchema.safeParse({
       ...validBody,
       created_at: 1700000000000,
     });
@@ -60,7 +59,7 @@ describe("documentUpsertSchema", () => {
   });
 
   it("rejects a missing workspace_id", () => {
-    const result = v.safeParse(documentUpsertSchema, {
+    const result = documentUpsertSchema.safeParse({
       title: "x",
       sort_order: "a0",
     });
@@ -68,7 +67,7 @@ describe("documentUpsertSchema", () => {
   });
 
   it("rejects a non-numeric workspace_id", () => {
-    const result = v.safeParse(documentUpsertSchema, {
+    const result = documentUpsertSchema.safeParse({
       ...validBody,
       workspace_id: "default",
     });
@@ -76,7 +75,7 @@ describe("documentUpsertSchema", () => {
   });
 
   it("rejects a missing title", () => {
-    const result = v.safeParse(documentUpsertSchema, {
+    const result = documentUpsertSchema.safeParse({
       workspace_id: "1",
       sort_order: "a0",
     });
@@ -84,7 +83,7 @@ describe("documentUpsertSchema", () => {
   });
 
   it("rejects an empty title", () => {
-    const result = v.safeParse(documentUpsertSchema, {
+    const result = documentUpsertSchema.safeParse({
       ...validBody,
       title: "",
     });
@@ -92,7 +91,7 @@ describe("documentUpsertSchema", () => {
   });
 
   it("rejects a whitespace-only title", () => {
-    const result = v.safeParse(documentUpsertSchema, {
+    const result = documentUpsertSchema.safeParse({
       ...validBody,
       title: "   \t\n",
     });
@@ -100,7 +99,7 @@ describe("documentUpsertSchema", () => {
   });
 
   it("rejects a title longer than 256 characters", () => {
-    const result = v.safeParse(documentUpsertSchema, {
+    const result = documentUpsertSchema.safeParse({
       ...validBody,
       title: "x".repeat(257),
     });
@@ -108,7 +107,7 @@ describe("documentUpsertSchema", () => {
   });
 
   it("rejects a title with a null byte", () => {
-    const result = v.safeParse(documentUpsertSchema, {
+    const result = documentUpsertSchema.safeParse({
       ...validBody,
       title: "hello\u0000world",
     });
@@ -116,7 +115,7 @@ describe("documentUpsertSchema", () => {
   });
 
   it("rejects a missing sort_order", () => {
-    const result = v.safeParse(documentUpsertSchema, {
+    const result = documentUpsertSchema.safeParse({
       workspace_id: "1",
       title: "x",
     });
@@ -124,7 +123,7 @@ describe("documentUpsertSchema", () => {
   });
 
   it("rejects an empty sort_order", () => {
-    const result = v.safeParse(documentUpsertSchema, {
+    const result = documentUpsertSchema.safeParse({
       ...validBody,
       sort_order: "",
     });
@@ -132,7 +131,7 @@ describe("documentUpsertSchema", () => {
   });
 
   it("rejects a sort_order longer than 256 characters", () => {
-    const result = v.safeParse(documentUpsertSchema, {
+    const result = documentUpsertSchema.safeParse({
       ...validBody,
       sort_order: "a".repeat(257),
     });
@@ -140,7 +139,7 @@ describe("documentUpsertSchema", () => {
   });
 
   it("rejects a non-string sort_order", () => {
-    const result = v.safeParse(documentUpsertSchema, {
+    const result = documentUpsertSchema.safeParse({
       ...validBody,
       sort_order: 1.5,
     });
@@ -148,7 +147,7 @@ describe("documentUpsertSchema", () => {
   });
 
   it("rejects a non-integer created_at", () => {
-    const result = v.safeParse(documentUpsertSchema, {
+    const result = documentUpsertSchema.safeParse({
       ...validBody,
       created_at: 1700000000000.5,
     });
@@ -156,7 +155,7 @@ describe("documentUpsertSchema", () => {
   });
 
   it("rejects a negative created_at", () => {
-    const result = v.safeParse(documentUpsertSchema, {
+    const result = documentUpsertSchema.safeParse({
       ...validBody,
       created_at: -1,
     });
@@ -171,12 +170,12 @@ describe("snapshotPushBodySchema", () => {
   };
 
   it("accepts a well-formed body", () => {
-    const result = v.safeParse(snapshotPushBodySchema, validBody);
+    const result = snapshotPushBodySchema.safeParse(validBody);
     expect(result.success).toBe(true);
   });
 
   it("accepts an empty snapshot record", () => {
-    const result = v.safeParse(snapshotPushBodySchema, {
+    const result = snapshotPushBodySchema.safeParse({
       ...validBody,
       snapshot: {},
     });
@@ -184,7 +183,7 @@ describe("snapshotPushBodySchema", () => {
   });
 
   it("rejects a negative expectedSnapshotVersion", () => {
-    const result = v.safeParse(snapshotPushBodySchema, {
+    const result = snapshotPushBodySchema.safeParse({
       ...validBody,
       expectedSnapshotVersion: -1,
     });
@@ -192,7 +191,7 @@ describe("snapshotPushBodySchema", () => {
   });
 
   it("rejects a non-integer expectedSnapshotVersion", () => {
-    const result = v.safeParse(snapshotPushBodySchema, {
+    const result = snapshotPushBodySchema.safeParse({
       ...validBody,
       expectedSnapshotVersion: 1.5,
     });
@@ -200,7 +199,7 @@ describe("snapshotPushBodySchema", () => {
   });
 
   it("rejects a NaN expectedSnapshotVersion", () => {
-    const result = v.safeParse(snapshotPushBodySchema, {
+    const result = snapshotPushBodySchema.safeParse({
       ...validBody,
       expectedSnapshotVersion: Number.NaN,
     });
@@ -208,7 +207,7 @@ describe("snapshotPushBodySchema", () => {
   });
 
   it("rejects a non-object snapshot", () => {
-    const result = v.safeParse(snapshotPushBodySchema, {
+    const result = snapshotPushBodySchema.safeParse({
       snapshot: "not an object",
       expectedSnapshotVersion: 0,
     });

--- a/packages/worker/src/routes/documents.ts
+++ b/packages/worker/src/routes/documents.ts
@@ -1,7 +1,7 @@
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { nanoid } from "nanoid";
-import { z } from "zod";
+import * as z from "zod";
 import { documentIdParamSchema } from "../schemas";
 import { startDocumentDeletion } from "../tldraw-assets";
 import type { AppBindings, AppContext } from "../types";

--- a/packages/worker/src/routes/documents.ts
+++ b/packages/worker/src/routes/documents.ts
@@ -1,17 +1,13 @@
-import { vValidator } from "@hono/valibot-validator";
+import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { nanoid } from "nanoid";
-import * as v from "valibot";
+import { z } from "zod";
 import { documentIdParamSchema } from "../schemas";
 import { startDocumentDeletion } from "../tldraw-assets";
 import type { AppBindings, AppContext } from "../types";
 import { bumpWorkspaceFeed } from "../WorkspaceFeedRoom";
 
-const nonNegativeFiniteInteger = v.pipe(
-  v.number(),
-  v.integer(),
-  v.minValue(0),
-);
+const nonNegativeFiniteInteger = z.number().int().min(0);
 
 const DOCUMENT_TITLE_MAX_LENGTH = 256;
 
@@ -19,35 +15,32 @@ const DOCUMENT_TITLE_MAX_LENGTH = 256;
 // fallback: empty / whitespace-only titles would render as a blank
 // sidebar row. Null bytes are rejected because D1's TEXT tolerates
 // them but they break grep and leak through raw logs.
-const documentTitleSchema = v.pipe(
-  v.string(),
-  v.minLength(1),
-  v.regex(/\S/u, "Title cannot be only whitespace"),
-  v.maxLength(DOCUMENT_TITLE_MAX_LENGTH),
-  v.regex(/^[^\u0000]*$/u, "Title contains a null byte"),
-);
+const documentTitleSchema = z
+  .string()
+  .min(1)
+  .regex(/\S/u, "Title cannot be only whitespace")
+  .max(DOCUMENT_TITLE_MAX_LENGTH)
+  .regex(/^[^\u0000]*$/u, "Title contains a null byte");
 
 // Sort-order is a fractional-indexing key (printable-ASCII string;
 // see https://www.npmjs.com/package/fractional-indexing). The bound
 // is a sanity cap to reject pathological inputs.
 const SORT_ORDER_MAX_LENGTH = 256;
-const sortOrderSchema = v.pipe(
-  v.string(),
-  v.minLength(1, "sort_order cannot be empty"),
-  v.maxLength(SORT_ORDER_MAX_LENGTH, "sort_order too long"),
-);
+const sortOrderSchema = z
+  .string()
+  .min(1, "sort_order cannot be empty")
+  .max(SORT_ORDER_MAX_LENGTH, "sort_order too long");
 
 // Workspace ids are INTEGER on the server side (see the migration);
 // clients pass them as decimal strings on the wire. Coerce to JS
 // number after validation so handlers can pass it straight to D1
 // `.bind()`.
-const workspaceIdSchema = v.pipe(
-  v.string(),
-  v.regex(/^[1-9]\d*$/u, "Invalid workspace id"),
-  v.transform(Number),
-);
+const workspaceIdSchema = z
+  .string()
+  .regex(/^[1-9]\d*$/u, "Invalid workspace id")
+  .transform(Number);
 
-export const documentListQuerySchema = v.object({
+export const documentListQuerySchema = z.object({
   workspace_id: workspaceIdSchema,
 });
 
@@ -60,19 +53,19 @@ export const documentListQuerySchema = v.object({
 // preserve on-device creation time; ignored on update. `updated_at`
 // is always server-stamped via the documents.updated_at trigger;
 // `id` lives in the URL path (see `documentIdParamSchema`).
-export const documentUpsertSchema = v.object({
+export const documentUpsertSchema = z.object({
   workspace_id: workspaceIdSchema,
   title: documentTitleSchema,
   sort_order: sortOrderSchema,
-  created_at: v.optional(nonNegativeFiniteInteger),
+  created_at: nonNegativeFiniteInteger.optional(),
 });
 
 // Cap on snapshot push body size. Prevents a runaway client from
 // streaming arbitrary blobs at the DO; sized with headroom over
 // realistic tldraw snapshot sizes.
 const MAX_SNAPSHOT_BODY_BYTES = 5 * 1024 * 1024;
-export const snapshotPushBodySchema = v.object({
-  snapshot: v.record(v.string(), v.unknown()),
+export const snapshotPushBodySchema = z.object({
+  snapshot: z.record(z.string(), z.unknown()),
   expectedSnapshotVersion: nonNegativeFiniteInteger,
 });
 
@@ -108,10 +101,10 @@ export const documentsRoutes = new Hono<AppBindings>()
   // create finalization) that the user shouldn't see in the sidebar.
   .get(
     "/api/documents",
-    vValidator("query", documentListQuerySchema, (result, c) => {
+    zValidator("query", documentListQuerySchema, (result, c) => {
       if (!result.success) {
         return c.json(
-          { error: "Invalid workspace_id", details: result.issues },
+          { error: "Invalid workspace_id", details: result.error.issues },
           400,
         );
       }
@@ -145,10 +138,10 @@ export const documentsRoutes = new Hono<AppBindings>()
   // the Durable Object, fetched separately via the WebSocket sync.
   .get(
     "/api/documents/:id",
-    vValidator("param", documentIdParamSchema, (result, c) => {
+    zValidator("param", documentIdParamSchema, (result, c) => {
       if (!result.success) {
         return c.json(
-          { error: "Invalid document id", details: result.issues },
+          { error: "Invalid document id", details: result.error.issues },
           400,
         );
       }
@@ -174,18 +167,18 @@ export const documentsRoutes = new Hono<AppBindings>()
   )
   .put(
     "/api/documents/:id",
-    vValidator("param", documentIdParamSchema, (result, c) => {
+    zValidator("param", documentIdParamSchema, (result, c) => {
       if (!result.success) {
         return c.json(
-          { error: "Invalid document id", details: result.issues },
+          { error: "Invalid document id", details: result.error.issues },
           400,
         );
       }
     }),
-    vValidator("json", documentUpsertSchema, (result, c) => {
+    zValidator("json", documentUpsertSchema, (result, c) => {
       if (!result.success) {
         return c.json(
-          { error: "Invalid document metadata", details: result.issues },
+          { error: "Invalid document metadata", details: result.error.issues },
           400,
         );
       }
@@ -342,10 +335,10 @@ export const documentsRoutes = new Hono<AppBindings>()
   // period (see `startDocumentDeletion` in `../tldraw-assets`).
   .delete(
     "/api/documents/:id",
-    vValidator("param", documentIdParamSchema, (result, c) => {
+    zValidator("param", documentIdParamSchema, (result, c) => {
       if (!result.success) {
         return c.json(
-          { error: "Invalid document id", details: result.issues },
+          { error: "Invalid document id", details: result.error.issues },
           400,
         );
       }
@@ -399,10 +392,10 @@ export const documentsRoutes = new Hono<AppBindings>()
   // where pushing a synthesized empty snapshot would be wasted work.
   .post(
     "/api/documents/:id/finalize",
-    vValidator("param", documentIdParamSchema, (result, c) => {
+    zValidator("param", documentIdParamSchema, (result, c) => {
       if (!result.success) {
         return c.json(
-          { error: "Invalid document id", details: result.issues },
+          { error: "Invalid document id", details: result.error.issues },
           400,
         );
       }
@@ -459,10 +452,10 @@ export const documentsRoutes = new Hono<AppBindings>()
   // snapshot here doesn't need to also call /finalize.
   .put(
     "/api/documents/:id/snapshot",
-    vValidator("param", documentIdParamSchema, (result, c) => {
+    zValidator("param", documentIdParamSchema, (result, c) => {
       if (!result.success) {
         return c.json(
-          { error: "Invalid document id", details: result.issues },
+          { error: "Invalid document id", details: result.error.issues },
           400,
         );
       }
@@ -483,10 +476,10 @@ export const documentsRoutes = new Hono<AppBindings>()
       }
       await next();
     },
-    vValidator("json", snapshotPushBodySchema, (result, c) => {
+    zValidator("json", snapshotPushBodySchema, (result, c) => {
       if (!result.success) {
         return c.json(
-          { error: "Invalid request body", details: result.issues },
+          { error: "Invalid request body", details: result.error.issues },
           400,
         );
       }
@@ -566,10 +559,10 @@ export const documentsRoutes = new Hono<AppBindings>()
   )
   .get(
     "/api/documents/:id/offline-cache",
-    vValidator("param", documentIdParamSchema, (result, c) => {
+    zValidator("param", documentIdParamSchema, (result, c) => {
       if (!result.success) {
         return c.json(
-          { error: "Invalid document id", details: result.issues },
+          { error: "Invalid document id", details: result.error.issues },
           400,
         );
       }
@@ -603,10 +596,10 @@ export const documentsRoutes = new Hono<AppBindings>()
   )
   .get(
     "/api/documents/:id/snapshot-status",
-    vValidator("param", documentIdParamSchema, (result, c) => {
+    zValidator("param", documentIdParamSchema, (result, c) => {
       if (!result.success) {
         return c.json(
-          { error: "Invalid document id", details: result.issues },
+          { error: "Invalid document id", details: result.error.issues },
           400,
         );
       }

--- a/packages/worker/src/routes/documents.ts
+++ b/packages/worker/src/routes/documents.ts
@@ -34,10 +34,15 @@ const sortOrderSchema = z
 // Workspace ids are INTEGER on the server side (see the migration);
 // clients pass them as decimal strings on the wire. Coerce to JS
 // number after validation so handlers can pass it straight to D1
-// `.bind()`.
+// `.bind()`. The `Number.isSafeInteger` refine rejects digit strings
+// above 2^53-1: the regex would happily accept them, and `Number(s)`
+// would silently round, leaving the validator + transform out of
+// sync. Realistically auto-incremented ids never approach the bound,
+// but the cheap refine keeps the contract honest.
 const workspaceIdSchema = z
   .string()
   .regex(/^[1-9]\d*$/u, "Invalid workspace id")
+  .refine((s) => Number.isSafeInteger(Number(s)), "Invalid workspace id")
   .transform(Number);
 
 export const documentListQuerySchema = z.object({

--- a/packages/worker/src/routes/workspaces.ts
+++ b/packages/worker/src/routes/workspaces.ts
@@ -1,6 +1,6 @@
-import { vValidator } from "@hono/valibot-validator";
+import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
-import * as v from "valibot";
+import { z } from "zod";
 import type { AppBindings } from "../types";
 
 type WorkspaceRow = {
@@ -10,12 +10,11 @@ type WorkspaceRow = {
   updated_at: number;
 };
 
-const workspaceIdParamSchema = v.object({
-  id: v.pipe(
-    v.string(),
-    v.regex(/^[1-9]\d*$/u, "Invalid workspace id"),
-    v.transform(Number),
-  ),
+const workspaceIdParamSchema = z.object({
+  id: z
+    .string()
+    .regex(/^[1-9]\d*$/u, "Invalid workspace id")
+    .transform(Number),
 });
 
 export const workspacesRoutes = new Hono<AppBindings>()
@@ -41,10 +40,10 @@ export const workspacesRoutes = new Hono<AppBindings>()
   // refreshInterval polling backstop covers any drop.
   .get(
     "/api/workspaces/:id/events",
-    vValidator("param", workspaceIdParamSchema, (result, c) => {
+    zValidator("param", workspaceIdParamSchema, (result, c) => {
       if (!result.success) {
         return c.json(
-          { error: "Invalid workspace id", details: result.issues },
+          { error: "Invalid workspace id", details: result.error.issues },
           400,
         );
       }

--- a/packages/worker/src/routes/workspaces.ts
+++ b/packages/worker/src/routes/workspaces.ts
@@ -11,9 +11,13 @@ type WorkspaceRow = {
 };
 
 const workspaceIdParamSchema = z.object({
+  // See the corresponding schema in routes/documents.ts for why the
+  // regex isn't enough on its own — the safe-integer refine closes
+  // the precision-loss gap between regex acceptance and `Number`.
   id: z
     .string()
     .regex(/^[1-9]\d*$/u, "Invalid workspace id")
+    .refine((s) => Number.isSafeInteger(Number(s)), "Invalid workspace id")
     .transform(Number),
 });
 

--- a/packages/worker/src/routes/workspaces.ts
+++ b/packages/worker/src/routes/workspaces.ts
@@ -1,6 +1,6 @@
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
-import { z } from "zod";
+import * as z from "zod";
 import type { AppBindings } from "../types";
 
 type WorkspaceRow = {

--- a/packages/worker/src/schemas.test.ts
+++ b/packages/worker/src/schemas.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import * as v from "valibot";
 import { assetNameSchema, documentIdParamSchema } from "./schemas";
 
 describe("documentIdParamSchema", () => {
@@ -10,76 +9,72 @@ describe("documentIdParamSchema", () => {
   const validUuid = "0190e7c0-9c52-7000-9d4f-1a2b3c4d5e6f";
 
   it("accepts a canonical UUID", () => {
-    const result = v.safeParse(documentIdParamSchema, { id: validUuid });
+    const result = documentIdParamSchema.safeParse({ id: validUuid });
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.output.id).toBe(validUuid);
+      expect(result.data.id).toBe(validUuid);
     }
   });
 
   it("accepts mixed-case hex", () => {
-    const result = v.safeParse(documentIdParamSchema, {
+    const result = documentIdParamSchema.safeParse({
       id: "0190E7C0-9C52-7000-9D4F-1A2B3C4D5E6F",
     });
     expect(result.success).toBe(true);
   });
 
   it("rejects a missing dash", () => {
-    const result = v.safeParse(documentIdParamSchema, {
+    const result = documentIdParamSchema.safeParse({
       id: "0190e7c09c52-7000-9d4f-1a2b3c4d5e6f",
     });
     expect(result.success).toBe(false);
   });
 
   it("rejects a non-hex character", () => {
-    const result = v.safeParse(documentIdParamSchema, {
+    const result = documentIdParamSchema.safeParse({
       id: "0190e7c0-9c52-7000-9d4z-1a2b3c4d5e6f",
     });
     expect(result.success).toBe(false);
   });
 
   it("rejects a too-short id", () => {
-    const result = v.safeParse(documentIdParamSchema, {
+    const result = documentIdParamSchema.safeParse({
       id: "0190e7c0-9c52-7000-9d4f",
     });
     expect(result.success).toBe(false);
   });
 
   it("rejects a decimal integer (the previous shape)", () => {
-    const result = v.safeParse(documentIdParamSchema, { id: "42" });
+    const result = documentIdParamSchema.safeParse({ id: "42" });
     expect(result.success).toBe(false);
   });
 
   it("rejects a missing id", () => {
-    const result = v.safeParse(documentIdParamSchema, {});
+    const result = documentIdParamSchema.safeParse({});
     expect(result.success).toBe(false);
   });
 });
 
 describe("assetNameSchema", () => {
   it("accepts a UUID with no extension", () => {
-    const result = v.safeParse(
-      assetNameSchema,
-      "8d6f4d3e-3c8f-4a8a-9c9d-1e2f3a4b5c6d",
+    const result = assetNameSchema.safeParse("8d6f4d3e-3c8f-4a8a-9c9d-1e2f3a4b5c6d",
     );
     expect(result.success).toBe(true);
   });
 
   it("accepts a UUID with an extension", () => {
-    const result = v.safeParse(
-      assetNameSchema,
-      "8d6f4d3e-3c8f-4a8a-9c9d-1e2f3a4b5c6d.png",
+    const result = assetNameSchema.safeParse("8d6f4d3e-3c8f-4a8a-9c9d-1e2f3a4b5c6d.png",
     );
     expect(result.success).toBe(true);
   });
 
   it("rejects a path-traversal attempt", () => {
-    const result = v.safeParse(assetNameSchema, "../etc/passwd");
+    const result = assetNameSchema.safeParse("../etc/passwd");
     expect(result.success).toBe(false);
   });
 
   it("rejects an arbitrary string", () => {
-    const result = v.safeParse(assetNameSchema, "not-a-uuid.png");
+    const result = assetNameSchema.safeParse("not-a-uuid.png");
     expect(result.success).toBe(false);
   });
 });

--- a/packages/worker/src/schemas.ts
+++ b/packages/worker/src/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod";
 
 // Reject malformed document ids at the wire boundary so they never
 // reach D1 (the table's own CHECK constraint is the second line of

--- a/packages/worker/src/schemas.ts
+++ b/packages/worker/src/schemas.ts
@@ -1,16 +1,15 @@
-import * as v from "valibot";
+import { z } from "zod";
 
 // Reject malformed document ids at the wire boundary so they never
 // reach D1 (the table's own CHECK constraint is the second line of
 // defense).
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-export const documentIdSchema = v.pipe(
-  v.string(),
-  v.regex(UUID_PATTERN, "Invalid document id"),
-);
+export const documentIdSchema = z
+  .string()
+  .regex(UUID_PATTERN, "Invalid document id");
 
-export const documentIdParamSchema = v.object({
+export const documentIdParamSchema = z.object({
   id: documentIdSchema,
 });
 
@@ -36,7 +35,6 @@ export const SUPPORTED_ASSET_CONTENT_TYPES = [
 const ASSET_NAME_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}(?:\.[a-z0-9]+)?$/i;
 
-export const assetNameSchema = v.pipe(
-  v.string(),
-  v.regex(ASSET_NAME_PATTERN, "Invalid asset name"),
-);
+export const assetNameSchema = z
+  .string()
+  .regex(ASSET_NAME_PATTERN, "Invalid asset name");

--- a/packages/worker/src/tldraw-assets.ts
+++ b/packages/worker/src/tldraw-assets.ts
@@ -1,4 +1,3 @@
-import * as v from "valibot";
 import { assetNameSchema } from "./schemas";
 import type { AppContext } from "./types";
 
@@ -31,7 +30,7 @@ function getAssetNameFromDocumentAssetSrc(src: string, documentId: string) {
 
     const encodedAssetName = url.pathname.slice(prefix.length);
     const assetName = decodeURIComponent(encodedAssetName);
-    return v.safeParse(assetNameSchema, assetName).success ? assetName : null;
+    return assetNameSchema.safeParse(assetName).success ? assetName : null;
   } catch {
     return null;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,9 +299,9 @@ importers:
       '@hono/oauth-providers':
         specifier: ^0.8.5
         version: 0.8.5(hono@4.12.15)
-      '@hono/valibot-validator':
-        specifier: ^0.6.1
-        version: 0.6.1(hono@4.12.15)(valibot@1.3.1(typescript@5.8.3))
+      '@hono/zod-validator':
+        specifier: ^0.7.6
+        version: 0.7.6(hono@4.12.15)(zod@4.1.13)
       '@tldraw/sync-core':
         specifier: 3.15.5
         version: 3.15.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -317,9 +317,9 @@ importers:
       tldraw:
         specifier: 3.15.5
         version: 3.15.5(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      valibot:
-        specifier: ^1.3.1
-        version: 1.3.1(typescript@5.8.3)
+      zod:
+        specifier: ^4.1.8
+        version: 4.1.13
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.15.2
@@ -1175,11 +1175,11 @@ packages:
     peerDependencies:
       hono: '>=3.0.0'
 
-  '@hono/valibot-validator@0.6.1':
-    resolution: {integrity: sha512-rqKhQJI8IVR8gRRNHHf2wGtIT7sKEqV1KoGL5f2SocNytl+tBNn4EtRu4zfk/D6axgWSswnaxeiuJhM5yNFrCg==, tarball: https://registry.npmjs.org/@hono/valibot-validator/-/valibot-validator-0.6.1.tgz}
+  '@hono/zod-validator@0.7.6':
+    resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==, tarball: https://registry.npmjs.org/@hono/zod-validator/-/zod-validator-0.7.6.tgz}
     peerDependencies:
       hono: '>=3.9.0'
-      valibot: ^1.0.0 || ^1.0.0-beta.4 || ^1.0.0-rc
+      zod: ^3.25.0 || ^4.0.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==, tarball: https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz}
@@ -1252,105 +1252,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==, tarball: https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==, tarball: https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==, tarball: https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==, tarball: https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==, tarball: https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==, tarball: https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==, tarball: https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==, tarball: https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==, tarball: https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==, tarball: https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz}
@@ -1520,42 +1504,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==, tarball: https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz}
@@ -2385,67 +2363,56 @@ packages:
     resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.3':
     resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==, tarball: https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz}
@@ -6378,56 +6345,48 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: glibc
 
   sass-embedded-linux-arm@1.93.3:
     resolution: {integrity: sha512-yeiv2y+dp8B4wNpd3+JsHYD0mvpXSfov7IGyQ1tMIR40qv+ROkRqYiqQvAOXf76Qwh4Y9OaYZtLpnsPjfeq6mA==, tarball: https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.93.3.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: glibc
 
   sass-embedded-linux-musl-arm64@1.93.3:
     resolution: {integrity: sha512-PS829l+eUng+9W4PFclXGb4uA2+965NHV3/Sa5U7qTywjeeUUYTZg70dJHSqvhrBEfCc2XJABeW3adLJbyQYkw==, tarball: https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.93.3.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-musl-arm@1.93.3:
     resolution: {integrity: sha512-fU0fwAwbp7sBE3h5DVU5UPzvaLg7a4yONfFWkkcCp6ZrOiPuGRHXXYriWQ0TUnWy4wE+svsVuWhwWgvlb/tkKg==, tarball: https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.93.3.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-musl-riscv64@1.93.3:
     resolution: {integrity: sha512-cK1oBY+FWQquaIGEeQ5H74KTO8cWsSWwXb/WaildOO9U6wmUypTgUYKQ0o5o/29nZbWWlM1PHuwVYTSnT23Jjg==, tarball: https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.93.3.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-musl-x64@1.93.3:
     resolution: {integrity: sha512-A7wkrsHu2/I4Zpa0NMuPGkWDVV7QGGytxGyUq3opSXgAexHo/vBPlGoDXoRlSdex0cV+aTMRPjoGIfdmNlHwyg==, tarball: https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.93.3.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-riscv64@1.93.3:
     resolution: {integrity: sha512-vWkW1+HTF5qcaHa6hO80gx/QfB6GGjJUP0xLbnAoY4pwEnw5ulGv6RM8qYr8IDhWfVt/KH+lhJ2ZFxnJareisQ==, tarball: https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.93.3.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: glibc
 
   sass-embedded-linux-x64@1.93.3:
     resolution: {integrity: sha512-k6uFxs+e5jSuk1Y0niCwuq42F9ZC5UEP7P+RIOurIm8w/5QFa0+YqeW+BPWEW5M1FqVOsNZH3qGn4ahqvAEjPA==, tarball: https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.93.3.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: glibc
 
   sass-embedded-unknown-all@1.93.3:
     resolution: {integrity: sha512-o5wj2rLpXH0C+GJKt/VpWp6AnMsCCbfFmnMAttcrsa+U3yrs/guhZ3x55KAqqUsE8F47e3frbsDL+1OuQM5DAA==, tarball: https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.93.3.tgz}
@@ -7121,14 +7080,6 @@ packages:
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==, tarball: https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz}
     hasBin: true
-
-  valibot@1.3.1:
-    resolution: {integrity: sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==, tarball: https://registry.npmjs.org/valibot/-/valibot-1.3.1.tgz}
-    peerDependencies:
-      typescript: '>=5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   varint@6.0.0:
     resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==, tarball: https://registry.npmjs.org/varint/-/varint-6.0.0.tgz}
@@ -8397,10 +8348,10 @@ snapshots:
     dependencies:
       hono: 4.12.15
 
-  '@hono/valibot-validator@0.6.1(hono@4.12.15)(valibot@1.3.1(typescript@5.8.3))':
+  '@hono/zod-validator@0.7.6(hono@4.12.15)(zod@4.1.13)':
     dependencies:
       hono: 4.12.15
-      valibot: 1.3.1(typescript@5.8.3)
+      zod: 4.1.13
 
   '@humanfs/core@0.19.1': {}
 
@@ -15896,10 +15847,6 @@ snapshots:
   uuid@11.1.0: {}
 
   uuid@14.0.0: {}
-
-  valibot@1.3.1(typescript@5.8.3):
-    optionalDependencies:
-      typescript: 5.8.3
 
   varint@6.0.0: {}
 


### PR DESCRIPTION
## Summary

- Worker had been on valibot since before the agent feature; with `agent-core` (which the worker imports) committed to zod for its JSON-Schema export of action/prompt schemas, every deployed worker bundle was already shipping zod via the transitive dep.
- Valibot was duplicate weight in every cold start, with no behavioral difference at the API boundary — this PR removes that duplication.
- Migration is mechanical: schemas rewritten in zod's chained-builder style, validator hooks read `result.error.issues` instead of `result.issues`, tests use `schema.safeParse(value)` and `result.data`. The HTTP-layer error response shape is unchanged.

## Notable details

- `valibot` + `@hono/valibot-validator` → `zod@^4.1.8` (matches the range agent-core already pins) + `@hono/zod-validator@^0.7.6` (zod v3.25 || v4 compatible).
- File validation in `document-assets.ts` moves from `pipe(file(), mimeType(...), maxSize(...))` to `instanceof(File).refine(mimeOk).refine(sizeOk)` — zod has no built-in helpers for File MIME/size, so refines stay closest to the original semantics.
- Drop the "Why zod (and not valibot like the rest of the worker)" paragraph in `agent-core/src/schemas/prompt-part.ts`; the asymmetry it explained no longer exists.
- Update the prose comment in `migrations/0001_initial_schema.sql` to "API-layer schema validator" since the SQL CHECK constraint isn't validator-library-specific. Comment-only edit; D1 tracks migrations by name, so the file can be updated safely.

## Test plan

- [x] `pnpm --filter anipres-worker typecheck`
- [x] `pnpm --filter anipres-worker test` — 51 tests pass
- [x] `pnpm -r typecheck` — clean across all packages
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated request and schema validation across the backend to a single Zod-based framework for consistency.
  * Updated worker runtime dependencies to align with the new validator.
  * Adjusted tests to use the new validation APIs.
  * Minor documentation/comment clarifications around whitespace handling and schema notes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/anipres/pull/479)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->