### PR TITLE
ci: post bundle-size sticky comment on every PR

### DIFF
--- a/.github/actions/measure-bundle-size/action.yml
+++ b/.github/actions/measure-bundle-size/action.yml
@@ -138,14 +138,9 @@ runs:
         cat "$RUNNER_TEMP/bsr-comment.md"
         echo "::endgroup::"
 
-    # Retry handles the race where two jobs read "no existing comment"
-    # simultaneously and one's create wins (the loser sees 422/409 from
-    # GitHub validating against the now-updated state). 403 covers the
-    # secondary rate limit.
-    #
-    # Caveat: if both jobs successfully POST in the same window (no
-    # error to retry on), we can end up with duplicate comments. Stlite
-    # has the same edge case; rare enough not to engineer around.
+    # Caveat: if two jobs both successfully POST in the same window
+    # (no error to retry on), we can end up with duplicate comments.
+    # Stlite has the same edge case; rare enough not to engineer around.
     - name: Update sticky PR comment
       if: github.event_name == 'pull_request'
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -154,62 +149,13 @@ runs:
         COMMENT_PATH: ${{ runner.temp }}/bsr-comment.md
       with:
         script: |
-          const fs = require("fs");
-          const MARKER = "<!-- bundle-size-report -->";
-          const prNumber = parseInt(process.env.PR_NUMBER, 10);
-          const body = `${MARKER}\n${fs.readFileSync(process.env.COMMENT_PATH, "utf8")}`;
-
-          const MAX_RETRIES = 3;
-          const RETRY_DELAY_MS = 1000;
-
-          for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-            try {
-              const comments = await github.paginate(
-                github.rest.issues.listComments,
-                {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: prNumber,
-                },
-              );
-              const existing = comments.find(
-                (c) =>
-                  c.body?.startsWith(MARKER) &&
-                  c.user?.login === "github-actions[bot]",
-              );
-
-              if (existing) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: existing.id,
-                  body,
-                });
-                core.info(
-                  `Updated bundle-size comment ${existing.id} on PR #${prNumber}`,
-                );
-              } else {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: prNumber,
-                  body,
-                });
-                core.info(`Created bundle-size comment on PR #${prNumber}`);
-              }
-              break;
-            } catch (error) {
-              const isRetryable =
-                error.status === 409 ||
-                error.status === 422 ||
-                error.status === 403;
-              if (isRetryable && attempt < MAX_RETRIES) {
-                core.warning(
-                  `Attempt ${attempt} failed with status ${error.status}, retrying in ${RETRY_DELAY_MS}ms…`,
-                );
-                await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
-                continue;
-              }
-              throw error;
-            }
-          }
+          const { pathToFileURL } = require("node:url");
+          const path = require("node:path");
+          const url = pathToFileURL(
+            path.join(
+              process.env.GITHUB_WORKSPACE,
+              ".github/scripts/bundle-size-report/update-sticky-comment.mjs",
+            ),
+          ).href;
+          const { default: run } = await import(url);
+          await run({ github, context, core });

--- a/.github/actions/measure-bundle-size/action.yml
+++ b/.github/actions/measure-bundle-size/action.yml
@@ -1,9 +1,14 @@
 # Patterned after whitphx/stlite's .github/actions/set-package-stats
-# (Apache-2.0). This version measures a directory directly (no tarball
-# staging) and produces a JSON shape the report job consumes.
+# (Apache-2.0). Each invocation measures one bundle, uploads its
+# bundle-stats.<key> artifact, and (on PRs) re-renders the sticky
+# comment from whatever stats artifacts are visible *right now* —
+# its own plus any earlier jobs'. So the comment fills in
+# incrementally as builds finish, and one job's failure only
+# subtracts that one row from the report instead of suppressing
+# the whole comment.
 # Upstream: https://github.com/whitphx/stlite/blob/main/.github/actions/set-package-stats/action.yml
-name: Measure bundle size
-description: Walk a built directory and upload a bundle-stats.<key> artifact for downstream PR reporting.
+name: Measure & report bundle size
+description: Measure a built directory, upload bundle-stats artifact, and update the sticky PR comment with the current state of all measured bundles.
 inputs:
   key:
     required: true
@@ -44,3 +49,167 @@ runs:
         name: bundle-stats.${{ inputs.key }}
         path: ${{ env.BUNDLE_STATS_FILE }}
         if-no-files-found: error
