### PR TITLE
ci: post Cloudflare preview URLs to the PR and refresh them when CI fails

### DIFF
--- a/.github/actions/measure-bundle-size/action.yml
+++ b/.github/actions/measure-bundle-size/action.yml
@@ -149,13 +149,21 @@ runs:
         COMMENT_PATH: ${{ runner.temp }}/bsr-comment.md
       with:
         script: |
-          const { pathToFileURL } = require("node:url");
+          const fs = require("node:fs");
           const path = require("node:path");
+          const { pathToFileURL } = require("node:url");
           const url = pathToFileURL(
             path.join(
               process.env.GITHUB_WORKSPACE,
-              ".github/scripts/bundle-size-report/update-sticky-comment.mjs",
+              ".github/scripts/sticky-comment.mjs",
             ),
           ).href;
-          const { default: run } = await import(url);
-          await run({ github, context, core });
+          const { default: updateStickyComment } = await import(url);
+          await updateStickyComment({
+            github,
+            context,
+            core,
+            marker: "<!-- bundle-size-report -->",
+            prNumber: parseInt(process.env.PR_NUMBER, 10),
+            body: fs.readFileSync(process.env.COMMENT_PATH, "utf8"),
+          });

--- a/.github/scripts/sticky-comment.mjs
+++ b/.github/scripts/sticky-comment.mjs
@@ -1,23 +1,24 @@
-// Posts or updates the bundle-size sticky comment on the current PR.
-// Loaded by .github/actions/measure-bundle-size/action.yml via
-// actions/github-script's dynamic-import bridge so the github/context/
-// core handles flow in cleanly.
+// Posts or updates a marker-identified sticky comment on a pull request.
+// Loaded via actions/github-script's dynamic-import bridge so the
+// github/context/core handles flow in cleanly.
 //
 // Patterned after whitphx/stlite's sticky-comment-add-section retry
-// loop (Apache-2.0). The race-handling logic is what makes per-job
-// updates safe when several measure jobs finish near-simultaneously.
+// loop (Apache-2.0). The race-handling logic is what makes concurrent
+// updates safe when several jobs finish near-simultaneously.
 // Upstream: https://github.com/whitphx/stlite/blob/main/.github/actions/sticky-comment-add-section/action.yml
 
-import fs from "node:fs";
-
-const MARKER = "<!-- bundle-size-report -->";
 const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 1000;
 
