### PR TITLE
ci: split secret-needing deploys into post-build.yml (workflow_run)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,50 @@ concurrency:
 permissions: {}
 
 jobs:
+  # Hand off the event metadata to `post-build.yml` (workflow_run).
+  # `workflow_run.head_sha` is the merge commit on PRs, not the PR HEAD
+  # we want to deploy, and `pull_requests` is empty for forks — so this
+  # job captures the values authoritatively here and ships them as an
+  # artifact instead.
+  set-build-info:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save build info (pull_request)
+        if: github.event_name == 'pull_request'
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          TRIGGER_SHA: ${{ github.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          printf '%s\n' "$BRANCH" > branch
+          printf '%s\n' "$HEAD_SHA" > head-sha
+          printf '%s\n' "$TRIGGER_SHA" > trigger-sha
+          printf '%s\n' "$BASE_SHA" > base-sha
+          printf '%s\n' "$PR_NUMBER" > pr-number
+      - name: Save build info (push)
+        if: github.event_name == 'push'
+        env:
+          BRANCH: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          printf '%s\n' "$BRANCH" > branch
+          printf '%s\n' "$SHA" > head-sha
+          printf '%s\n' "$SHA" > trigger-sha
+          : > base-sha
+          : > pr-number
+      - name: Upload build info
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: build-info
+          path: |
+            branch
+            head-sha
+            trigger-sha
+            base-sha
+            pr-number
+
   build-anipres:
     runs-on: ubuntu-latest
     # `pull-requests: write` so the measure-bundle-size action can update
@@ -194,28 +238,6 @@ jobs:
           name: slidev-addon-anipres
           input-path: packages/slidev-addon-anipres/dist
 
-  deploy-slidev-addon-anipres-preview:
-    needs: [build-slidev-addon-anipres-preview]
-
-    permissions:
-      contents: read
-      deployments: write
-
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: slidev-addon-anipres-dist
-          path: packages/slidev-addon-anipres/dist
-
-      - name: Deploy
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy packages/slidev-addon-anipres/dist --project-name=slidev-addon-anipres-preview --branch=${{ github.head_ref || github.ref_name }} --commit-hash=${{ github.sha }}
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-
   lint-app:
     runs-on: ubuntu-latest
     defaults:
@@ -326,48 +348,20 @@ jobs:
           name: app
           input-path: packages/app/dist
 
-  # Per-PR Pages deploy — UI smoke check at <branch>.anipres.pages.dev.
-  # Pages production (anipres.app) is now served by the unified worker
-  # (`deploy-worker` below), so this job is gated to PRs only.
-  deploy-app:
-    needs: [build-app]
-
-    if: ${{ github.event_name == 'pull_request' }}
-
-    permissions:
-      contents: read
-      deployments: write
-
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: app-dist
-          path: packages/app/dist
-
-      - name: Deploy
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy packages/app/dist --project-name=anipres --branch=${{ github.head_ref || github.ref_name }} --commit-hash=${{ github.sha }}
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-
-  # Worker deploy — same code, two targets:
-  # - on PR: shared preview worker (*.workers.dev, isolated D1/R2/DO,
-  #   last push wins, see [env.preview] in wrangler.toml).
-  # - on push to main: prod worker at anipres.app, bundles app/dist via
-  #   the top-level [assets] binding and handles /api/* and /auth/*.
-  # The per-PR Pages preview (`deploy-app` above) covers UI smoke checks;
-  # the preview worker is for exercising auth + sync end-to-end.
-  deploy-worker:
+  # Worker bundle build — produces the worker dist for bundle-size
+  # measurement only. The actual `wrangler deploy` (plus the D1
+  # migration reset gate) needs `CLOUDFLARE_*` secrets and lives in
+  # `post-build.yml`, which runs from `workflow_run` so it can access
+  # secrets even when the trigger was a Dependabot PR.
+  #
+  # `wrangler deploy --dry-run --outdir dist` bundles via esbuild
+  # without contacting the Cloudflare API, so this step works without
+  # secrets and produces the same artifact the deploy will upload.
+  build-worker:
     needs: [test-agent-core, build-app, lint-app, test-worker]
 
-    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch) }}
-
     permissions:
       contents: read
-      deployments: write
       pull-requests: write
       actions: read
 
@@ -380,13 +374,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          # Need history back to the PR base to diff
-          # `packages/worker/migrations/` for the reset gate below.
-          # Only needed on the PR path; harmless on main pushes.
-          # Quoted: GHA `&&`/`||` short-circuit like JS, and numeric `0`
-          # is falsy, so `… && 0 || 1` always yields `1`. Strings `'0'`
-          # / `'1'` are both truthy and pass through unchanged.
-          fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
 
       - uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a # v6.0.4
         with:
@@ -406,46 +393,16 @@ jobs:
           name: app-dist
           path: packages/app/dist
 
-      # Wrangler tracks applied D1 migrations by filename in the
-      # internal `d1_migrations` table. If a migration file is edited
-      # mid-review (or renamed, squashed), the next apply sees the tag
-      # as done and silently skips the new contents — preview's schema
-      # then drifts permanently from the file. When this PR's
-      # `migrations/` differs from the base, wipe preview D1 first so
-      # the subsequent `migrate:remote:preview` rebuilds from scratch.
-      # Skipped on main pushes (preview isn't deployed there).
-      - name: Reset preview D1 if migrations changed
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        # `git diff --quiet` distinguishes the three outcomes by exit
-        # code (0 unchanged, 1 changed, >1 error), so a real failure
-        # surfaces instead of being silently routed to "skip reset" —
-        # which `if git diff … | grep -q .` would do under `set -e`,
-        # since `if` disables errexit for the condition.
+      # On PR we measure the preview build; on push to main we measure
+      # the prod build. Matches what `post-build.yml` will actually
+      # deploy via `pnpm deploy:preview` / `deploy:prod`.
+      - name: Build worker bundle (dry-run)
         run: |
-          set +e
-          git diff --quiet "$BASE_SHA"...HEAD -- migrations/
-          rc=$?
-          set -e
-          case "$rc" in
-            0) echo "Migrations unchanged since $BASE_SHA — skipping preview D1 reset." ;;
-            1) echo "Migrations changed since $BASE_SHA — resetting preview D1."
-               pnpm reset:remote:preview ;;
-            *) echo "git diff failed (exit $rc); refusing to deploy."
-               exit "$rc" ;;
-          esac
-
-      - name: Deploy worker
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        # `deploy:preview` / `deploy:prod` pass `--outdir dist` to
-        # wrangler so this same step writes the deployed bundle to
-        # disk for the measurement step below.
-        run: pnpm ${{ github.event_name == 'pull_request' && 'deploy:preview' || 'deploy:prod' }}
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            pnpm exec wrangler deploy --dry-run --env preview --outdir dist
+          else
+            pnpm exec wrangler deploy --dry-run --outdir dist
+          fi
 
       # CF Workers don't deploy sourcemaps by default, so drop them
       # before measuring — otherwise the report shows the sourcemap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,7 +373,6 @@ jobs:
           input-path: packages/worker/dist
 
       - name: Upload worker deploy package
