### PR TITLE
fix: version `anipres` as a 0.x minor, not a 1.0.0 major

### DIFF
--- a/.changeset/animation-data-model-v2.md
+++ b/.changeset/animation-data-model-v2.md
@@ -1,5 +1,5 @@
 ---
-"anipres": major
+"anipres": minor
 "anipres-worker": minor
 "slidev-addon-anipres": patch
 "@anipres/agent-core": patch


### PR DESCRIPTION
The `animation-data-model-v2` changeset marks `anipres` as `major`, which for a pre-1.0 package makes changesets jump it to `1.0.0`. A breaking change in a 0.x package should stay in 0.x, so this marks it `minor` and the release goes out as `0.14.0` instead. The changeset's `BREAKING (anipres):` note still documents the break; the other packages in the changeset are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package release classification from a major release to a minor release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->