-// Env: PR_NUMBER, COMMENT_PATH
-export default async function run({ github, context, core }) {
-  const prNumber = parseInt(process.env.PR_NUMBER, 10);
-  const body = `${MARKER}\n${fs.readFileSync(process.env.COMMENT_PATH, "utf8")}`;
+export default async function updateStickyComment({
+  github,
+  context,
+  core,
+  marker,
+  prNumber,
+  body,
+}) {
+  const fullBody = `${marker}\n${body}`;
 
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {
@@ -28,8 +29,7 @@ export default async function run({ github, context, core }) {
       });
       const existing = comments.find(
         (c) =>
-          c.body?.startsWith(MARKER) &&
-          c.user?.login === "github-actions[bot]",
+          c.body?.startsWith(marker) && c.user?.login === "github-actions[bot]",
       );
 
       if (existing) {
@@ -37,19 +37,19 @@ export default async function run({ github, context, core }) {
           owner: context.repo.owner,
           repo: context.repo.repo,
           comment_id: existing.id,
-          body,
+          body: fullBody,
         });
         core.info(
-          `Updated bundle-size comment ${existing.id} on PR #${prNumber}`,
+          `Updated ${marker} comment ${existing.id} on PR #${prNumber}`,
         );
       } else {
         await github.rest.issues.createComment({
           owner: context.repo.owner,
           repo: context.repo.repo,
           issue_number: prNumber,
-          body,
+          body: fullBody,
         });
-        core.info(`Created bundle-size comment on PR #${prNumber}`);
+        core.info(`Created ${marker} comment on PR #${prNumber}`);
       }
       return;
     } catch (error) {
@@ -57,9 +57,7 @@ export default async function run({ github, context, core }) {
       // validation; 403 = secondary rate limit. Each is retryable after a
       // pause + a fresh listComments fetch.
       const isRetryable =
-        error.status === 409 ||
-        error.status === 422 ||
-        error.status === 403;
+        error.status === 409 || error.status === 422 || error.status === 403;
       if (isRetryable && attempt < MAX_RETRIES) {
         core.warning(
           `Attempt ${attempt} failed with status ${error.status}, retrying in ${RETRY_DELAY_MS}ms…`,

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -337,8 +337,13 @@ jobs:
   # `PAGES_BRANCH` is namespaced by CI run ID, so the Pages alias isn't
   # guessable from the branch name either. Put the URLs on the PR
   # explicitly.
+  #
+  # Unlike the deploy jobs, this one runs whatever CI concluded: a
+  # failed run deploys nothing, and a comment still advertising the
+  # previous commit's previews would send reviewers to code that is no
+  # longer the PR's head.
   comment-preview-urls:
-    if: ${{ always() && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    if: ${{ always() && github.event.workflow_run.event == 'pull_request' }}
     needs:
       - deploy-app
       - deploy-slidev-addon-anipres-preview
@@ -367,6 +372,8 @@ jobs:
           SLIDEV_RESULT: ${{ needs.deploy-slidev-addon-anipres-preview.result }}
           WORKER_URL: ${{ needs.deploy-worker-preview.outputs.url }}
           WORKER_RESULT: ${{ needs.deploy-worker-preview.result }}
+          CI_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          CI_RUN_URL: ${{ github.event.workflow_run.html_url }}
           COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
@@ -399,39 +406,51 @@ jobs:
               return
             }
 
-            const targets = [
-              { name: 'App', url: process.env.APP_URL, result: process.env.APP_RESULT },
-              { name: 'Slidev addon demo', url: process.env.SLIDEV_URL, result: process.env.SLIDEV_RESULT },
-              { name: 'Worker (auth + sync)', url: process.env.WORKER_URL, result: process.env.WORKER_RESULT },
-            ]
-            // Bare URLs instead of `[text](url)` — nothing in the cell is
-            // then interpretable as markup.
-            const cell = ({ url, result }) =>
-              url
-                ? url
-                : result === 'skipped'
-                  ? '— _not deployed_'
-                  : `⚠️ deploy \`${result}\``
+            const commitLink = `[\`${headSha.slice(0, 7)}\`](${process.env.COMMIT_URL})`
 
-            // deploy-worker-preview also reports `skipped` when an earlier job
-            // in the chain fails, which is not the fork/Dependabot case — a
-            // deployed app is what distinguishes the two.
-            const workerNote = process.env.WORKER_URL
-              ? 'The preview worker is shared by every PR — last deploy wins.'
-              : process.env.WORKER_RESULT === 'skipped' && process.env.APP_URL
-                ? 'The preview worker is not deployed for fork or Dependabot PRs.'
-                : null
+            const summary = () => {
+              // Overwrite rather than leave the previous commit's URLs
+              // standing — they serve code that is no longer the PR's head.
+              if (process.env.CI_CONCLUSION !== 'success') {
+                return [
+                  `Nothing deployed for ${commitLink} — [CI](${process.env.CI_RUN_URL}) concluded \`${process.env.CI_CONCLUSION}\`.`,
+                ]
+              }
 
-            const body = [
-              '## 🚀 Preview deployments',
-              '',
-              '| Target | URL |',
-              '| --- | --- |',
-              ...targets.map((target) => `| ${target.name} | ${cell(target)} |`),
-              '',
-              `Built from [\`${headSha.slice(0, 7)}\`](${process.env.COMMIT_URL}) · [post-build run](${process.env.RUN_URL}).`,
-              ...(workerNote ? ['', `> ${workerNote}`] : []),
-            ].join('\n')
+              const targets = [
+                { name: 'App', url: process.env.APP_URL, result: process.env.APP_RESULT },
+                { name: 'Slidev addon demo', url: process.env.SLIDEV_URL, result: process.env.SLIDEV_RESULT },
+                { name: 'Worker (auth + sync)', url: process.env.WORKER_URL, result: process.env.WORKER_RESULT },
+              ]
+              // Bare URLs instead of `[text](url)` — nothing in the cell is
+              // then interpretable as markup.
+              const cell = ({ url, result }) =>
+                url
+                  ? url
+                  : result === 'skipped'
+                    ? '— _not deployed_'
+                    : `⚠️ deploy \`${result}\``
+
+              // deploy-worker-preview also reports `skipped` when an earlier job
+              // in the chain fails, which is not the fork/Dependabot case — a
+              // deployed app is what distinguishes the two.
+              const workerNote = process.env.WORKER_URL
+                ? 'The preview worker is shared by every PR — last deploy wins.'
+                : process.env.WORKER_RESULT === 'skipped' && process.env.APP_URL
+                  ? 'The preview worker is not deployed for fork or Dependabot PRs.'
+                  : null
+
+              return [
+                '| Target | URL |',
+                '| --- | --- |',
+                ...targets.map((target) => `| ${target.name} | ${cell(target)} |`),
+                '',
+                `Built from ${commitLink} · [post-build run](${process.env.RUN_URL}).`,
+                ...(workerNote ? ['', `> ${workerNote}`] : []),
+              ]
+            }
+
+            const body = ['## 🚀 Preview deployments', '', ...summary()].join('\n')
 
             const moduleUrl = pathToFileURL(
               path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/sticky-comment.mjs'),

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -385,6 +385,8 @@ jobs:
                 per_page: 100,
               },
             )
+            // Looser than deploy-worker-preview's filter on purpose: fork and
+            // Dependabot PRs get no worker deploy but still get the comment.
             const pullRequests = associatedPullRequests.filter((pullRequest) =>
               pullRequest.state === 'open' &&
               pullRequest.base.repo.full_name === repository &&
@@ -400,21 +402,25 @@ jobs:
             const targets = [
               { name: 'App', url: process.env.APP_URL, result: process.env.APP_RESULT },
               { name: 'Slidev addon demo', url: process.env.SLIDEV_URL, result: process.env.SLIDEV_RESULT },
-              {
-                name: 'Worker (auth + sync)',
-                url: process.env.WORKER_URL,
-                result: process.env.WORKER_RESULT,
-                skippedNote: 'fork and Dependabot PRs keep the Pages previews only',
-              },
+              { name: 'Worker (auth + sync)', url: process.env.WORKER_URL, result: process.env.WORKER_RESULT },
             ]
             // Bare URLs instead of `[text](url)` — nothing in the cell is
             // then interpretable as markup.
-            const cell = ({ url, result, skippedNote }) =>
+            const cell = ({ url, result }) =>
               url
                 ? url
                 : result === 'skipped'
-                  ? `— _${skippedNote ?? 'not deployed'}_`
+                  ? '— _not deployed_'
                   : `⚠️ deploy \`${result}\``
+
+            // deploy-worker-preview also reports `skipped` when an earlier job
+            // in the chain fails, which is not the fork/Dependabot case — a
+            // deployed app is what distinguishes the two.
+            const workerNote = process.env.WORKER_URL
+              ? 'The preview worker is shared by every PR — last deploy wins.'
+              : process.env.WORKER_RESULT === 'skipped' && process.env.APP_URL
+                ? 'The preview worker is not deployed for fork or Dependabot PRs.'
+                : null
 
             const body = [
               '## 🚀 Preview deployments',
@@ -424,9 +430,7 @@ jobs:
               ...targets.map((target) => `| ${target.name} | ${cell(target)} |`),
               '',
               `Built from [\`${headSha.slice(0, 7)}\`](${process.env.COMMIT_URL}) · [post-build run](${process.env.RUN_URL}).`,
-              ...(process.env.WORKER_URL
-                ? ['', '> The preview worker is shared by every PR — last deploy wins.']
-                : []),
+              ...(workerNote ? ['', `> ${workerNote}`] : []),
             ].join('\n')
 
             const moduleUrl = pathToFileURL(

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -338,10 +338,9 @@ jobs:
   # guessable from the branch name either. Put the URLs on the PR
   # explicitly.
   #
-  # Unlike the deploy jobs, this one runs whatever CI concluded: a
-  # failed run deploys nothing, and a comment still advertising the
+  # A failed run deploys nothing, and a comment still advertising the
   # previous commit's previews would send reviewers to code that is no
-  # longer the PR's head.
+  # longer the PR's head — so this job runs whatever CI concluded.
   comment-preview-urls:
     if: ${{ always() && github.event.workflow_run.event == 'pull_request' }}
     needs:
@@ -409,8 +408,6 @@ jobs:
             const commitLink = `[\`${headSha.slice(0, 7)}\`](${process.env.COMMIT_URL})`
 
             const summary = () => {
-              // Overwrite rather than leave the previous commit's URLs
-              // standing — they serve code that is no longer the PR's head.
               if (process.env.CI_CONCLUSION !== 'success') {
                 return [
                   `Nothing deployed for ${commitLink} — [CI](${process.env.CI_RUN_URL}) concluded \`${process.env.CI_CONCLUSION}\`.`,

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -63,6 +63,8 @@ jobs:
       actions: read
 
     runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.deploy.outputs.pages-deployment-alias-url || steps.deploy.outputs.deployment-url }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -72,6 +74,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Deploy
+        id: deploy
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -89,6 +92,8 @@ jobs:
       actions: read
 
     runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.deploy.outputs.pages-deployment-alias-url || steps.deploy.outputs.deployment-url }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -98,6 +103,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Deploy
+        id: deploy
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -120,6 +126,8 @@ jobs:
       pull-requests: read
 
     runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.deploy.outputs.deployment-url }}
 
     steps:
       # Migration tags make edited migrations look already applied. Both the
@@ -237,6 +245,7 @@ jobs:
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy preview worker
+        id: deploy
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -322,6 +331,116 @@ jobs:
           wranglerVersion: '4.85.0'
           command: deploy --no-bundle
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+  # This workflow runs in the default-branch context, so nothing the
+  # deploy jobs do lands on the PR that produced the build — and
+  # `PAGES_BRANCH` is namespaced by CI run ID, so the Pages alias isn't
+  # guessable from the branch name either. Put the URLs on the PR
+  # explicitly.
+  comment-preview-urls:
+    if: ${{ always() && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    needs:
+      - deploy-app
+      - deploy-slidev-addon-anipres-preview
+      - deploy-worker-preview
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # A `workflow_run` checkout resolves to the default branch, so this
+      # brings in the trusted script rather than the PR's code. The job
+      # holds no Cloudflare credentials either way.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          APP_URL: ${{ needs.deploy-app.outputs.url }}
+          APP_RESULT: ${{ needs.deploy-app.result }}
+          SLIDEV_URL: ${{ needs.deploy-slidev-addon-anipres-preview.outputs.url }}
+          SLIDEV_RESULT: ${{ needs.deploy-slidev-addon-anipres-preview.result }}
+          WORKER_URL: ${{ needs.deploy-worker-preview.outputs.url }}
+          WORKER_RESULT: ${{ needs.deploy-worker-preview.result }}
+          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const path = require('node:path')
+            const { pathToFileURL } = require('node:url')
+
+            const repository = `${context.repo.owner}/${context.repo.repo}`
+            const headSha = process.env.HEAD_SHA
+            const associatedPullRequests = await github.paginate(
+              github.rest.repos.listPullRequestsAssociatedWithCommit,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: headSha,
+                per_page: 100,
+              },
+            )
+            const pullRequests = associatedPullRequests.filter((pullRequest) =>
+              pullRequest.state === 'open' &&
+              pullRequest.base.repo.full_name === repository &&
+              pullRequest.head.sha === headSha
+            )
+            // A PR closed or pushed over while post-build was running has
+            // nowhere to put the comment; that's not a deployment failure.
+            if (pullRequests.length !== 1) {
+              core.info(`Found ${pullRequests.length} open pull requests at ${headSha}; skipping the preview comment.`)
+              return
+            }
+
+            const targets = [
+              { name: 'App', url: process.env.APP_URL, result: process.env.APP_RESULT },
+              { name: 'Slidev addon demo', url: process.env.SLIDEV_URL, result: process.env.SLIDEV_RESULT },
+              {
+                name: 'Worker (auth + sync)',
+                url: process.env.WORKER_URL,
+                result: process.env.WORKER_RESULT,
+                skippedNote: 'fork and Dependabot PRs keep the Pages previews only',
+              },
+            ]
+            // Bare URLs instead of `[text](url)` — nothing in the cell is
+            // then interpretable as markup.
+            const cell = ({ url, result, skippedNote }) =>
+              url
+                ? url
+                : result === 'skipped'
+                  ? `— _${skippedNote ?? 'not deployed'}_`
+                  : `⚠️ deploy \`${result}\``
+
+            const body = [
+              '## 🚀 Preview deployments',
+              '',
+              '| Target | URL |',
+              '| --- | --- |',
+              ...targets.map((target) => `| ${target.name} | ${cell(target)} |`),
+              '',
+              `Built from [\`${headSha.slice(0, 7)}\`](${process.env.COMMIT_URL}) · [post-build run](${process.env.RUN_URL}).`,
+              ...(process.env.WORKER_URL
+                ? ['', '> The preview worker is shared by every PR — last deploy wins.']
+                : []),
+            ].join('\n')
+
+            const moduleUrl = pathToFileURL(
+              path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/sticky-comment.mjs'),
+            ).href
+            const { default: updateStickyComment } = await import(moduleUrl)
+            await updateStickyComment({
+              github,
+              context,
+              core,
+              marker: '<!-- preview-deployments -->',
+              prNumber: pullRequests[0].number,
+              body,
+            })
 
   report-status:
     if: ${{ always() && needs.initialize-status.result != 'skipped' }}


### PR DESCRIPTION
Cloudflare preview URLs stopped reaching PRs when #485 moved the deploys into `post-build.yml`. Before that, the deploy jobs ran inside the PR's own CI run, so `wrangler-action`'s GitHub Deployment attached to the PR head and the Pages alias came from `--branch=${{ github.head_ref }}` — guessable straight from the branch name. Now the deploys run in a `workflow_run` job whose context is the default branch, so nothing they do lands on the PR, and `PAGES_BRANCH` is namespaced by CI run ID rather than branch name. The URLs exist only in the post-build job log.

Each deploy job now exposes its URL as a job output, and a new `comment-preview-urls` job resolves the PR from the `workflow_run` head SHA and posts a sticky comment with the App, Slidev addon demo, and preview Worker URLs. Rows for deploys that failed or were skipped render their status instead of a URL, so one failed deploy subtracts a row rather than the whole comment. Because `workflow_run` always runs the default branch's copy of the workflow, this job first executes on the PR after this one merges — there is no preview comment on this PR to look at.

A comment that outlives its build is worse than no comment: gating the job on a successful CI run would leave the previous commit's URLs in place after a push failed CI, sending reviewers to code that is no longer the PR's head. So the job runs on every completed PR CI run, and renders `Nothing deployed for <commit> — CI concluded <conclusion>` in place of the table when CI didn't succeed. A superseded run is left alone — its head SHA no longer matches the PR, so it skips rather than overwriting a newer comment; the comment always names the commit it was built from.

The sticky-comment retry loop moves from `.github/scripts/bundle-size-report/update-sticky-comment.mjs` to `.github/scripts/sticky-comment.mjs` and takes its marker, PR number, and body as arguments so both comments share it.

`comment-preview-urls` is deliberately not in `report-status`'s `needs`: that commit status is named `Post-build / deployments` and describes Cloudflare deploys, so folding a comment-posting failure into it would make its description wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull requests now receive a sticky comment with preview deployment URLs for the app, Slidev addon, and preview Worker.
  * Comments include deployment status, CI failures, skipped deployments, commit links, and relevant Worker preview notes.
  * Preview comments are posted only when a unique matching open pull request is found.

* **Bug Fixes**
  * Existing preview comments are now updated consistently instead of creating duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->