-        if: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: worker-deploy-package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,50 +14,6 @@ concurrency:
 permissions: {}
 
 jobs:
-  # Hand off the event metadata to `post-build.yml` (workflow_run).
-  # `workflow_run.head_sha` is the merge commit on PRs, not the PR HEAD
-  # we want to deploy, and `pull_requests` is empty for forks — so this
-  # job captures the values authoritatively here and ships them as an
-  # artifact instead.
-  set-build-info:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Save build info (pull_request)
-        if: github.event_name == 'pull_request'
-        env:
-          BRANCH: ${{ github.event.pull_request.head.ref }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          TRIGGER_SHA: ${{ github.sha }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          printf '%s\n' "$BRANCH" > branch
-          printf '%s\n' "$HEAD_SHA" > head-sha
-          printf '%s\n' "$TRIGGER_SHA" > trigger-sha
-          printf '%s\n' "$BASE_SHA" > base-sha
-          printf '%s\n' "$PR_NUMBER" > pr-number
-      - name: Save build info (push)
-        if: github.event_name == 'push'
-        env:
-          BRANCH: ${{ github.ref_name }}
-          SHA: ${{ github.sha }}
-        run: |
-          printf '%s\n' "$BRANCH" > branch
-          printf '%s\n' "$SHA" > head-sha
-          printf '%s\n' "$SHA" > trigger-sha
-          : > base-sha
-          : > pr-number
-      - name: Upload build info
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: build-info
-          path: |
-            branch
-            head-sha
-            trigger-sha
-            base-sha
-            pr-number
-
   build-anipres:
     runs-on: ubuntu-latest
     # `pull-requests: write` so the measure-bundle-size action can update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,14 +410,27 @@ jobs:
       # Repoint `main` at the prebuilt bundle so `post-build.yml` can
       # `wrangler deploy --no-bundle` without re-running esbuild
       # against the PR's source (which is what was avoiding privileged
-      # PR-code execution in the first place). The grep after the sed
-      # turns a failed substitution (wrangler.toml schema changed) into
-      # a deploy-blocking error instead of a silent deploy with `main`
-      # still pointing at `src/worker.ts`.
+      # PR-code execution in the first place). Wrangler writes the
+      # bundle to `dist/<basename(main)>.js` — for our `src/worker.ts`
+      # that's `dist/worker.js`, but rather than hardcode the name we
+      # discover whatever wrangler actually emitted so a PR-side
+      # rename of `main` doesn't silently break the deploy.
       - name: Repoint main in wrangler.toml for --no-bundle deploy
         run: |
-          sed -i -E 's|^main[[:space:]]*=.*|main = "./dist/index.js"|' wrangler.toml
-          grep -Fxq 'main = "./dist/index.js"' wrangler.toml
+          js_files=$(find dist -maxdepth 1 -type f -name '*.js')
+          count=$(printf '%s\n' "$js_files" | grep -c .)
+          if [ "$count" -ne 1 ]; then
+            echo "Expected exactly 1 .js file in dist/, found $count:"
+            printf '%s\n' "$js_files"
+            exit 1
+          fi
+          # The filename can't contain `"` or newlines (filesystem-
+          # allowed but wrangler-rejected for `main`), so plain
+          # double-quoting in the sed replacement and the verify grep
+          # is safe.
+          new_main="./$js_files"
+          sed -i -E "s|^main[[:space:]]*=.*|main = \"${new_main}\"|" wrangler.toml
+          grep -Fxq "main = \"${new_main}\"" wrangler.toml
 
       - name: Upload worker deploy package
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,15 +348,17 @@ jobs:
           name: app
           input-path: packages/app/dist
 
-  # Worker bundle build — produces the worker dist for bundle-size
-  # measurement only. The actual `wrangler deploy` (plus the D1
-  # migration reset gate) needs `CLOUDFLARE_*` secrets and lives in
-  # `post-build.yml`, which runs from `workflow_run` so it can access
-  # secrets even when the trigger was a Dependabot PR.
+  # Worker bundle build — produces the dist for both bundle-size
+  # measurement and the post-build deploy. The actual `wrangler deploy`
+  # (plus the D1 migration reset gate) needs `CLOUDFLARE_*` secrets and
+  # lives in `post-build.yml`, which runs from `workflow_run` so it can
+  # access secrets even when the trigger was a Dependabot PR.
   #
   # `wrangler deploy --dry-run --outdir dist` bundles via esbuild
   # without contacting the Cloudflare API, so this step works without
-  # secrets and produces the same artifact the deploy will upload.
+  # secrets and produces the same JS the deploy will upload via
+  # `--no-bundle`. Bundling here also keeps the privileged post-build
+  # job free of `pnpm install` on PR-controlled deps.
   build-worker:
     needs: [test-agent-core, build-app, lint-app, test-worker]
 
@@ -374,6 +376,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          # Need history back to the PR base for the reset-gate diff.
+          # Harmless on main pushes.
+          # Quoted: GHA `&&`/`||` short-circuit like JS, and numeric `0`
+          # is falsy, so `… && 0 || 1` always yields `1`. Strings `'0'`
+          # / `'1'` are both truthy and pass through unchanged.
+          fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
 
       - uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a # v6.0.4
         with:
@@ -393,9 +401,8 @@ jobs:
           name: app-dist
           path: packages/app/dist
 
-      # On PR we measure the preview build; on push to main we measure
-      # the prod build. Matches what `post-build.yml` will actually
-      # deploy via `pnpm deploy:preview` / `deploy:prod`.
+      # On PR we build the preview env; on push to main we build prod.
+      # Matches what `post-build.yml` will deploy via `--no-bundle`.
       - name: Build worker bundle (dry-run)
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -416,6 +423,55 @@ jobs:
           key: worker
           name: worker
           input-path: packages/worker/dist
+
+      # Compute the reset-gate flag here (where the PR diff context is
+      # available); `post-build.yml` reads the flag without needing the
+      # repo history.
+      - name: Compute migrations-changed flag
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        # `git diff --quiet` distinguishes the three outcomes by exit
+        # code (0 unchanged, 1 changed, >1 error), so a real failure
+        # surfaces instead of being silently routed to "skip reset" —
+        # which `if git diff … | grep -q .` would do under `set -e`,
+        # since `if` disables errexit for the condition.
+        run: |
+          set +e
+          git diff --quiet "$BASE_SHA"...HEAD -- migrations/
+          rc=$?
+          set -e
+          case "$rc" in
+            0) printf 'false' > migrations-changed ;;
+            1) printf 'true' > migrations-changed ;;
+            *) echo "git diff failed (exit $rc)"; exit "$rc" ;;
+          esac
+
+      - name: Default migrations-changed (push)
+        if: github.event_name != 'pull_request'
+        run: printf 'false' > migrations-changed
+
+      # Repoint `main` at the prebuilt bundle so `post-build.yml` can
+      # `wrangler deploy --no-bundle` without re-running esbuild
+      # against the PR's source (which is what was avoiding privileged
+      # PR-code execution in the first place). The grep after the sed
+      # turns a failed substitution (wrangler.toml schema changed) into
+      # a deploy-blocking error instead of a silent deploy with `main`
+      # still pointing at `src/worker.ts`.
+      - name: Repoint main in wrangler.toml for --no-bundle deploy
+        run: |
+          sed -i -E 's|^main[[:space:]]*=.*|main = "./dist/index.js"|' wrangler.toml
+          grep -Fxq 'main = "./dist/index.js"' wrangler.toml
+
+      - name: Upload worker deploy package
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: worker-deploy-package
+          path: |
+            packages/worker/dist/
+            packages/worker/migrations/
+            packages/worker/wrangler.toml
+            packages/worker/migrations-changed
 
   release:
     needs: [build-anipres, test-slidev-addon-anipres, build-slidev-addon-anipres-preview]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,11 +304,9 @@ jobs:
           name: app
           input-path: packages/app/dist
 