+
+    # Wipe any stale workspaces from a previous invocation in the
+    # same job (composite is reusable; assume nothing).
+    - name: Prepare comment workspaces
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: |
+        rm -rf "$RUNNER_TEMP/bsr-current" "$RUNNER_TEMP/bsr-base"
+        mkdir -p "$RUNNER_TEMP/bsr-current" "$RUNNER_TEMP/bsr-base"
+
+    - name: Download current run bundle-stats
+      if: github.event_name == 'pull_request'
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        pattern: bundle-stats.*
+        path: ${{ runner.temp }}/bsr-current
+
+    # Skip the current run when looking for a baseline so a main-push
+    # invocation diffs against the *previous* main run instead of itself.
+    - name: Find latest baseline run on default branch
+      if: github.event_name == 'pull_request'
+      id: bsr-base
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        BASE_BRANCH: ${{ github.event.repository.default_branch }}
+        CURRENT_RUN_ID: ${{ github.run_id }}
+        WORKFLOW: ${{ github.workflow }}
+      run: |
+        info=$(gh run list \
+          --branch "$BASE_BRANCH" \
+          --workflow "$WORKFLOW" \
+          --status success \
+          --limit 5 \
+          --json databaseId,headSha \
+          --jq "[.[] | select(.databaseId != ${CURRENT_RUN_ID})] | .[0] // {}")
+        run_id=$(echo "$info" | jq -r '.databaseId // empty')
+        sha=$(echo "$info" | jq -r '.headSha // empty')
+        {
+          echo "run-id=$run_id"
+          echo "sha=$sha"
+          echo "branch=$BASE_BRANCH"
+        } >> "$GITHUB_OUTPUT"
+        if [ -n "$run_id" ]; then
+          echo "Base run: $run_id ($sha)"
+        else
+          echo "No baseline run found on $BASE_BRANCH yet."
+        fi
+
+    # `continue-on-error` covers the bootstrap case where the baseline
+    # main run pre-dates this feature and has no bundle-stats artifacts.
+    - name: Download base run bundle-stats
+      if: github.event_name == 'pull_request' && steps.bsr-base.outputs.run-id != ''
+      continue-on-error: true
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        pattern: bundle-stats.*
+        path: ${{ runner.temp }}/bsr-base
+        run-id: ${{ steps.bsr-base.outputs.run-id }}
+        github-token: ${{ github.token }}
+
+    - name: Format comment
+      if: github.event_name == 'pull_request'
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        BASE_RUN_ID: ${{ steps.bsr-base.outputs.run-id }}
+        BASE_SHA: ${{ steps.bsr-base.outputs.sha }}
+        BASE_BRANCH: ${{ steps.bsr-base.outputs.branch }}
+        REPO: ${{ github.repository }}
+      run: |
+        base_args=()
+        if [ -n "$BASE_SHA" ] && [ -d "$RUNNER_TEMP/bsr-base" ]; then
+          base_args+=(--base-dir "$RUNNER_TEMP/bsr-base" --base-sha "$BASE_SHA")
+          if [ -n "$BASE_RUN_ID" ]; then
+            base_args+=(--base-run-id "$BASE_RUN_ID")
+          fi
+        fi
+        node .github/scripts/bundle-size-report/format-comment.mjs \
+          --current-dir "$RUNNER_TEMP/bsr-current" \
+          --base-branch "$BASE_BRANCH" \
+          --repo "$REPO" \
+          --output "$RUNNER_TEMP/bsr-comment.md" \
+          "${base_args[@]}"
+        echo "::group::Comment preview"
+        cat "$RUNNER_TEMP/bsr-comment.md"
+        echo "::endgroup::"
+
+    # Retry handles the race where two jobs read "no existing comment"
+    # simultaneously and one's create wins (the loser sees 422/409 from
+    # GitHub validating against the now-updated state). 403 covers the
+    # secondary rate limit.
+    #
+    # Caveat: if both jobs successfully POST in the same window (no
+    # error to retry on), we can end up with duplicate comments. Stlite
+    # has the same edge case; rare enough not to engineer around.
+    - name: Update sticky PR comment
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        COMMENT_PATH: ${{ runner.temp }}/bsr-comment.md
+      with:
+        script: |
+          const fs = require("fs");
+          const MARKER = "<!-- bundle-size-report -->";
+          const prNumber = parseInt(process.env.PR_NUMBER, 10);
+          const body = `${MARKER}\n${fs.readFileSync(process.env.COMMENT_PATH, "utf8")}`;
+
+          const MAX_RETRIES = 3;
+          const RETRY_DELAY_MS = 1000;
+
+          for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+            try {
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                },
+              );
+              const existing = comments.find(
+                (c) =>
+                  c.body?.startsWith(MARKER) &&
+                  c.user?.login === "github-actions[bot]",
+              );
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+                core.info(
+                  `Updated bundle-size comment ${existing.id} on PR #${prNumber}`,
+                );
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body,
+                });
+                core.info(`Created bundle-size comment on PR #${prNumber}`);
+              }
+              break;
+            } catch (error) {
+              const isRetryable =
+                error.status === 409 ||
+                error.status === 422 ||
+                error.status === 403;
+              if (isRetryable && attempt < MAX_RETRIES) {
+                core.warning(
+                  `Attempt ${attempt} failed with status ${error.status}, retrying in ${RETRY_DELAY_MS}ms…`,
+                );
+                await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+                continue;
+              }
+              throw error;
+            }
+          }

--- a/.github/actions/measure-bundle-size/action.yml
+++ b/.github/actions/measure-bundle-size/action.yml
@@ -1,0 +1,46 @@
+# Patterned after whitphx/stlite's .github/actions/set-package-stats
+# (Apache-2.0). This version measures a directory directly (no tarball
+# staging) and produces a JSON shape the report job consumes.
+# Upstream: https://github.com/whitphx/stlite/blob/main/.github/actions/set-package-stats/action.yml
+name: Measure bundle size
+description: Walk a built directory and upload a bundle-stats.<key> artifact for downstream PR reporting.
+inputs:
+  key:
+    required: true
+    description: Stable identifier for this bundle (e.g. 'anipres', 'app'). Used as the artifact suffix and to match against the base run.
+  name:
+    required: false
+    description: Human-readable name for the bundle in the comment. Defaults to key.
+  input-path:
+    required: true
+    description: Path to the built directory to measure.
+
+runs:
+  using: composite
+  steps:
+    - name: Measure bundle
+      shell: bash
+      # Pin to the repo root so input-path is interpreted from there
+      # regardless of the calling job's defaults.run.working-directory.
+      working-directory: ${{ github.workspace }}
+      env:
+        KEY: ${{ inputs.key }}
+        NAME: ${{ inputs.name }}
+        INPUT_PATH: ${{ inputs.input-path }}
+      run: |
+        out_dir="$RUNNER_TEMP/bundle-stats/$KEY"
+        mkdir -p "$out_dir"
+        out_file="$out_dir/bundle-stats.json"
+        node "$GITHUB_WORKSPACE/.github/scripts/bundle-size-report/measure.mjs" \
+          --input "$INPUT_PATH" \
+          --output "$out_file" \
+          --key "$KEY" \
+          ${NAME:+--name "$NAME"}
+        echo "BUNDLE_STATS_FILE=$out_file" >> "$GITHUB_ENV"
+
+    - name: Upload bundle-stats artifact
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: bundle-stats.${{ inputs.key }}
+        path: ${{ env.BUNDLE_STATS_FILE }}
+        if-no-files-found: error