-  # Worker bundle build — produces the dist for both bundle-size
-  # measurement and the post-build deploy. The actual `wrangler deploy`
-  # (plus the D1 migration reset gate) needs `CLOUDFLARE_*` secrets and
-  # lives in `post-build.yml`, which runs from `workflow_run` so it can
-  # access secrets even when the trigger was a Dependabot PR.
+  # Worker bundle build — produces the dist for bundle-size measurement
+  # on every run and for the post-build production deploy on main pushes.
+  # PR bundles are never uploaded to the secret-bearing preview worker.
   #
   # `wrangler deploy --dry-run --outdir dist` bundles via esbuild
   # without contacting the Cloudflare API, so this step works without
@@ -332,12 +330,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          # Need history back to the PR base for the reset-gate diff.
-          # Harmless on main pushes.
-          # Quoted: GHA `&&`/`||` short-circuit like JS, and numeric `0`
-          # is falsy, so `… && 0 || 1` always yields `1`. Strings `'0'`
-          # / `'1'` are both truthy and pass through unchanged.
-          fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
 
       - uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a # v6.0.4
         with:
@@ -357,8 +349,8 @@ jobs:
           name: app-dist
           path: packages/app/dist
 
-      # On PR we build the preview env; on push to main we build prod.
-      # Matches what `post-build.yml` will deploy via `--no-bundle`.
+      # PR measurements include the preview environment's bindings and
+      # main pushes produce the production bundle uploaded below.
       - name: Build worker bundle (dry-run)
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -380,67 +372,14 @@ jobs:
           name: worker
           input-path: packages/worker/dist
 
-      # Compute the reset-gate flag here (where the PR diff context is
-      # available); `post-build.yml` reads the flag without needing the
-      # repo history.
-      - name: Compute migrations-changed flag
-        if: github.event_name == 'pull_request'
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        # `git diff --quiet` distinguishes the three outcomes by exit
-        # code (0 unchanged, 1 changed, >1 error), so a real failure
-        # surfaces instead of being silently routed to "skip reset" —
-        # which `if git diff … | grep -q .` would do under `set -e`,
-        # since `if` disables errexit for the condition.
-        run: |
-          set +e
-          git diff --quiet "$BASE_SHA"...HEAD -- migrations/
-          rc=$?
-          set -e
-          case "$rc" in
-            0) printf 'false' > migrations-changed ;;
-            1) printf 'true' > migrations-changed ;;
-            *) echo "git diff failed (exit $rc)"; exit "$rc" ;;
-          esac
-
-      - name: Default migrations-changed (push)
-        if: github.event_name != 'pull_request'
-        run: printf 'false' > migrations-changed
-
-      # Repoint `main` at the prebuilt bundle so `post-build.yml` can
-      # `wrangler deploy --no-bundle` without re-running esbuild
-      # against the PR's source (which is what was avoiding privileged
-      # PR-code execution in the first place). Wrangler writes the
-      # bundle to `dist/<basename(main)>.js` — for our `src/worker.ts`
-      # that's `dist/worker.js`, but rather than hardcode the name we
-      # discover whatever wrangler actually emitted so a PR-side
-      # rename of `main` doesn't silently break the deploy.
-      - name: Repoint main in wrangler.toml for --no-bundle deploy
-        run: |
-          js_files=$(find dist -maxdepth 1 -type f -name '*.js')
-          count=$(printf '%s\n' "$js_files" | grep -c .)
-          if [ "$count" -ne 1 ]; then
-            echo "Expected exactly 1 .js file in dist/, found $count:"
-            printf '%s\n' "$js_files"
-            exit 1
-          fi
-          # The filename can't contain `"` or newlines (filesystem-
-          # allowed but wrangler-rejected for `main`), so plain
-          # double-quoting in the sed replacement and the verify grep
-          # is safe.
-          new_main="./$js_files"
-          sed -i -E "s|^main[[:space:]]*=.*|main = \"${new_main}\"|" wrangler.toml
-          grep -Fxq "main = \"${new_main}\"" wrangler.toml
-
       - name: Upload worker deploy package
+        if: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: worker-deploy-package
           path: |
             packages/worker/dist/
             packages/worker/migrations/
-            packages/worker/wrangler.toml
-            packages/worker/migrations-changed
 
   release:
     needs: [build-anipres, test-slidev-addon-anipres, build-slidev-addon-anipres-preview]

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -105,6 +105,147 @@ jobs:
           command: pages deploy packages/slidev-addon-anipres/dist --project-name=slidev-addon-anipres-preview --branch=${{ env.PAGES_BRANCH }} --commit-hash=${{ env.HEAD_SHA }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
+  # `workflow_run` has secrets even when the triggering PR would not. Restrict
+  # runtime deployment to same-repository PRs because the Worker bundle can
+  # read its preview secrets; fork and Dependabot PRs keep the Pages previews
+  # and the secretless Worker dry-run from CI.
+  deploy-worker-preview:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name == github.repository && github.event.workflow_run.actor.login != 'dependabot[bot]' }}
+    needs: initialize-status
+
+    permissions:
+      contents: read
+      deployments: write
+      actions: read
+      pull-requests: read
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # Migration tags make edited migrations look already applied. Both the
+      # change decision and reset program must therefore come from GitHub and
+      # the default branch, not from the credential-less PR artifact.
+      - name: Prepare trusted preview deployment inputs
+        id: prepare-preview
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { mkdir, writeFile } = require('node:fs/promises')
+
+            const repository = `${context.repo.owner}/${context.repo.repo}`
+            const defaultBranch = context.payload.repository.default_branch
+            const headSha = context.payload.workflow_run.head_sha
+            const { data: branch } = await github.rest.repos.getBranch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: defaultBranch,
+            })
+            const trustedRef = branch.commit.sha
+
+            const [configuration, resetScript, associatedPullRequests] = await Promise.all([
+              github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: 'packages/worker/wrangler.toml',
+                ref: trustedRef,
+              }),
+              github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: 'packages/worker/scripts/reset-preview-d1.mjs',
+                ref: trustedRef,
+              }),
+              github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: headSha,
+                per_page: 100,
+              }),
+            ])
+
+            const pullRequests = associatedPullRequests.filter((pullRequest) =>
+              pullRequest.state === 'open' &&
+              pullRequest.base.repo.full_name === repository &&
+              pullRequest.base.ref === defaultBranch &&
+              pullRequest.head.repo?.full_name === repository &&
+              pullRequest.head.sha === headSha
+            )
+            if (pullRequests.length !== 1) {
+              throw new Error(`Expected one matching pull request, found ${pullRequests.length}`)
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequests[0].number,
+              per_page: 100,
+            })
+            const migrationPath = 'packages/worker/migrations/'
+            const migrationsChanged = files.some((file) =>
+              file.filename.startsWith(migrationPath) ||
+              file.previous_filename?.startsWith(migrationPath)
+            )
+            core.setOutput('migrations-changed', String(migrationsChanged))
+
+            const writeTrustedFile = async (response, destination) => {
+              const data = response.data
+              if (Array.isArray(data) || data.type !== 'file' || data.encoding !== 'base64') {
+                throw new Error(`Expected a base64-encoded file for ${destination}`)
+              }
+              await writeFile(destination, Buffer.from(data.content, data.encoding))
+            }
+
+            await mkdir('packages/worker/scripts', { recursive: true })
+            await Promise.all([
+              writeTrustedFile(configuration, 'packages/worker/wrangler.toml'),
+              writeTrustedFile(resetScript, 'packages/worker/scripts/reset-preview-d1.mjs'),
+            ])
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: worker-deploy-package
+          path: packages/worker
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: app-dist
+          path: packages/app/dist
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Point trusted configuration at the prebuilt bundle
+        working-directory: packages/worker
+        run: |
+          test -f dist/worker.js
+          sed -i -E 's|^main[[:space:]]*=.*|main = "./dist/worker.js"|' wrangler.toml
+          grep -Fxq 'main = "./dist/worker.js"' wrangler.toml
+
+      - name: Reset preview D1 if needed and apply migrations
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        env:
+          MIGRATIONS_CHANGED: ${{ steps.prepare-preview.outputs.migrations-changed }}
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: packages/worker
+          wranglerVersion: '4.85.0'
+          # preCommands bypass the package-manager exec that exposes Wrangler.
+          preCommands: if [ "$MIGRATIONS_CHANGED" = "true" ]; then PATH="$PWD/node_modules/.bin:$PATH" node scripts/reset-preview-d1.mjs; fi
+          command: d1 migrations apply DB --remote --env preview
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy preview worker
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: packages/worker
+          wranglerVersion: '4.85.0'
+          command: deploy --env preview --no-bundle
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
   # Worker code can read its runtime secrets, so only the bundle from a
   # successful default-branch push is eligible for deployment. The resource
   # configuration is checked out from that exact commit instead of coming
@@ -188,6 +329,7 @@ jobs:
       - initialize-status
       - deploy-app
       - deploy-slidev-addon-anipres-preview
+      - deploy-worker-preview
       - deploy-worker
     permissions:
       statuses: write
@@ -198,6 +340,7 @@ jobs:
           INITIALIZE_RESULT: ${{ needs.initialize-status.result }}
           APP_RESULT: ${{ needs.deploy-app.result }}
           SLIDEV_RESULT: ${{ needs.deploy-slidev-addon-anipres-preview.result }}
+          WORKER_PREVIEW_RESULT: ${{ needs.deploy-worker-preview.result }}
           WORKER_RESULT: ${{ needs.deploy-worker.result }}
           TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
@@ -206,6 +349,7 @@ jobs:
               process.env.INITIALIZE_RESULT,
               process.env.APP_RESULT,
               process.env.SLIDEV_RESULT,
+              process.env.WORKER_PREVIEW_RESULT,
               process.env.WORKER_RESULT,
             ]
             const state = results.includes('failure')

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -12,7 +12,7 @@ on:
   # secrets, regardless of who originated the underlying PR.
   # Reference: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
   #
-  # All metadata used here (event type, branch, head SHA) is sourced
+  # All metadata used here (event type, run ID, head SHA) is sourced
   # from `github.event.workflow_run.*`, which GitHub populates from
   # the actual git ref / event that triggered CI. We do *not* trust
   # any artifact for routing decisions — artifacts produced by a PR
@@ -25,22 +25,37 @@ on:
 permissions: {}
 
 env:
-  # `head_branch` is the source branch on a PR run or the pushed
-  # branch on a `push` run. `head_sha` is the merge commit on PRs
-  # (i.e. what CI actually built) or the pushed sha on `push`.
-  # The `IS_PR` / `IS_DEFAULT_PUSH` flags fan out into each deploy
-  # job's `if`. Kept here so the routing rules live in one place.
-  BRANCH: ${{ github.event.workflow_run.head_branch }}
   HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-  IS_PR: ${{ github.event.workflow_run.event == 'pull_request' }}
-  IS_DEFAULT_PUSH: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == github.event.repository.default_branch }}
+  PAGES_BRANCH: ${{ github.event.workflow_run.event == 'pull_request' && format('pr-run-{0}', github.event.workflow_run.id) || github.event.repository.default_branch }}
 
 jobs:
+  initialize-status:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.event == 'pull_request' || (github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == github.event.repository.default_branch)) }}
+    permissions:
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.HEAD_SHA,
+              state: 'pending',
+              context: 'Post-build / deployments',
+              description: 'Cloudflare deployments are running',
+              target_url: process.env.TARGET_URL,
+            })
+
   deploy-app:
-    # Per-PR Pages deploy — UI smoke check at <branch>.anipres.pages.dev.
+    # Per-PR Pages deploy — UI smoke check at a run-ID-namespaced URL.
     # Pages production (anipres.app) is served by the unified worker
     # (`deploy-worker` below), so this job is PR-only.
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    needs: initialize-status
 
     permissions:
       contents: read