--- a/.github/scripts/bundle-size-report/format-comment.mjs
+++ b/.github/scripts/bundle-size-report/format-comment.mjs
@@ -166,7 +166,7 @@ function renderSummary(currentByKey, baseByKey) {
   const lines = [];
   if (significantCount > 0) {
     lines.push(
-      `⚠️ ${significantCount} bundle${significantCount === 1 ? "" : "s"} changed by ≥${SIGNIFICANT_GZIP_PCT * 100}% gzip (and ≥${formatBytes(SIGNIFICANT_GZIP_BYTES)}).`,
+      `⚠️ ${significantCount} bundle${significantCount === 1 ? "" : "s"} changed by ≥${Math.round(SIGNIFICANT_GZIP_PCT * 100)}% gzip (and ≥${formatBytes(SIGNIFICANT_GZIP_BYTES)}).`,
     );
     lines.push("");
   }

--- a/.github/scripts/bundle-size-report/format-comment.mjs
+++ b/.github/scripts/bundle-size-report/format-comment.mjs
@@ -1,0 +1,277 @@
+// Renders the bundle-size sticky-comment markdown from the current
+// run's bundle-stats.* artifacts and (optionally) a base run's same
+// artifacts. Emits markdown to --output.
+//
+// Patterned after whitphx/stlite's .github/actions/inform-package-stats
+// (Apache-2.0, https://github.com/whitphx/stlite/blob/main/.github/actions/inform-package-stats/action.yml).
+// Differences worth flagging when syncing forward:
+//   - Reports gzip size + percentage delta (stlite reports raw kiB
+//     only). Significance threshold is computed on gzip.
+//   - Per-file rendering is a status-icon table (🟢 new / 🔴 removed /
+//     🔼 grew / 🔽 shrunk) sorted by Δgzip then by size, instead of a
+//     line-diff over `find -printf "%s %p"` text.
+//   - Base bundle is matched by `key`, so reordering / renaming an
+//     artifact doesn't show as removed+added at the bundle level.
+
+import fs from "node:fs";
+import path from "node:path";
+import { parseArgs } from "node:util";
+
+const SIGNIFICANT_GZIP_PCT = 0.05;
+const SIGNIFICANT_GZIP_BYTES = 512;
+
+const { values } = parseArgs({
+  options: {
+    "current-dir": { type: "string" },
+    "base-dir": { type: "string" },
+    "output": { type: "string" },
+    "head-sha": { type: "string" },
+    "base-sha": { type: "string" },
+    "base-run-id": { type: "string" },
+    "base-branch": { type: "string" },
+    "repo": { type: "string" },
+  },
+});
+
+if (!values["current-dir"] || !values.output) {
+  console.error(
+    "Usage: format-comment.mjs --current-dir <dir> [--base-dir <dir>] --output <file> [--head-sha <sha>] [--base-sha <sha>] [--base-run-id <id>] [--base-branch <name>] [--repo <owner/name>]",
+  );
+  process.exit(1);
+}
+
+function loadStatsFromDir(dir) {
+  const stats = [];
+  if (!dir || !fs.existsSync(dir)) return stats;
+  for (const entry of fs.readdirSync(dir, {
+    recursive: true,
+    withFileTypes: true,
+  })) {
+    if (!entry.isFile() || entry.name !== "bundle-stats.json") continue;
+    const full = path.join(entry.parentPath, entry.name);
+    try {
+      const parsed = JSON.parse(fs.readFileSync(full, "utf8"));
+      if (parsed.schemaVersion === 1 && typeof parsed.key === "string") {
+        stats.push(parsed);
+      } else {
+        console.warn(`Skipping ${full}: unexpected shape`);
+      }
+    } catch (e) {
+      console.warn(`Skipping ${full}: ${e.message}`);
+    }
+  }
+  return stats;
+}
+
+function indexByKey(list) {
+  const m = new Map();
+  for (const item of list) m.set(item.key, item);
+  return m;
+}
+
+function formatBytes(n) {
+  if (n == null) return "—";
+  const KIB = 1024;
+  const MIB = KIB * 1024;
+  if (n === 0) return "0 B";
+  if (n < KIB) return `${n} B`;
+  if (n < MIB) return `${(n / KIB).toFixed(1)} KiB`;
+  return `${(n / MIB).toFixed(2)} MiB`;
+}
+
+function formatDeltaCell(curr, base, { bold = true } = {}) {
+  if (base == null && curr == null) return "—";
+  if (base == null) return bold ? "**new**" : "new";
+  if (curr == null) return bold ? "**removed**" : "removed";
+  const diff = curr - base;
+  if (diff === 0) return "—";
+  const sign = diff > 0 ? "+" : "−";
+  const sizeStr = `${sign}${formatBytes(Math.abs(diff))}`;
+  const pctStr =
+    base > 0
+      ? ` (${sign}${((Math.abs(diff) / base) * 100).toFixed(1)}%)`
+      : "";
+  return bold ? `**${sizeStr}**${pctStr}` : `${sizeStr}${pctStr}`;
+}
+
+function isSignificantGzip(curr, base) {
+  // Only flag a regression when both sides exist; "new"/"removed"
+  // bundles are informational, not threshold violations.
+  if (base == null || curr == null) return false;
+  const diff = curr - base;
+  if (Math.abs(diff) < SIGNIFICANT_GZIP_BYTES) return false;
+  if (Math.abs(diff) / Math.max(base, 1) < SIGNIFICANT_GZIP_PCT) return false;
+  return true;
+}
+
+function statusIcon(curr, base) {
+  if (base == null) return "🟢";
+  if (curr == null) return "🔴";
+  if (curr > base) return "🔼";
+  if (curr < base) return "🔽";
+  return "";
+}
+
+function renderHeader({ hasBase }) {
+  const lines = ["## 📦 Bundle size report", ""];
+  const repo = values.repo;
+  const baseSha = values["base-sha"];
+  const baseBranch = values["base-branch"] ?? "main";
+  const baseRunId = values["base-run-id"];
+
+  if (hasBase && baseSha && repo) {
+    const shaLink = `[\`${baseSha.slice(0, 7)}\`](https://github.com/${repo}/commit/${baseSha})`;
+    const runLink = baseRunId
+      ? ` · [run #${baseRunId}](https://github.com/${repo}/actions/runs/${baseRunId})`
+      : "";
+    lines.push(
+      `> Compared against \`${baseBranch}\` (${shaLink}${runLink}).`,
+    );
+  } else {
+    lines.push(
+      `> No baseline run found on \`${baseBranch}\`; showing absolute sizes only.`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function renderSummary(currentByKey, baseByKey) {
+  const rows = [];
+  let significantCount = 0;
+  const allKeys = [
+    ...new Set([...currentByKey.keys(), ...baseByKey.keys()]),
+  ].sort();
+
+  for (const key of allKeys) {
+    const curr = currentByKey.get(key);
+    const base = baseByKey.get(key);
+    const name = curr?.name ?? base?.name ?? key;
+    const currTotals = curr?.totals;
+    const baseTotals = base?.totals;
+    const significant = isSignificantGzip(
+      currTotals?.gzipBytes,
+      baseTotals?.gzipBytes,
+    );
+    if (significant) significantCount++;
+
+    const rawCell = `${formatBytes(currTotals?.rawBytes ?? null)} ${formatDeltaCell(currTotals?.rawBytes, baseTotals?.rawBytes, { bold: false })}`.trim();
+    const gzipCell = `${formatBytes(currTotals?.gzipBytes ?? null)} ${formatDeltaCell(currTotals?.gzipBytes, baseTotals?.gzipBytes)}`.trim();
+    const indicator = significant ? "⚠️ " : "";
+    rows.push(
+      `| ${indicator}${name} | ${currTotals?.files ?? "—"} | ${rawCell} | ${gzipCell} |`,
+    );
+  }
+
+  const lines = [];
+  if (significantCount > 0) {
+    lines.push(
+      `⚠️ ${significantCount} bundle${significantCount === 1 ? "" : "s"} changed by ≥${SIGNIFICANT_GZIP_PCT * 100}% gzip (and ≥${formatBytes(SIGNIFICANT_GZIP_BYTES)}).`,
+    );
+    lines.push("");
+  }
+  lines.push("### Summary");
+  lines.push("");
+  lines.push("| Bundle | Files | Raw | Gzip |");
+  lines.push("| --- | ---: | ---: | ---: |");
+  lines.push(...rows);
+  lines.push("");
+  return lines.join("\n");
+}
+
+function renderFileTable(curr, base) {
+  const baseFiles = new Map();
+  if (base) for (const f of base.files) baseFiles.set(f.path, f);
+  const currFiles = new Map();
+  if (curr) for (const f of curr.files) currFiles.set(f.path, f);
+
+  const allPaths = new Set([...baseFiles.keys(), ...currFiles.keys()]);
+  const rows = [];
+  for (const p of allPaths) {
+    const c = currFiles.get(p);
+    const b = baseFiles.get(p);
+    const currGzip = c?.gzipBytes ?? null;
+    const baseGzip = b?.gzipBytes ?? null;
+    const diff =
+      currGzip != null && baseGzip != null ? currGzip - baseGzip : null;
+    rows.push({
+      path: p,
+      curr: c,
+      base: b,
+      diff,
+      sortKey:
+        diff != null
+          ? Math.abs(diff)
+          : currGzip != null
+            ? currGzip
+            : (baseGzip ?? 0),
+      hasChange: diff !== 0 || c == null || b == null,
+    });
+  }
+
+  rows.sort((a, b) => {
+    if (a.hasChange !== b.hasChange) return a.hasChange ? -1 : 1;
+    return b.sortKey - a.sortKey;
+  });
+
+  const lines = [];
+  lines.push("|   | File | Raw | Gzip | Δ Gzip |");
+  lines.push("| --- | --- | ---: | ---: | ---: |");
+  for (const r of rows) {
+    const icon = statusIcon(r.curr?.gzipBytes, r.base?.gzipBytes);
+    const path =
+      r.curr == null ? `~~\`${r.path}\`~~` : `\`${r.path}\``;
+    const raw = formatBytes(r.curr?.rawBytes ?? null);
+    const gzip = formatBytes(r.curr?.gzipBytes ?? null);
+    const delta = formatDeltaCell(r.curr?.gzipBytes, r.base?.gzipBytes);
+    lines.push(`| ${icon} | ${path} | ${raw} | ${gzip} | ${delta} |`);
+  }
+  return lines.join("\n");
+}
+
+function renderPerBundle(currentByKey, baseByKey) {
+  const lines = ["### File breakdown", ""];
+  const keys = [...currentByKey.keys()].sort();
+
+  for (const key of keys) {
+    const curr = currentByKey.get(key);
+    const base = baseByKey.get(key);
+    const name = curr?.name ?? key;
+    const t = curr.totals;
+    const summary =
+      `${t.files} files · ${formatBytes(t.rawBytes)} raw · ${formatBytes(t.gzipBytes)} gzip` +
+      (base
+        ? ` · ${formatDeltaCell(t.rawBytes, base.totals.rawBytes, { bold: false })} raw / ${formatDeltaCell(t.gzipBytes, base.totals.gzipBytes, { bold: false })} gzip`
+        : "");
+    lines.push(`<details>`);
+    lines.push(`<summary><b>${name}</b> — ${summary}</summary>`);
+    lines.push("");
+    lines.push(renderFileTable(curr, base));
+    lines.push("");
+    lines.push(`</details>`);
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+const current = loadStatsFromDir(values["current-dir"]);
+if (current.length === 0) {
+  console.error(
+    `No bundle-stats found in ${values["current-dir"]}; aborting.`,
+  );
+  process.exit(1);
+}
+const base = loadStatsFromDir(values["base-dir"]);
+
+const currentByKey = indexByKey(current);
+const baseByKey = indexByKey(base);
+
+const out =
+  renderHeader({ hasBase: base.length > 0 }) +
+  "\n" +
+  renderSummary(currentByKey, baseByKey) +
+  "\n" +
+  renderPerBundle(currentByKey, baseByKey);
+
+fs.writeFileSync(values.output, out);
+console.log(`Wrote comment markdown to ${values.output} (${out.length} bytes)`);

--- a/.github/scripts/bundle-size-report/measure.mjs
+++ b/.github/scripts/bundle-size-report/measure.mjs
@@ -1,0 +1,98 @@
+// Walks a directory and emits JSON describing every file's raw +
+// gzip size, plus totals. Consumed by the bundle-size-report job.
+//
+// Patterned after whitphx/stlite's .github/actions/set-package-stats
+// (Apache-2.0, https://github.com/whitphx/stlite/blob/main/.github/actions/set-package-stats/action.yml).
+// Differences worth flagging when syncing forward:
+//   - Stlite uses `du -k` (block-rounded disk usage) plus separate
+//     `tree` and `find -printf "%s %p"` shell pipelines. This script
+//     reads byte-accurate sizes from a single Node walk and adds gzip
+//     so deltas can be reasoned about against what users actually
+//     download.
+//   - Output is JSON only; the formatter handles tree/list rendering.
+import { readdirSync, statSync, readFileSync, writeFileSync } from "node:fs";
+import { gzipSync, constants as zlibConstants } from "node:zlib";
+import { join, relative, sep } from "node:path";
+import { parseArgs } from "node:util";
+
+function* walk(root) {
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (entry.isFile()) {
+        yield full;
+      }
+    }
+  }
+}
+
+const { values } = parseArgs({
+  options: {
+    input: { type: "string" },
+    output: { type: "string" },
+    key: { type: "string" },
+    name: { type: "string" },
+  },
+});
+
+if (!values.input || !values.output || !values.key) {
+  console.error(
+    "Usage: measure.mjs --input <dir> --output <file> --key <key> [--name <name>]",
+  );
+  process.exit(1);
+}
+
+const inputDir = values.input;
+const outputFile = values.output;
+const key = values.key;
+const name = values.name ?? key;
+
+if (!statSync(inputDir).isDirectory()) {
+  console.error(`Input is not a directory: ${inputDir}`);
+  process.exit(1);
+}
+
+const files = [];
+for (const filePath of walk(inputDir)) {
+  const buf = readFileSync(filePath);
+  const rawBytes = buf.byteLength;
+  // Match what static hosts typically serve (max compression). Mirrors
+  // what downstream consumers measure against budgets.
+  const gzipBytes = gzipSync(buf, {
+    level: zlibConstants.Z_BEST_COMPRESSION,
+  }).byteLength;
+  files.push({
+    path: relative(inputDir, filePath).split(sep).join("/"),
+    rawBytes,
+    gzipBytes,
+  });
+}
+
+files.sort((a, b) => a.path.localeCompare(b.path));
+
+const totals = files.reduce(
+  (acc, f) => ({
+    files: acc.files + 1,
+    rawBytes: acc.rawBytes + f.rawBytes,
+    gzipBytes: acc.gzipBytes + f.gzipBytes,
+  }),
+  { files: 0, rawBytes: 0, gzipBytes: 0 },
+);
+
+const report = {
+  schemaVersion: 1,
+  key,
+  name,
+  createdAt: new Date().toISOString(),
+  totals,
+  files,
+};
+
+writeFileSync(outputFile, JSON.stringify(report, null, 2) + "\n");
+console.log(
+  `Wrote ${outputFile}: ${totals.files} files, raw=${totals.rawBytes}B, gzip=${totals.gzipBytes}B`,
+);

--- a/.github/scripts/bundle-size-report/update-sticky-comment.mjs
+++ b/.github/scripts/bundle-size-report/update-sticky-comment.mjs
@@ -1,0 +1,73 @@
+// Posts or updates the bundle-size sticky comment on the current PR.
+// Loaded by .github/actions/measure-bundle-size/action.yml via
+// actions/github-script's dynamic-import bridge so the github/context/
+// core handles flow in cleanly.
+//
+// Patterned after whitphx/stlite's sticky-comment-add-section retry
+// loop (Apache-2.0). The race-handling logic is what makes per-job
+// updates safe when several measure jobs finish near-simultaneously.
+// Upstream: https://github.com/whitphx/stlite/blob/main/.github/actions/sticky-comment-add-section/action.yml
+
+import fs from "node:fs";
+
+const MARKER = "<!-- bundle-size-report -->";
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 1000;
+
+// Env: PR_NUMBER, COMMENT_PATH
+export default async function run({ github, context, core }) {
+  const prNumber = parseInt(process.env.PR_NUMBER, 10);
+  const body = `${MARKER}\n${fs.readFileSync(process.env.COMMENT_PATH, "utf8")}`;
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const comments = await github.paginate(github.rest.issues.listComments, {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: prNumber,
+      });
+      const existing = comments.find(
+        (c) =>
+          c.body?.startsWith(MARKER) &&
+          c.user?.login === "github-actions[bot]",
+      );
+
+      if (existing) {
+        await github.rest.issues.updateComment({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          comment_id: existing.id,
+          body,
+        });
+        core.info(
+          `Updated bundle-size comment ${existing.id} on PR #${prNumber}`,
+        );
+      } else {
+        await github.rest.issues.createComment({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          issue_number: prNumber,
+          body,
+        });
+        core.info(`Created bundle-size comment on PR #${prNumber}`);
+      }
+      return;
+    } catch (error) {
+      // 409 = comment was modified between read and update; 422 = stale-data
+      // validation; 403 = secondary rate limit. Each is retryable after a
+      // pause + a fresh listComments fetch.
+      const isRetryable =
+        error.status === 409 ||
+        error.status === 422 ||
+        error.status === 403;
+      if (isRetryable && attempt < MAX_RETRIES) {
+        core.warning(
+          `Attempt ${attempt} failed with status ${error.status}, retrying in ${RETRY_DELAY_MS}ms…`,
+        );
+        await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+        continue;
+      }
+      throw error;
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -567,6 +567,7 @@ jobs:
           persist-credentials: false
           sparse-checkout: |
             .github/scripts/bundle-size-report
+            .nvmrc
           sparse-checkout-cone-mode: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,70 +386,6 @@ jobs:
           command: pages deploy packages/app/dist --project-name=anipres --branch=${{ github.head_ref || github.ref_name }} --commit-hash=${{ github.sha }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
-  # Worker bundle measurement — produces a non-deploying bundle so the
-  # bundle-size-report job has a worker artifact to compare. The
-  # `deploy-worker` job below builds again because it also handles
-  # migrations and asset upload; keeping them split avoids reshuffling
-  # the deploy path for a measurement-only need.
-  build-worker:
-    needs: [build-anipres, build-agent-core, build-app]
-
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/worker
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-        with:
-          version: latest
-          run_install: false
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version-file: .nvmrc
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: anipres-dist
-          path: packages/anipres/dist
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: agent-core-dist
-          path: packages/agent-core/dist
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: app-dist
-          path: packages/app/dist
-
-      # `--dry-run` skips Cloudflare API calls; `--outdir` writes the
-      # bundled worker JS for measurement. Uses `--env preview` so the
-      # bindings shape matches what the preview deploy ships.
-      # CF Workers don't deploy sourcemaps by default, so drop them
-      # before measuring — otherwise the report shows the sourcemap
-      # weight (often 2× the JS) and looks broken.
-      - name: Build worker bundle
-        run: |
-          pnpm wrangler deploy --env preview --dry-run --outdir dist
-          rm -f dist/*.map
-
-      - name: Measure bundle size
-        uses: ./.github/actions/measure-bundle-size
-        with:
-          key: worker
-          name: worker
-          input-path: packages/worker/dist
-
   # Worker deploy — same code, two targets:
   # - on PR: shared preview worker (*.workers.dev, isolated D1/R2/DO,
   #   last push wins, see [env.preview] in wrangler.toml).
@@ -547,7 +483,23 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        # `deploy:preview` / `deploy:prod` pass `--outdir dist` to
+        # wrangler so this same step writes the deployed bundle to
+        # disk for the measurement step below.
         run: pnpm ${{ github.event_name == 'pull_request' && 'deploy:preview' || 'deploy:prod' }}
+
+      # CF Workers don't deploy sourcemaps by default, so drop them
+      # before measuring — otherwise the report shows the sourcemap
+      # weight (often 2× the JS) and looks broken.
+      - name: Strip sourcemaps from worker bundle
+        run: rm -f dist/*.map
+
+      - name: Measure bundle size
+        uses: ./.github/actions/measure-bundle-size
+        with:
+          key: worker
+          name: worker
+          input-path: packages/worker/dist
 
   # Bundle-size sticky comment. Compares each build's `bundle-stats.<key>`
   # artifact against the latest successful main run. Runs on main pushes
@@ -558,7 +510,7 @@ jobs:
       - build-agent-core
       - build-app
       - build-slidev-addon-anipres-preview
-      - build-worker
+      - deploy-worker
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,13 @@ jobs:
           path: packages/agent-core/dist
           name: agent-core-dist
 
+      - name: Measure bundle size
+        uses: ./.github/actions/measure-bundle-size
+        with:
+          key: agent-core
+          name: agent-core
+          input-path: packages/agent-core/dist
+
   test-slidev-addon-anipres:
     runs-on: ubuntu-latest
     defaults:
@@ -385,7 +392,7 @@ jobs:
   # migrations and asset upload; keeping them split avoids reshuffling
   # the deploy path for a measurement-only need.
   build-worker:
-    needs: [build-anipres, build-app]
+    needs: [build-anipres, build-agent-core, build-app]
 
     runs-on: ubuntu-latest
     defaults:
@@ -414,6 +421,11 @@ jobs:
         with:
           name: anipres-dist
           path: packages/anipres/dist
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: agent-core-dist
+          path: packages/agent-core/dist
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -538,6 +550,7 @@ jobs:
   bundle-size-report:
     needs:
       - build-anipres
+      - build-agent-core
       - build-app
       - build-slidev-addon-anipres-preview
       - build-worker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ permissions: {}
 jobs:
   build-anipres:
     runs-on: ubuntu-latest
+    # `pull-requests: write` so the measure-bundle-size action can update
+    # the sticky comment; `actions: read` for cross-run baseline downloads.
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
     defaults:
       run:
         working-directory: packages/anipres
@@ -66,6 +72,10 @@ jobs:
   build-agent-core:
     needs: [build-anipres]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
     defaults:
       run:
         working-directory: packages/agent-core
@@ -156,6 +166,10 @@ jobs:
 
   build-slidev-addon-anipres-preview:
     needs: [test-slidev-addon-anipres, build-anipres]
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
     defaults:
       run:
         working-directory: packages/slidev-addon-anipres
@@ -309,6 +323,10 @@ jobs:
     needs: [build-anipres, build-agent-core, lint-app]
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
     defaults:
       run:
         working-directory: packages/app
@@ -401,6 +419,8 @@ jobs:
     permissions:
       contents: read
       deployments: write
+      pull-requests: write
+      actions: read
 
     runs-on: ubuntu-latest
     defaults:
@@ -500,153 +520,6 @@ jobs:
           key: worker
           name: worker
           input-path: packages/worker/dist
-
-  # Bundle-size sticky comment. Compares each build's `bundle-stats.<key>`
-  # artifact against the latest successful main run. Runs on main pushes
-  # too so the artifact set is always available as a baseline.
-  bundle-size-report:
-    needs:
-      - build-anipres
-      - build-agent-core
-      - build-app
-      - build-slidev-addon-anipres-preview
-      - deploy-worker
-
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      actions: read
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          sparse-checkout: |
-            .github/scripts/bundle-size-report
-            .nvmrc
-          sparse-checkout-cone-mode: false
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version-file: .nvmrc
-
-      - name: Download current run's bundle-stats
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: bundle-stats.*
-          path: ${{ runner.temp }}/current-stats
-
-      # Skip the current run when looking for a baseline so a main-push
-      # invocation diffs against the *previous* main run instead of itself.
-      - name: Find latest baseline run on default branch
-        id: base
-        env:
-          GH_TOKEN: ${{ github.token }}
-          BASE_BRANCH: ${{ github.event.repository.default_branch }}
-          CURRENT_RUN_ID: ${{ github.run_id }}
-          WORKFLOW: ${{ github.workflow }}
-        run: |
-          info=$(gh run list \
-            --branch "$BASE_BRANCH" \
-            --workflow "$WORKFLOW" \
-            --status success \
-            --limit 5 \
-            --json databaseId,headSha \
-            --jq "[.[] | select(.databaseId != ${CURRENT_RUN_ID})] | .[0] // {}")
-          run_id=$(echo "$info" | jq -r '.databaseId // empty')
-          sha=$(echo "$info" | jq -r '.headSha // empty')
-          {
-            echo "run-id=$run_id"
-            echo "sha=$sha"
-            echo "branch=$BASE_BRANCH"
-          } >> "$GITHUB_OUTPUT"
-          if [ -n "$run_id" ]; then
-            echo "Base run: $run_id ($sha)"
-          else
-            echo "No baseline run found on $BASE_BRANCH yet."
-          fi
-
-      # `continue-on-error` covers the bootstrap case where the baseline
-      # main run pre-dates this feature and has no bundle-stats artifacts.
-      - name: Download base run's bundle-stats
-        if: steps.base.outputs.run-id != ''
-        continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: bundle-stats.*
-          path: ${{ runner.temp }}/base-stats
-          run-id: ${{ steps.base.outputs.run-id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Format comment
-        env:
-          BASE_RUN_ID: ${{ steps.base.outputs.run-id }}
-          BASE_SHA: ${{ steps.base.outputs.sha }}
-          BASE_BRANCH: ${{ steps.base.outputs.branch }}
-          REPO: ${{ github.repository }}
-        run: |
-          base_args=()
-          if [ -n "$BASE_SHA" ] && [ -d "$RUNNER_TEMP/base-stats" ]; then
-            base_args+=(--base-dir "$RUNNER_TEMP/base-stats" --base-sha "$BASE_SHA")
-            if [ -n "$BASE_RUN_ID" ]; then
-              base_args+=(--base-run-id "$BASE_RUN_ID")
-            fi
-          fi
-          node .github/scripts/bundle-size-report/format-comment.mjs \
-            --current-dir "$RUNNER_TEMP/current-stats" \
-            --base-branch "$BASE_BRANCH" \
-            --repo "$REPO" \
-            --output "$RUNNER_TEMP/comment.md" \
-            "${base_args[@]}"
-          echo "::group::Comment preview"
-          cat "$RUNNER_TEMP/comment.md"
-          echo "::endgroup::"
-
-      - name: Post or update sticky PR comment
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          COMMENT_PATH: ${{ runner.temp }}/comment.md
-        with:
-          script: |
-            const fs = require("fs");
-            const MARKER = "<!-- bundle-size-report -->";
-            const prNumber = parseInt(process.env.PR_NUMBER, 10);
-            const body = `${MARKER}\n${fs.readFileSync(process.env.COMMENT_PATH, "utf8")}`;
-
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-              },
-            );
-            const existing = comments.find(
-              (c) =>
-                c.body?.startsWith(MARKER) &&
-                c.user?.login === "github-actions[bot]",
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-              core.info(`Updated bundle-size comment ${existing.id} on PR #${prNumber}`);
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body,
-              });
-              core.info(`Created bundle-size comment on PR #${prNumber}`);
-            }
 
   release:
     needs: [build-anipres, test-slidev-addon-anipres, build-slidev-addon-anipres-preview]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,8 +435,13 @@ jobs:
       # `--dry-run` skips Cloudflare API calls; `--outdir` writes the
       # bundled worker JS for measurement. Uses `--env preview` so the
       # bindings shape matches what the preview deploy ships.
+      # CF Workers don't deploy sourcemaps by default, so drop them
+      # before measuring — otherwise the report shows the sourcemap
+      # weight (often 2× the JS) and looks broken.
       - name: Build worker bundle
-        run: pnpm wrangler deploy --env preview --dry-run --outdir dist
+        run: |
+          pnpm wrangler deploy --env preview --dry-run --outdir dist
+          rm -f dist/*.map
 
       - name: Measure bundle size
         uses: ./.github/actions/measure-bundle-size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,13 @@ jobs:
           path: packages/anipres/dist
           name: anipres-dist
 
+      - name: Measure bundle size
+        uses: ./.github/actions/measure-bundle-size
+        with:
+          key: anipres
+          name: anipres
+          input-path: packages/anipres/dist
+
   build-agent-core:
     needs: [build-anipres]
     runs-on: ubuntu-latest
@@ -188,6 +195,14 @@ jobs:
         with:
           name: slidev-addon-anipres-dist
           path: packages/slidev-addon-anipres/dist/
+
+      - name: Measure bundle size
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: ./.github/actions/measure-bundle-size
+        with:
+          key: slidev-addon-anipres
+          name: slidev-addon-anipres
+          input-path: packages/slidev-addon-anipres/dist
 
   deploy-slidev-addon-anipres-preview:
     needs: [build-slidev-addon-anipres-preview]
@@ -330,6 +345,13 @@ jobs:
           name: app-dist
           path: packages/app/dist/
 
+      - name: Measure bundle size
+        uses: ./.github/actions/measure-bundle-size
+        with:
+          key: app
+          name: app
+          input-path: packages/app/dist
+
   # Per-PR Pages deploy — UI smoke check at <branch>.anipres.pages.dev.
   # Pages production (anipres.app) is now served by the unified worker
   # (`deploy-worker` below), so this job is gated to PRs only.
@@ -356,6 +378,60 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy packages/app/dist --project-name=anipres --branch=${{ github.head_ref || github.ref_name }} --commit-hash=${{ github.sha }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+  # Worker bundle measurement — produces a non-deploying bundle so the
+  # bundle-size-report job has a worker artifact to compare. The
+  # `deploy-worker` job below builds again because it also handles
+  # migrations and asset upload; keeping them split avoids reshuffling
+  # the deploy path for a measurement-only need.
+  build-worker:
+    needs: [build-anipres, build-app]
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/worker
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          version: latest
+          run_install: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: .nvmrc
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: anipres-dist
+          path: packages/anipres/dist
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: app-dist
+          path: packages/app/dist
+
+      # `--dry-run` skips Cloudflare API calls; `--outdir` writes the
+      # bundled worker JS for measurement. Uses `--env preview` so the
+      # bindings shape matches what the preview deploy ships.
+      - name: Build worker bundle
+        run: pnpm wrangler deploy --env preview --dry-run --outdir dist
+
+      - name: Measure bundle size
+        uses: ./.github/actions/measure-bundle-size
+        with:
+          key: worker
+          name: worker
+          input-path: packages/worker/dist
 
   # Worker deploy — same code, two targets:
   # - on PR: shared preview worker (*.workers.dev, isolated D1/R2/DO,
@@ -455,6 +531,151 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: pnpm ${{ github.event_name == 'pull_request' && 'deploy:preview' || 'deploy:prod' }}
+
+  # Bundle-size sticky comment. Compares each build's `bundle-stats.<key>`
+  # artifact against the latest successful main run. Runs on main pushes
+  # too so the artifact set is always available as a baseline.
+  bundle-size-report:
+    needs:
+      - build-anipres
+      - build-app
+      - build-slidev-addon-anipres-preview
+      - build-worker
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/scripts/bundle-size-report
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Download current run's bundle-stats
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: bundle-stats.*
+          path: ${{ runner.temp }}/current-stats
+
+      # Skip the current run when looking for a baseline so a main-push
+      # invocation diffs against the *previous* main run instead of itself.
+      - name: Find latest baseline run on default branch
+        id: base
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
+          WORKFLOW: ${{ github.workflow }}
+        run: |
+          info=$(gh run list \
+            --branch "$BASE_BRANCH" \
+            --workflow "$WORKFLOW" \
+            --status success \
+            --limit 5 \
+            --json databaseId,headSha \
+            --jq "[.[] | select(.databaseId != ${CURRENT_RUN_ID})] | .[0] // {}")
+          run_id=$(echo "$info" | jq -r '.databaseId // empty')
+          sha=$(echo "$info" | jq -r '.headSha // empty')
+          {
+            echo "run-id=$run_id"
+            echo "sha=$sha"
+            echo "branch=$BASE_BRANCH"
+          } >> "$GITHUB_OUTPUT"
+          if [ -n "$run_id" ]; then
+            echo "Base run: $run_id ($sha)"
+          else
+            echo "No baseline run found on $BASE_BRANCH yet."
+          fi
+
+      # `continue-on-error` covers the bootstrap case where the baseline
+      # main run pre-dates this feature and has no bundle-stats artifacts.
+      - name: Download base run's bundle-stats
+        if: steps.base.outputs.run-id != ''
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: bundle-stats.*
+          path: ${{ runner.temp }}/base-stats
+          run-id: ${{ steps.base.outputs.run-id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Format comment
+        env:
+          BASE_RUN_ID: ${{ steps.base.outputs.run-id }}
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+          BASE_BRANCH: ${{ steps.base.outputs.branch }}
+          REPO: ${{ github.repository }}
+        run: |
+          base_args=()
+          if [ -n "$BASE_SHA" ] && [ -d "$RUNNER_TEMP/base-stats" ]; then
+            base_args+=(--base-dir "$RUNNER_TEMP/base-stats" --base-sha "$BASE_SHA")
+            if [ -n "$BASE_RUN_ID" ]; then
+              base_args+=(--base-run-id "$BASE_RUN_ID")
+            fi
+          fi
+          node .github/scripts/bundle-size-report/format-comment.mjs \
+            --current-dir "$RUNNER_TEMP/current-stats" \
+            --base-branch "$BASE_BRANCH" \
+            --repo "$REPO" \
+            --output "$RUNNER_TEMP/comment.md" \
+            "${base_args[@]}"
+          echo "::group::Comment preview"
+          cat "$RUNNER_TEMP/comment.md"
+          echo "::endgroup::"
+
+      - name: Post or update sticky PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMENT_PATH: ${{ runner.temp }}/comment.md
+        with:
+          script: |
+            const fs = require("fs");
+            const MARKER = "<!-- bundle-size-report -->";
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const body = `${MARKER}\n${fs.readFileSync(process.env.COMMENT_PATH, "utf8")}`;
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+              },
+            );
+            const existing = comments.find(
+              (c) =>
+                c.body?.startsWith(MARKER) &&
+                c.user?.login === "github-actions[bot]",
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated bundle-size comment ${existing.id} on PR #${prNumber}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.info(`Created bundle-size comment on PR #${prNumber}`);
+            }
 
   release:
     needs: [build-anipres, test-slidev-addon-anipres, build-slidev-addon-anipres-preview]

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "predev": "mkdir -p ../app/dist",
     "dev": "pnpm run migrate:local && wrangler dev",
-    "deploy:prod": "pnpm run migrate:remote && wrangler deploy",
-    "deploy:preview": "pnpm run migrate:remote:preview && wrangler deploy --env preview",
+    "deploy:prod": "pnpm run migrate:remote && wrangler deploy --outdir dist",
+    "deploy:preview": "pnpm run migrate:remote:preview && wrangler deploy --env preview --outdir dist",
     "migrate:local": "wrangler d1 migrations apply DB --local",
     "migrate:remote": "wrangler d1 migrations apply DB --remote",
     "migrate:remote:preview": "wrangler d1 migrations apply DB --remote --env preview",


### PR DESCRIPTION
## Summary

- Each build job uploads a `bundle-stats.<key>` artifact (raw + gzip per file via `.github/actions/measure-bundle-size`).
- A new `bundle-size-report` job downloads the current run's stats plus the latest successful main run's stats, renders a sticky comment, and posts/updates it on the PR.
- Adds a `build-worker` job that produces a dry-run worker bundle so the worker can be measured without deploying.

Patterned after [`whitphx/stlite`'s `set-package-stats` / `inform-package-stats`](https://github.com/whitphx/stlite/tree/main/.github/actions). Differences vs. upstream are documented in the file headers (byte-accurate sizes, gzip + Δ instead of raw kiB, status-icon diff table, key-matched bundles, single sticky-comment marker).

## Test plan

- [ ] All four build jobs produce a `bundle-stats.*` artifact.
- [ ] `bundle-size-report` posts a comment to this PR (will look like "no baseline" the first time, then proper diffs once main has its first run with this feature merged).
- [ ] On main push: artifacts uploaded, no comment posted.
- [ ] `actionlint` is clean (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated bundle-size measurement added to CI for multiple build outputs.
  * Generated, formatted bundle-size comparison reports posted/updated as sticky PR comments.
  * New CLI tools to produce bundle-stats and render markdown comparisons against baselines.
* **Chores**
  * Deployment scripts updated to emit build output to a dist directory.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/anipres/pull/480)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->