@@ -61,11 +76,12 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy packages/app/dist --project-name=anipres --branch=${{ env.BRANCH }} --commit-hash=${{ env.HEAD_SHA }}
+          command: pages deploy packages/app/dist --project-name=anipres --branch=${{ env.PAGES_BRANCH }} --commit-hash=${{ env.HEAD_SHA }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-slidev-addon-anipres-preview:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    needs: initialize-status
 
     permissions:
       contents: read
@@ -86,25 +102,16 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy packages/slidev-addon-anipres/dist --project-name=slidev-addon-anipres-preview --branch=${{ env.BRANCH }} --commit-hash=${{ env.HEAD_SHA }}
+          command: pages deploy packages/slidev-addon-anipres/dist --project-name=slidev-addon-anipres-preview --branch=${{ env.PAGES_BRANCH }} --commit-hash=${{ env.HEAD_SHA }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
-  # Worker deploy — same code, two targets:
-  # - on PR: shared preview worker (*.workers.dev, isolated D1/R2/DO,
-  #   last push wins, see [env.preview] in wrangler.toml).
-  # - on push to main: prod worker at anipres.app, bundles app/dist via
-  #   the top-level [assets] binding and handles /api/* and /auth/*.
-  # The per-PR Pages preview (`deploy-app` above) covers UI smoke checks;
-  # the preview worker is for exercising auth + sync end-to-end.
-  #
-  # Artifact-only deploy: the worker bundle, the (CI-rewritten)
-  # wrangler.toml, the migrations directory, and the reset-gate flag
-  # all come from CI artifacts. No `actions/checkout` of PR code, no
-  # `pnpm install` against PR-controlled deps — so no PR-controlled
-  # script ever executes in this privileged (secrets-bearing) context.
-  # Wrangler runs via `npx` at a pinned version.
+  # Worker code can read its runtime secrets, so only the bundle from a
+  # successful default-branch push is eligible for deployment. The resource
+  # configuration is checked out from that exact commit instead of coming
+  # from an artifact.
   deploy-worker:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.event == 'pull_request' || (github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == github.event.repository.default_branch)) }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == github.event.repository.default_branch }}
+    needs: initialize-status
 
     permissions:
       contents: read
@@ -114,6 +121,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ env.HEAD_SHA }}
+          persist-credentials: false
+          sparse-checkout: packages/worker/wrangler.toml
+          sparse-checkout-cone-mode: false
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: worker-deploy-package
@@ -128,51 +142,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      # Wrangler tracks applied D1 migrations by filename in the
-      # internal `d1_migrations` table. If a migration file is edited
-      # mid-review (or renamed, squashed), the next apply sees the tag
-      # as done and silently skips the new contents — preview's schema
-      # then drifts permanently from the file. When this PR's
-      # `migrations/` differs from the base, wipe preview D1 first so
-      # the subsequent `d1 migrations apply` rebuilds from scratch.
-      # Skipped on main pushes (preview isn't deployed there).
-      #
-      # The drop SQL is generated inline here — we don't invoke
-      # `packages/worker/scripts/reset-preview-d1.mjs` from the
-      # artifact, since that would re-introduce execution of
-      # PR-controlled code. Logic mirrors the script on `main`.
-      - name: Reset preview D1 if migrations changed
-        if: ${{ github.event.workflow_run.event == 'pull_request' }}
+      - name: Point trusted configuration at the prebuilt bundle
         working-directory: packages/worker
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          WRANGLER_VERSION: 4.85.0
         run: |
-          if [ "$(cat migrations-changed 2>/dev/null)" != "true" ]; then
-            echo "Migrations unchanged — skipping preview D1 reset."
-            exit 0
-          fi
-          echo "Migrations changed — resetting preview D1."
-          # `_cf_*` and `sqlite_sequence` are SQLite/D1-managed and
-          # reject DROP with SQLITE_AUTH; exclude them from the list.
-          npx -y -p "wrangler@${WRANGLER_VERSION}" wrangler d1 execute DB \
-            --remote --env preview --json --command \
-            "SELECT type, name FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' AND name NOT LIKE '_cf_%' AND name != 'sqlite_sequence' AND type IN ('table','index','trigger','view')" \
-            > objects.json
-          drop_sql=$(jq -r '
-            (.[0].results // [])
-            | sort_by(({trigger:0, view:1, index:2, table:3})[.type] // 99)
-            | map("DROP \(.type | ascii_upcase) IF EXISTS \"\(.name)\";")
-            | join(" ")
-          ' objects.json)
-          if [ -n "$drop_sql" ]; then
-            echo "Dropping: $drop_sql"
-            npx -y -p "wrangler@${WRANGLER_VERSION}" wrangler d1 execute DB \
-              --remote --env preview --command "$drop_sql"
-          else
-            echo "No D1 objects to drop."
-          fi
+          test -f dist/worker.js
+          sed -i -E 's|^main[[:space:]]*=.*|main = "./dist/worker.js"|' wrangler.toml
+          grep -Fxq 'main = "./dist/worker.js"' wrangler.toml
 
       - name: Apply D1 migrations
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
@@ -181,12 +156,9 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/worker
           wranglerVersion: '4.85.0'
-          command: d1 migrations apply DB --remote ${{ github.event.workflow_run.event == 'pull_request' && '--env preview' || '' }}
+          command: d1 migrations apply DB --remote
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
-      # `--no-bundle` uploads `dist/index.js` as-is; CI rewrote `main`
-      # in the bundled wrangler.toml to point at it. Same `--env`
-      # selector as the migrations step picks preview vs prod.
       - name: Deploy worker
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
         with:
@@ -194,5 +166,48 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/worker
           wranglerVersion: '4.85.0'
-          command: deploy --no-bundle ${{ github.event.workflow_run.event == 'pull_request' && '--env preview' || '' }}
+          command: deploy --no-bundle
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+  report-status:
+    if: ${{ always() && needs.initialize-status.result != 'skipped' }}
+    needs:
+      - initialize-status
+      - deploy-app
+      - deploy-slidev-addon-anipres-preview
+      - deploy-worker
+    permissions:
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INITIALIZE_RESULT: ${{ needs.initialize-status.result }}
+          APP_RESULT: ${{ needs.deploy-app.result }}
+          SLIDEV_RESULT: ${{ needs.deploy-slidev-addon-anipres-preview.result }}
+          WORKER_RESULT: ${{ needs.deploy-worker.result }}
+          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const results = [
+              process.env.INITIALIZE_RESULT,
+              process.env.APP_RESULT,
+              process.env.SLIDEV_RESULT,
+              process.env.WORKER_RESULT,
+            ]
+            const state = results.includes('failure')
+              ? 'failure'
+              : results.includes('cancelled')
+                ? 'error'
+                : 'success'
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.HEAD_SHA,
+              state,
+              context: 'Post-build / deployments',
+              description: state === 'success'
+                ? 'Cloudflare deployments succeeded'
+                : 'A Cloudflare deployment did not succeed',
+              target_url: process.env.TARGET_URL,
+            })

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -121,12 +121,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Download trusted worker configuration
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          ref: ${{ env.HEAD_SHA }}
-          persist-credentials: false
-          sparse-checkout: packages/worker/wrangler.toml
-          sparse-checkout-cone-mode: false
+          script: |
+            const { mkdir, writeFile } = require('node:fs/promises')
+            const { data } = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: 'packages/worker/wrangler.toml',
+              ref: process.env.HEAD_SHA,
+            })
+            if (Array.isArray(data) || data.type !== 'file' || data.encoding !== 'base64') {
+              throw new Error('Expected a base64-encoded wrangler.toml file')
+            }
+            await mkdir('packages/worker', { recursive: true })
+            await writeFile(
+              'packages/worker/wrangler.toml',
+              Buffer.from(data.content, data.encoding),
+            )
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -11,6 +11,12 @@ on:
   # the context of the default branch (trusted) and so does have
   # secrets, regardless of who originated the underlying PR.
   # Reference: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+  #
+  # All metadata used here (event type, branch, head SHA) is sourced
+  # from `github.event.workflow_run.*`, which GitHub populates from
+  # the actual git ref / event that triggered CI. We do *not* trust
+  # any artifact for routing decisions — artifacts produced by a PR
+  # run could be forged to redirect a secret-bearing deploy.
   workflow_run:
     workflows: ["CI"]
     types:
@@ -18,47 +24,28 @@ on:
 
 permissions: {}
 
-jobs:
-  get-build-info:
-    if: github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: read
-    outputs:
-      branch: ${{ steps.build-info.outputs.branch }}
-      head-sha: ${{ steps.build-info.outputs.head-sha }}
-      trigger-sha: ${{ steps.build-info.outputs.trigger-sha }}
-      base-sha: ${{ steps.build-info.outputs.base-sha }}
-      pr-number: ${{ steps.build-info.outputs.pr-number }}
-    steps:
-      - name: Download build info
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: build-info
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-      - name: Read build info
-        id: build-info
-        run: |
-          {
-            echo "branch=$(cat branch)"
-            echo "head-sha=$(cat head-sha)"
-            echo "trigger-sha=$(cat trigger-sha)"
-            echo "base-sha=$(cat base-sha)"
-            echo "pr-number=$(cat pr-number)"
-          } | tee -a "$GITHUB_OUTPUT"
+env:
+  # `head_branch` is the source branch on a PR run or the pushed
+  # branch on a `push` run. `head_sha` is the merge commit on PRs
+  # (i.e. what CI actually built) or the pushed sha on `push`.
+  # The `IS_PR` / `IS_DEFAULT_PUSH` flags fan out into each deploy
+  # job's `if`. Kept here so the routing rules live in one place.
+  BRANCH: ${{ github.event.workflow_run.head_branch }}
+  HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+  IS_PR: ${{ github.event.workflow_run.event == 'pull_request' }}
+  IS_DEFAULT_PUSH: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == github.event.repository.default_branch }}
 
+jobs:
   deploy-app:
-    needs: [get-build-info]
     # Per-PR Pages deploy — UI smoke check at <branch>.anipres.pages.dev.
     # Pages production (anipres.app) is served by the unified worker
     # (`deploy-worker` below), so this job is PR-only.
-    if: ${{ needs.get-build-info.outputs.pr-number != '' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
 
     permissions:
       contents: read
       deployments: write
+      actions: read
 
     runs-on: ubuntu-latest
     steps:
@@ -74,15 +61,16 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy packages/app/dist --project-name=anipres --branch=${{ needs.get-build-info.outputs.branch }} --commit-hash=${{ needs.get-build-info.outputs.head-sha }}
+          command: pages deploy packages/app/dist --project-name=anipres --branch=${{ env.BRANCH }} --commit-hash=${{ env.HEAD_SHA }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-slidev-addon-anipres-preview:
-    needs: [get-build-info]
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     permissions:
       contents: read
       deployments: write
+      actions: read
 
     runs-on: ubuntu-latest
     steps:
@@ -98,7 +86,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy packages/slidev-addon-anipres/dist --project-name=slidev-addon-anipres-preview --branch=${{ needs.get-build-info.outputs.branch }} --commit-hash=${{ needs.get-build-info.outputs.head-sha }}
+          command: pages deploy packages/slidev-addon-anipres/dist --project-name=slidev-addon-anipres-preview --branch=${{ env.BRANCH }} --commit-hash=${{ env.HEAD_SHA }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
   # Worker deploy — same code, two targets:
@@ -116,12 +104,12 @@ jobs:
   # script ever executes in this privileged (secrets-bearing) context.
   # Wrangler runs via `npx` at a pinned version.
   deploy-worker:
-    needs: [get-build-info]
-    if: ${{ needs.get-build-info.outputs.pr-number != '' || needs.get-build-info.outputs.branch == github.event.repository.default_branch }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.event == 'pull_request' || (github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == github.event.repository.default_branch)) }}
 
     permissions:
       contents: read
       deployments: write
+      actions: read
 
     runs-on: ubuntu-latest
 
@@ -154,7 +142,7 @@ jobs:
       # artifact, since that would re-introduce execution of
       # PR-controlled code. Logic mirrors the script on `main`.
       - name: Reset preview D1 if migrations changed
-        if: ${{ needs.get-build-info.outputs.pr-number != '' }}
+        if: ${{ github.event.workflow_run.event == 'pull_request' }}
         working-directory: packages/worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -193,7 +181,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/worker
           wranglerVersion: '4.85.0'
-          command: d1 migrations apply DB --remote ${{ needs.get-build-info.outputs.pr-number != '' && '--env preview' || '' }}
+          command: d1 migrations apply DB --remote ${{ github.event.workflow_run.event == 'pull_request' && '--env preview' || '' }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       # `--no-bundle` uploads `dist/index.js` as-is; CI rewrote `main`
@@ -206,5 +194,5 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/worker
           wranglerVersion: '4.85.0'
-          command: deploy --no-bundle ${{ needs.get-build-info.outputs.pr-number != '' && '--env preview' || '' }}
+          command: deploy --no-bundle ${{ github.event.workflow_run.event == 'pull_request' && '--env preview' || '' }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -109,12 +109,12 @@ jobs:
   # The per-PR Pages preview (`deploy-app` above) covers UI smoke checks;
   # the preview worker is for exercising auth + sync end-to-end.
   #
-  # SECURITY: This job checks out the PR HEAD and runs `pnpm install`
-  # with `CLOUDFLARE_*` secrets in the environment. A malicious PR
-  # could exfiltrate those via a postinstall script. The mitigation is
-  # repo-level: only the maintainer merges, and PRs from new external
-  # contributors require manual workflow approval in repo settings
-  # (Settings → Actions → "Require approval for first-time contributors").
+  # Artifact-only deploy: the worker bundle, the (CI-rewritten)
+  # wrangler.toml, the migrations directory, and the reset-gate flag
+  # all come from CI artifacts. No `actions/checkout` of PR code, no
+  # `pnpm install` against PR-controlled deps — so no PR-controlled
+  # script ever executes in this privileged (secrets-bearing) context.
+  # Wrangler runs via `npx` at a pinned version.
   deploy-worker:
     needs: [get-build-info]
     if: ${{ needs.get-build-info.outputs.pr-number != '' || needs.get-build-info.outputs.branch == github.event.repository.default_branch }}
@@ -124,35 +124,14 @@ jobs:
       deployments: write
 
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/worker
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          ref: ${{ needs.get-build-info.outputs.head-sha }}
-          persist-credentials: false
-          # Need history back to the PR base to diff
-          # `packages/worker/migrations/` for the reset gate below.
-          # Only needed on the PR path; harmless on main pushes.
-          # Quoted: GHA `&&`/`||` short-circuit like JS, and numeric `0`
-          # is falsy, so `… && 0 || 1` always yields `1`. Strings `'0'`
-          # / `'1'` are both truthy and pass through unchanged.
-          fetch-depth: ${{ needs.get-build-info.outputs.pr-number && '0' || '1' }}
-
-      - uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a # v6.0.4
-        with:
-          version: latest
-          run_install: false
-
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version-file: .nvmrc
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
+          name: worker-deploy-package
+          path: packages/worker
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -167,34 +146,65 @@ jobs:
       # as done and silently skips the new contents — preview's schema
       # then drifts permanently from the file. When this PR's
       # `migrations/` differs from the base, wipe preview D1 first so
-      # the subsequent `migrate:remote:preview` rebuilds from scratch.
+      # the subsequent `d1 migrations apply` rebuilds from scratch.
       # Skipped on main pushes (preview isn't deployed there).
+      #
+      # The drop SQL is generated inline here — we don't invoke
+      # `packages/worker/scripts/reset-preview-d1.mjs` from the
+      # artifact, since that would re-introduce execution of
+      # PR-controlled code. Logic mirrors the script on `main`.
       - name: Reset preview D1 if migrations changed
         if: ${{ needs.get-build-info.outputs.pr-number != '' }}
+        working-directory: packages/worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          BASE_SHA: ${{ needs.get-build-info.outputs.base-sha }}
-        # `git diff --quiet` distinguishes the three outcomes by exit
-        # code (0 unchanged, 1 changed, >1 error), so a real failure
-        # surfaces instead of being silently routed to "skip reset" —
-        # which `if git diff … | grep -q .` would do under `set -e`,
-        # since `if` disables errexit for the condition.
+          WRANGLER_VERSION: 4.85.0
         run: |
-          set +e
-          git diff --quiet "$BASE_SHA"...HEAD -- migrations/
-          rc=$?
-          set -e
-          case "$rc" in
-            0) echo "Migrations unchanged since $BASE_SHA — skipping preview D1 reset." ;;
-            1) echo "Migrations changed since $BASE_SHA — resetting preview D1."
-               pnpm reset:remote:preview ;;
-            *) echo "git diff failed (exit $rc); refusing to deploy."
-               exit "$rc" ;;
-          esac
+          if [ "$(cat migrations-changed 2>/dev/null)" != "true" ]; then
+            echo "Migrations unchanged — skipping preview D1 reset."
+            exit 0
+          fi
+          echo "Migrations changed — resetting preview D1."
+          # `_cf_*` and `sqlite_sequence` are SQLite/D1-managed and
+          # reject DROP with SQLITE_AUTH; exclude them from the list.
+          npx -y -p "wrangler@${WRANGLER_VERSION}" wrangler d1 execute DB \
+            --remote --env preview --json --command \
+            "SELECT type, name FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' AND name NOT LIKE '_cf_%' AND name != 'sqlite_sequence' AND type IN ('table','index','trigger','view')" \
+            > objects.json
+          drop_sql=$(jq -r '
+            (.[0].results // [])
+            | sort_by(({trigger:0, view:1, index:2, table:3})[.type] // 99)
+            | map("DROP \(.type | ascii_upcase) IF EXISTS \"\(.name)\";")
+            | join(" ")
+          ' objects.json)
+          if [ -n "$drop_sql" ]; then
+            echo "Dropping: $drop_sql"
+            npx -y -p "wrangler@${WRANGLER_VERSION}" wrangler d1 execute DB \
+              --remote --env preview --command "$drop_sql"
+          else
+            echo "No D1 objects to drop."
+          fi
 
+      - name: Apply D1 migrations
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: packages/worker
+          wranglerVersion: '4.85.0'
+          command: d1 migrations apply DB --remote ${{ needs.get-build-info.outputs.pr-number != '' && '--env preview' || '' }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      # `--no-bundle` uploads `dist/index.js` as-is; CI rewrote `main`
+      # in the bundled wrangler.toml to point at it. Same `--env`
+      # selector as the migrations step picks preview vs prod.
       - name: Deploy worker
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: pnpm ${{ needs.get-build-info.outputs.pr-number != '' && 'deploy:preview' || 'deploy:prod' }}
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: packages/worker
+          wranglerVersion: '4.85.0'
+          command: deploy --no-bundle ${{ needs.get-build-info.outputs.pr-number != '' && '--env preview' || '' }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -1,0 +1,200 @@
+name: Post-build
+run-name: Post-build for ${{ github.event.workflow_run.display_title || github.event.workflow_run.run_number }}
+
+on:
+  # For security reasons, this workflow is separated from the CI workflow
+  # and triggered by the `workflow_run` event following it.
+  # The deployment jobs need access to the repository secrets, however,
+  # workflows triggered by the `pull_request` event don't have access to
+  # the secrets when the PR is from a fork or from Dependabot — so PR
+  # CI runs can't call Cloudflare on their own. This workflow runs in
+  # the context of the default branch (trusted) and so does have
+  # secrets, regardless of who originated the underlying PR.
+  # Reference: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  get-build-info:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      branch: ${{ steps.build-info.outputs.branch }}
+      head-sha: ${{ steps.build-info.outputs.head-sha }}
+      trigger-sha: ${{ steps.build-info.outputs.trigger-sha }}
+      base-sha: ${{ steps.build-info.outputs.base-sha }}
+      pr-number: ${{ steps.build-info.outputs.pr-number }}
+    steps:
+      - name: Download build info
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: build-info
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Read build info
+        id: build-info
+        run: |
+          {
+            echo "branch=$(cat branch)"
+            echo "head-sha=$(cat head-sha)"
+            echo "trigger-sha=$(cat trigger-sha)"
+            echo "base-sha=$(cat base-sha)"
+            echo "pr-number=$(cat pr-number)"
+          } | tee -a "$GITHUB_OUTPUT"
+
+  deploy-app:
+    needs: [get-build-info]
+    # Per-PR Pages deploy — UI smoke check at <branch>.anipres.pages.dev.
+    # Pages production (anipres.app) is served by the unified worker
+    # (`deploy-worker` below), so this job is PR-only.
+    if: ${{ needs.get-build-info.outputs.pr-number != '' }}
+
+    permissions:
+      contents: read
+      deployments: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: app-dist
+          path: packages/app/dist
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy packages/app/dist --project-name=anipres --branch=${{ needs.get-build-info.outputs.branch }} --commit-hash=${{ needs.get-build-info.outputs.head-sha }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-slidev-addon-anipres-preview:
+    needs: [get-build-info]
+
+    permissions:
+      contents: read
+      deployments: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: slidev-addon-anipres-dist
+          path: packages/slidev-addon-anipres/dist
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy packages/slidev-addon-anipres/dist --project-name=slidev-addon-anipres-preview --branch=${{ needs.get-build-info.outputs.branch }} --commit-hash=${{ needs.get-build-info.outputs.head-sha }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+  # Worker deploy — same code, two targets:
+  # - on PR: shared preview worker (*.workers.dev, isolated D1/R2/DO,
+  #   last push wins, see [env.preview] in wrangler.toml).
+  # - on push to main: prod worker at anipres.app, bundles app/dist via
+  #   the top-level [assets] binding and handles /api/* and /auth/*.
+  # The per-PR Pages preview (`deploy-app` above) covers UI smoke checks;
+  # the preview worker is for exercising auth + sync end-to-end.
+  #
+  # SECURITY: This job checks out the PR HEAD and runs `pnpm install`
+  # with `CLOUDFLARE_*` secrets in the environment. A malicious PR
+  # could exfiltrate those via a postinstall script. The mitigation is
+  # repo-level: only the maintainer merges, and PRs from new external
+  # contributors require manual workflow approval in repo settings
+  # (Settings → Actions → "Require approval for first-time contributors").
+  deploy-worker:
+    needs: [get-build-info]
+    if: ${{ needs.get-build-info.outputs.pr-number != '' || needs.get-build-info.outputs.branch == github.event.repository.default_branch }}
+
+    permissions:
+      contents: read
+      deployments: write
+
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/worker
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.get-build-info.outputs.head-sha }}
+          persist-credentials: false
+          # Need history back to the PR base to diff
+          # `packages/worker/migrations/` for the reset gate below.
+          # Only needed on the PR path; harmless on main pushes.
+          # Quoted: GHA `&&`/`||` short-circuit like JS, and numeric `0`
+          # is falsy, so `… && 0 || 1` always yields `1`. Strings `'0'`
+          # / `'1'` are both truthy and pass through unchanged.
+          fetch-depth: ${{ needs.get-build-info.outputs.pr-number && '0' || '1' }}
+
+      - uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a # v6.0.4
+        with:
+          version: latest
+          run_install: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: .nvmrc
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: app-dist
+          path: packages/app/dist
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      # Wrangler tracks applied D1 migrations by filename in the
+      # internal `d1_migrations` table. If a migration file is edited
+      # mid-review (or renamed, squashed), the next apply sees the tag
+      # as done and silently skips the new contents — preview's schema
+      # then drifts permanently from the file. When this PR's
+      # `migrations/` differs from the base, wipe preview D1 first so
+      # the subsequent `migrate:remote:preview` rebuilds from scratch.
+      # Skipped on main pushes (preview isn't deployed there).
+      - name: Reset preview D1 if migrations changed
+        if: ${{ needs.get-build-info.outputs.pr-number != '' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          BASE_SHA: ${{ needs.get-build-info.outputs.base-sha }}
+        # `git diff --quiet` distinguishes the three outcomes by exit
+        # code (0 unchanged, 1 changed, >1 error), so a real failure
+        # surfaces instead of being silently routed to "skip reset" —
+        # which `if git diff … | grep -q .` would do under `set -e`,
+        # since `if` disables errexit for the condition.
+        run: |
+          set +e
+          git diff --quiet "$BASE_SHA"...HEAD -- migrations/
+          rc=$?
+          set -e
+          case "$rc" in
+            0) echo "Migrations unchanged since $BASE_SHA — skipping preview D1 reset." ;;
+            1) echo "Migrations changed since $BASE_SHA — resetting preview D1."
+               pnpm reset:remote:preview ;;
+            *) echo "git diff failed (exit $rc); refusing to deploy."
+               exit "$rc" ;;
+          esac
+
+      - name: Deploy worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm ${{ needs.get-build-info.outputs.pr-number != '' && 'deploy:preview' || 'deploy:prod' }}


### PR DESCRIPTION
## Summary

- Move the three Cloudflare deploy jobs (`deploy-app`, `deploy-slidev-addon-anipres-preview`, `deploy-worker`) out of `ci.yml` and into a new `post-build.yml` triggered by `workflow_run`, mirroring [stlite's `postbuild.yml`](https://github.com/whitphx/stlite/blob/main/.github/workflows/postbuild.yml).
- Replaces the former `deploy-worker` in CI with a build-only `build-worker` job that uses `wrangler deploy --dry-run --outdir dist` so the bundle-size report still runs on every PR.
- Adds a `set-build-info` job that uploads `branch` / `head-sha` / `trigger-sha` / `base-sha` / `pr-number` as a `build-info` artifact for post-build to consume (since `github.event.workflow_run.head_sha` is the merge commit on PRs, not the PR HEAD, and `workflow_run.pull_requests` is empty for forks).

## Why

Deploy jobs in [run 26441996481](https://github.com/whitphx/anipres/actions/runs/26441996481?pr=482) (the dependabot PR for `pnpm/action-setup@6.0.5`) failed with Cloudflare \`Authentication error [code: 10000]\` because \`pull_request\` runs from Dependabot — and runs from forks — don't receive repository secrets, so \`secrets.CLOUDFLARE_API_TOKEN\` was empty.

\`workflow_run\` executes in the context of the default branch (trusted) and so always has secrets, regardless of who originated the underlying PR. The security rationale is captured in a comment at the top of \`post-build.yml\` and links to GitHub Security Lab's [\"Preventing pwn requests\"](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) post.

## Test plan

- [ ] CI on this PR is green (build/test/measure jobs only — no Cloudflare deploy).
- [ ] \`actionlint\` passes (verified locally).
- [ ] After merge, the next \`push\` to \`main\` triggers \`post-build.yml\` and successfully deploys the worker to prod.
- [ ] After merge, the next Dependabot PR runs CI to completion AND triggers \`post-build.yml\`, which deploys the per-PR previews — replacing the previously-failing deploy steps.

> **Note:** \`workflow_run\` only fires when the workflow file is on the default branch, so the post-build deploys won't run for this PR itself. They will start working on PRs opened after this one is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pull-request-only worker preview deployment flow.
  * Worker bundles are now built as reusable deploy packages to improve preview and rollout speed.
* **Chores**
  * CI/CD reorganized: preview worker packaging happens in the main CI pipeline, while post-build handles app/add-on/worker deployments.
  * Updated deployment behavior for worker and add-on previews, including deriving trusted worker configuration via the default branch and improved commit status reporting.
  * Reduced deployment permissions and removed the previous per-PR add-on deployment job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->