### PR TITLE
app: keep the app mounted while `/auth/me` retries, and flush the pending local save on editor teardown

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,11 +1,12 @@
 # Third-party notices
 
-Anipres is MIT-licensed (see `LICENSE`). The agent feature draws
-significant inspiration from the third-party project listed below —
+Anipres is MIT-licensed (see `LICENSE`). The projects listed below
+contributed designs and code that Anipres adapts — the agent feature
+in particular draws significant inspiration from tldraw/agent-template
 in design, structure, naming, and several specific patterns. We owe
-that work a real intellectual debt; this notice exists both to thank
-the upstream authors and to satisfy the attribution requirements of
-their license.
+these works a real intellectual debt; this notice exists both to
+thank the upstream authors and to satisfy the attribution
+requirements of their licenses.
 
 ---
 
@@ -177,3 +178,19 @@ to minimise the upstream contribution.
 
 For the design rationale and how these pieces fit together in the
 context of Anipres' presentation model, see `docs/design-agent.md`.
+
+---
+
+## idb-keyval
+
+Source: https://github.com/jakearchibald/idb-keyval
+License: Apache-2.0 — Copyright 2016, Jake Archibald
+(full text: https://github.com/jakearchibald/idb-keyval/blob/main/LICENCE)
+
+- **`IdbDocumentRepository.updateSnapshot`** — `packages/app/src/documents/idb-repository.ts`
+  **closely follows** [`update`](https://github.com/jakearchibald/idb-keyval/blob/main/src/index.ts):
+  the same single-readwrite-transaction get-then-put structure and
+  the same `resolve(promisifyRequest(store.transaction))` completion
+  handshake. Modified here to write conditionally (a missing document
+  must stay missing, where `update` always writes) and to reject on a
+  failed `get`.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -184,8 +184,28 @@ context of Anipres' presentation model, see `docs/design-agent.md`.
 ## idb-keyval
 
 Source: https://github.com/jakearchibald/idb-keyval
-License: Apache-2.0 — Copyright 2016, Jake Archibald
-(full text: https://github.com/jakearchibald/idb-keyval/blob/main/LICENCE)
+License: Apache-2.0
+
+The package's `LICENCE` file, reproduced verbatim: this is the whole
+of the license file upstream distributes, in both its repository and
+its npm tarball, and it is the notice form the Apache-2.0 appendix
+prescribes. The full license text lives at the URL the notice names.
+
+```
+Copyright 2016, Jake Archibald
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
 
 - **`IdbDocumentRepository.updateSnapshot`** — `packages/app/src/documents/idb-repository.ts`
   **closely follows** [`update`](https://github.com/jakearchibald/idb-keyval/blob/main/src/index.ts):

--- a/packages/app/src/auth/AuthContext.test.tsx
+++ b/packages/app/src/auth/AuthContext.test.tsx
@@ -1,0 +1,107 @@
+import { useEffect } from "react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig, useSWRConfig, type ScopedMutator } from "swr";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuthProvider } from "./AuthContext";
+import { fetchMe } from "./me-fetcher";
+import { useAuth } from "./useAuth";
+
+vi.mock("./me-fetcher", () => ({
+  fetchMe: vi.fn(),
+}));
+
+const fetchMeMock = vi.mocked(fetchMe);
+
+function Probe({
+  mutateRef,
+}: {
+  mutateRef: { current: ScopedMutator | null };
+}) {
+  const { user, loading } = useAuth();
+  const { mutate } = useSWRConfig();
+  useEffect(() => {
+    mutateRef.current = mutate;
+  }, [mutate, mutateRef]);
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="user">{user ? String(user.id) : "null"}</span>
+    </div>
+  );
+}
+
+function renderProvider() {
+  const mutateRef: { current: ScopedMutator | null } = { current: null };
+  render(
+    // A fresh cache per test; retries are triggered manually via
+    // `mutate` so the test doesn't depend on SWR's backoff timing.
+    <SWRConfig
+      value={{
+        provider: () => new Map(),
+        dedupingInterval: 0,
+        shouldRetryOnError: false,
+      }}
+    >
+      <AuthProvider>
+        <Probe mutateRef={mutateRef} />
+      </AuthProvider>
+    </SWRConfig>,
+  );
+  return {
+    triggerRevalidation: () => mutateRef.current!(["auth", "me"]),
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("AuthProvider loading semantics", () => {
+  it("stops reporting loading once the first attempt fails, even while a retry is in flight", async () => {
+    fetchMeMock.mockRejectedValueOnce(new Error("Request failed (500)"));
+    const { triggerRevalidation } = renderProvider();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("loading").textContent).toBe("false"),
+    );
+    expect(screen.getByTestId("user").textContent).toBe("null");
+
+    // A retry request in flight (no data yet, error recorded) must not
+    // flip `loading` back to true — that unmounts the whole app on
+    // every retry when the server is down.
+    let resolveRetry!: (value: null) => void;
+    fetchMeMock.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveRetry = resolve)),
+    );
+    let revalidation!: Promise<unknown>;
+    act(() => {
+      revalidation = triggerRevalidation();
+    });
+    expect(screen.getByTestId("loading").textContent).toBe("false");
+
+    await act(async () => {
+      resolveRetry(null);
+      await revalidation.catch(() => {});
+    });
+    expect(screen.getByTestId("loading").textContent).toBe("false");
+  });
+
+  it("reports loading during the very first attempt and exposes the user on success", async () => {
+    let resolveFirst!: (value: { id: number }) => void;
+    fetchMeMock.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveFirst = resolve)),
+    );
+    renderProvider();
+
+    expect(screen.getByTestId("loading").textContent).toBe("true");
+
+    await act(async () => {
+      resolveFirst({ id: 42 });
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("loading").textContent).toBe("false"),
+    );
+    expect(screen.getByTestId("user").textContent).toBe("42");
+  });
+});

--- a/packages/app/src/auth/AuthContext.tsx
+++ b/packages/app/src/auth/AuthContext.tsx
@@ -14,8 +14,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // without needing a cross-tab broadcast. The BroadcastChannel
   // listener wired up below makes that propagation immediate so
   // tabs don't sit on stale auth state until the user clicks them.
-  const { data, isLoading: loading } = useSWR(ME_KEY, fetchMe);
+  const { data, error, isLoading } = useSWR(ME_KEY, fetchMe);
   const user = data ?? null;
+
+  // SWR's `isLoading` is true for every in-flight request with no data
+  // loaded, including each attempt of its error-retry loop. Consumers
+  // unmount their subtree while loading, so reporting that directly
+  // would remount the whole app on every retry against a down server.
+  // This reports only the never-yet-settled first attempt.
+  const loading = isLoading && error === undefined;
 
   // Pull the global mutate so logout can wipe every SWR cache key,
   // not just `/auth/me`. The server-side cookie clearing already

--- a/packages/app/src/documents/DocumentManagerContext.tsx
+++ b/packages/app/src/documents/DocumentManagerContext.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import type { DocumentRepository } from "./repository";
+import type { DocumentRepository, LocalDocumentRepository } from "./repository";
 import { useDocumentManager } from "./useDocumentManager";
 import { DocumentManagerContext } from "./useDocumentManagerContext";
 import { useWorkspaceFeed } from "./useWorkspaceFeed";
@@ -10,7 +10,7 @@ export function DocumentManagerProvider({
   workspaceId,
   children,
 }: {
-  localRepository: DocumentRepository;
+  localRepository: LocalDocumentRepository;
   syncedRepository?: DocumentRepository;
   workspaceId: string | null;
   children: ReactNode;

--- a/packages/app/src/documents/idb-repository.ts
+++ b/packages/app/src/documents/idb-repository.ts
@@ -58,12 +58,12 @@ export class IdbDocumentRepository implements LocalDocumentRepository {
     await del(id, store);
   }
 
-  // Patterned after idb-keyval's `update` (Apache-2.0, © Jake Archibald;
-  // https://github.com/jakearchibald/idb-keyval/blob/main/src/index.ts):
-  // the get and the conditional put share one readwrite transaction.
-  // `update` itself cannot express this operation because it
-  // unconditionally writes the updater's return value, and a missing
-  // document must stay missing here.
+  // Closely follows idb-keyval's `update` (Apache-2.0, © 2016 Jake
+  // Archibald; https://github.com/jakearchibald/idb-keyval/blob/main/src/index.ts
+  // — see THIRD_PARTY_NOTICES.md): the get and the conditional put
+  // share one readwrite transaction. `update` itself cannot express
+  // this operation because it unconditionally writes the updater's
+  // return value, and a missing document must stay missing here.
   async updateSnapshot(id: string, snapshot: TLStoreSnapshot): Promise<void> {
     await store(
       "readwrite",
@@ -85,7 +85,7 @@ export class IdbDocumentRepository implements LocalDocumentRepository {
                 },
                 id,
               );
-              resolve(promisifyRequest(s.transaction).then(() => undefined));
+              resolve(promisifyRequest(s.transaction));
             } catch (error) {
               reject(error);
             }

--- a/packages/app/src/documents/idb-repository.ts
+++ b/packages/app/src/documents/idb-repository.ts
@@ -1,6 +1,14 @@
-import { createStore, get, set, del, entries } from "idb-keyval";
+import {
+  createStore,
+  get,
+  set,
+  del,
+  entries,
+  promisifyRequest,
+} from "idb-keyval";
 import { compareOrderKeys } from "anipres/models";
-import type { DocumentRepository } from "./repository";
+import type { TLStoreSnapshot } from "tldraw";
+import type { LocalDocumentRepository } from "./repository";
 import type { DocumentData, DocumentInput, DocumentMeta } from "./types";
 
 const store = createStore("anipres-documents", "documents");
@@ -9,7 +17,7 @@ function stampLocal(meta: DocumentMeta): DocumentMeta {
   return { ...meta, source: "local" };
 }
 
-export class IdbDocumentRepository implements DocumentRepository {
+export class IdbDocumentRepository implements LocalDocumentRepository {
   async list(): Promise<DocumentMeta[]> {
     const all = await entries<string, DocumentData>(store);
     return all
@@ -48,5 +56,42 @@ export class IdbDocumentRepository implements DocumentRepository {
 
   async delete(id: string): Promise<void> {
     await del(id, store);
+  }
+
+  // Patterned after idb-keyval's `update` (Apache-2.0, © Jake Archibald;
+  // https://github.com/jakearchibald/idb-keyval/blob/main/src/index.ts):
+  // the get and the conditional put share one readwrite transaction.
+  // `update` itself cannot express this operation because it
+  // unconditionally writes the updater's return value, and a missing
+  // document must stay missing here.
+  async updateSnapshot(id: string, snapshot: TLStoreSnapshot): Promise<void> {
+    await store(
+      "readwrite",
+      (s) =>
+        new Promise<void>((resolve, reject) => {
+          const request = s.get(id);
+          request.onsuccess = () => {
+            try {
+              const existing = request.result as DocumentData | undefined;
+              if (existing === undefined) {
+                resolve();
+                return;
+              }
+              s.put(
+                {
+                  ...existing,
+                  snapshot,
+                  meta: { ...existing.meta, updatedAt: Date.now() },
+                },
+                id,
+              );
+              resolve(promisifyRequest(s.transaction).then(() => undefined));
+            } catch (error) {
+              reject(error);
+            }
+          };
+          request.onerror = () => reject(request.error);
+        }),
+    );
   }
 }

--- a/packages/app/src/documents/repository.ts
+++ b/packages/app/src/documents/repository.ts
@@ -25,17 +25,20 @@ export interface DocumentRepository {
 
 export interface LocalDocumentRepository extends DocumentRepository {
   /**
-   * Replace an existing document's snapshot without touching its meta;
-   * a no-op when the document no longer exists (it may have been
-   * deleted while an editor for it was still mounted).
+   * Replace an existing document's snapshot, bumping `updatedAt` and
+   * leaving the rest of its meta untouched; a no-op when the document
+   * no longer exists (it may have been deleted while an editor for it
+   * was still mounted).
    *
    * Must be atomic — read and write in one storage transaction. The
    * editor-teardown flush depends on this: IndexedDB starts a
    * transaction only after every earlier-created readwrite transaction
-   * with overlapping scope commits, so a single-transaction update
-   * guarantees that reads issued after teardown (e.g. by a remounted
-   * document manager) observe the flushed snapshot. A get-then-save
-   * pair has no such guarantee — a read can land between the two.
+   * with overlapping scope commits, and every call funnels through
+   * idb-keyval's single cached connection promise so transactions are
+   * created in call order. Together those guarantee that reads issued
+   * after teardown (e.g. by a remounted document manager) observe the
+   * flushed snapshot. A get-then-save pair has no such guarantee — a
+   * read can land between the two.
    */
   updateSnapshot(id: string, snapshot: TLStoreSnapshot): Promise<void>;
 }

--- a/packages/app/src/documents/repository.ts
+++ b/packages/app/src/documents/repository.ts
@@ -1,3 +1,4 @@
+import type { TLStoreSnapshot } from "tldraw";
 import type { DocumentData, DocumentInput, DocumentMeta } from "./types";
 
 export interface DocumentRepository {
@@ -20,4 +21,21 @@ export interface DocumentRepository {
    */
   save(input: DocumentInput): Promise<DocumentData>;
   delete(id: string): Promise<void>;
+}
+
+export interface LocalDocumentRepository extends DocumentRepository {
+  /**
+   * Replace an existing document's snapshot without touching its meta;
+   * a no-op when the document no longer exists (it may have been
+   * deleted while an editor for it was still mounted).
+   *
+   * Must be atomic — read and write in one storage transaction. The
+   * editor-teardown flush depends on this: IndexedDB starts a
+   * transaction only after every earlier-created readwrite transaction
+   * with overlapping scope commits, so a single-transaction update
+   * guarantees that reads issued after teardown (e.g. by a remounted
+   * document manager) observe the flushed snapshot. A get-then-save
+   * pair has no such guarantee — a read can land between the two.
+   */
+  updateSnapshot(id: string, snapshot: TLStoreSnapshot): Promise<void>;
 }

--- a/packages/app/src/documents/useDocumentManager.test.tsx
+++ b/packages/app/src/documents/useDocumentManager.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { compareOrderKeys } from "anipres/models";
-import type { TLStoreSnapshot } from "tldraw";
+import type { Editor, TLStoreSnapshot } from "tldraw";
 import { useDocumentManager } from "./useDocumentManager";
 import type { DocumentRepository } from "./repository";
 import type {
@@ -11,7 +11,32 @@ import type {
   DocumentSource,
 } from "./types";
 
+// The hook's only runtime import from tldraw is `getSnapshot`; the fake
+// editors below expose `store.getStoreSnapshot` for it to read.
+vi.mock("tldraw", () => ({
+  getSnapshot: (store: { getStoreSnapshot: () => TLStoreSnapshot }) => ({
+    document: store.getStoreSnapshot(),
+  }),
+}));
+
 const emptySnapshot = { store: {}, schema: {} } as unknown as TLStoreSnapshot;
+
+function makeFakeEditor(snapshot: TLStoreSnapshot) {
+  const listeners: Array<() => void> = [];
+  const editor = {
+    store: {
+      listen: (cb: () => void) => {
+        listeners.push(cb);
+        return () => {};
+      },
+      getStoreSnapshot: () => snapshot,
+    },
+  } as unknown as Editor;
+  return {
+    editor,
+    emitUserChange: () => listeners.forEach((cb) => cb()),
+  };
+}
 
 function makeLocalDocWithSnapshot(id: string): DocumentData {
   return {
@@ -775,6 +800,122 @@ describe("useDocumentManager", () => {
 
     expect(localRepo.delete).not.toHaveBeenCalled();
     expect(result.current.documents[0].source).toBe("local");
+  });
+
+  it("persists the active local doc when the debounced save fires", async () => {
+    const editedSnapshot = {
+      store: { edited: true },
+      schema: {},
+    } as unknown as TLStoreSnapshot;
+    const localRepo = makeFakeRepo("local", [makeLocalDocWithSnapshot("L1")]);
+
+    const { result } = renderHook(() =>
+      useDocumentManager({ localRepository: localRepo.repo }),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.activeDocument?.id).toBe("L1");
+
+    const { editor, emitUserChange } = makeFakeEditor(editedSnapshot);
+    let unregister!: () => void;
+    act(() => {
+      unregister = result.current.registerEditor(editor);
+    });
+    localRepo.save.mockClear();
+
+    act(() => {
+      emitUserChange();
+    });
+
+    await waitFor(
+      () => expect(localRepo.save).toHaveBeenCalledTimes(1),
+      // The debounce window is 500ms of real time.
+      { timeout: 2000 },
+    );
+    expect(localRepo.save.mock.calls[0][0].meta.id).toBe("L1");
+    expect(localRepo.save.mock.calls[0][0].snapshot).toBe(editedSnapshot);
+
+    act(() => {
+      unregister();
+    });
+  });
+
+  it("flushes a pending debounced save when the editor unregisters before it fires", async () => {
+    const editedSnapshot = {
+      store: { edited: true },
+      schema: {},
+    } as unknown as TLStoreSnapshot;
+    const localRepo = makeFakeRepo("local", [makeLocalDocWithSnapshot("L1")]);
+
+    const { result } = renderHook(() =>
+      useDocumentManager({ localRepository: localRepo.repo }),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.activeDocument?.id).toBe("L1");
+
+    const { editor, emitUserChange } = makeFakeEditor(editedSnapshot);
+    let unregister!: () => void;
+    act(() => {
+      unregister = result.current.registerEditor(editor);
+    });
+    localRepo.save.mockClear();
+
+    // An edit schedules the debounced save; the editor tears down before
+    // the 500ms window elapses — the app-level unmount that happens when
+    // auth resolves mid-editing-session. The scheduled save must be
+    // flushed, not dropped.
+    act(() => {
+      emitUserChange();
+      unregister();
+    });
+
+    await waitFor(() => expect(localRepo.save).toHaveBeenCalledTimes(1));
+    expect(localRepo.save.mock.calls[0][0].meta.id).toBe("L1");
+    expect(localRepo.save.mock.calls[0][0].snapshot).toBe(editedSnapshot);
+  });
+
+  it("does not flush the outgoing editor's content onto a newly selected doc", async () => {
+    const editedSnapshot = {
+      store: { edited: true },
+      schema: {},
+    } as unknown as TLStoreSnapshot;
+    const localRepo = makeFakeRepo("local", [
+      makeLocalDocWithSnapshot("L1"),
+      makeLocalDocWithSnapshot("L2"),
+    ]);
+
+    const { result } = renderHook(() =>
+      useDocumentManager({ localRepository: localRepo.repo }),
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.activeDocument?.id).toBe("L1");
+
+    const { editor, emitUserChange } = makeFakeEditor(editedSnapshot);
+    let unregister!: () => void;
+    act(() => {
+      unregister = result.current.registerEditor(editor);
+    });
+
+    act(() => {
+      emitUserChange();
+    });
+    // selectDocument saves L1 through saveCurrentEditor before switching.
+    await act(async () => {
+      await result.current.selectDocument("L2");
+    });
+    expect(
+      localRepo.save.mock.calls.every((call) => call[0].meta.id === "L1"),
+    ).toBe(true);
+    localRepo.save.mockClear();
+
+    // The old editor's debounced save is still pending, but the active
+    // doc is now L2 — flushing it would overwrite L2 with L1's content.
+    act(() => {
+      unregister();
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(localRepo.save).not.toHaveBeenCalled();
   });
 
   it("treats createDocument({source: 'synced'}) as a no-op when no synced repository is configured", async () => {

--- a/packages/app/src/documents/useDocumentManager.test.tsx
+++ b/packages/app/src/documents/useDocumentManager.test.tsx
@@ -11,8 +11,8 @@ import type {
   DocumentSource,
 } from "./types";
 
-// The hook's only runtime import from tldraw is `getSnapshot`; the fake
-// editors below expose `store.getStoreSnapshot` for it to read.
+// The real getSnapshot needs a real TLStore; the fake editors below
+// expose `store.getStoreSnapshot` for this stub to read instead.
 vi.mock("tldraw", () => ({
   getSnapshot: (store: { getStoreSnapshot: () => TLStoreSnapshot }) => ({
     document: store.getStoreSnapshot(),
@@ -134,6 +134,7 @@ describe("useDocumentManager", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it("merges synced and local documents on initial load with synced first", async () => {
@@ -802,7 +803,7 @@ describe("useDocumentManager", () => {
     expect(result.current.documents[0].source).toBe("local");
   });
 
-  it("persists the active local doc when the debounced save fires", async () => {
+  it("persists the active local doc when the debounced save fires, without a second write on unregister", async () => {
     const editedSnapshot = {
       store: { edited: true },
       schema: {},
@@ -822,21 +823,30 @@ describe("useDocumentManager", () => {
     });
     localRepo.save.mockClear();
 
+    // Fake timers only around the debounce window; the load above and
+    // the settling below rely on real timers.
+    vi.useFakeTimers();
     act(() => {
       emitUserChange();
     });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    vi.useRealTimers();
 
-    await waitFor(
-      () => expect(localRepo.save).toHaveBeenCalledTimes(1),
-      // The debounce window is 500ms of real time.
-      { timeout: 2000 },
-    );
+    expect(localRepo.save).toHaveBeenCalledTimes(1);
     expect(localRepo.save.mock.calls[0][0].meta.id).toBe("L1");
     expect(localRepo.save.mock.calls[0][0].snapshot).toBe(editedSnapshot);
 
+    // The fired save cleared the pending state, so teardown has nothing
+    // left to flush.
     act(() => {
       unregister();
     });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(localRepo.save).toHaveBeenCalledTimes(1);
   });
 
   it("flushes a pending debounced save when the editor unregisters before it fires", async () => {
@@ -873,7 +883,7 @@ describe("useDocumentManager", () => {
     expect(localRepo.save.mock.calls[0][0].snapshot).toBe(editedSnapshot);
   });
 
-  it("does not flush the outgoing editor's content onto a newly selected doc", async () => {
+  it("skips the flush when a doc switch has already detached the editor", async () => {
     const editedSnapshot = {
       store: { edited: true },
       schema: {},
@@ -907,8 +917,9 @@ describe("useDocumentManager", () => {
     ).toBe(true);
     localRepo.save.mockClear();
 
-    // The old editor's debounced save is still pending, but the active
-    // doc is now L2 — flushing it would overwrite L2 with L1's content.
+    // The old editor's debounced save is still pending, but the switch
+    // detached the editor after saving L1 itself; teardown must not
+    // write again.
     act(() => {
       unregister();
     });

--- a/packages/app/src/documents/useDocumentManager.test.tsx
+++ b/packages/app/src/documents/useDocumentManager.test.tsx
@@ -3,7 +3,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { compareOrderKeys } from "anipres/models";
 import type { Editor, TLStoreSnapshot } from "tldraw";
 import { useDocumentManager } from "./useDocumentManager";
-import type { DocumentRepository } from "./repository";
+import type { DocumentRepository, LocalDocumentRepository } from "./repository";
 import type {
   DocumentData,
   DocumentInput,
@@ -102,14 +102,26 @@ function makeFakeRepo(source: DocumentSource, initial: DocumentData[] = []) {
   const del = vi.fn(async (id: string): Promise<void> => {
     store.delete(id);
   });
+  const updateSnapshot = vi.fn(
+    async (id: string, snapshot: TLStoreSnapshot): Promise<void> => {
+      const existing = store.get(id);
+      if (!existing) return;
+      store.set(id, {
+        ...existing,
+        snapshot,
+        meta: { ...existing.meta, updatedAt: Date.now() },
+      });
+    },
+  );
 
-  const repo: DocumentRepository = {
+  const repo: LocalDocumentRepository = {
     list,
     get,
     save,
     delete: del,
+    updateSnapshot,
   };
-  return { repo, store, list, get, save, delete: del };
+  return { repo, store, list, get, save, delete: del, updateSnapshot };
 }
 
 describe("useDocumentManager", () => {
@@ -821,7 +833,6 @@ describe("useDocumentManager", () => {
     act(() => {
       unregister = result.current.registerEditor(editor);
     });
-    localRepo.save.mockClear();
 
     // Fake timers only around the debounce window; the load above and
     // the settling below rely on real timers.
@@ -834,9 +845,8 @@ describe("useDocumentManager", () => {
     });
     vi.useRealTimers();
 
-    expect(localRepo.save).toHaveBeenCalledTimes(1);
-    expect(localRepo.save.mock.calls[0][0].meta.id).toBe("L1");
-    expect(localRepo.save.mock.calls[0][0].snapshot).toBe(editedSnapshot);
+    expect(localRepo.updateSnapshot).toHaveBeenCalledTimes(1);
+    expect(localRepo.updateSnapshot).toHaveBeenCalledWith("L1", editedSnapshot);
 
     // The fired save cleared the pending state, so teardown has nothing
     // left to flush.
@@ -846,7 +856,7 @@ describe("useDocumentManager", () => {
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
-    expect(localRepo.save).toHaveBeenCalledTimes(1);
+    expect(localRepo.updateSnapshot).toHaveBeenCalledTimes(1);
   });
 
   it("flushes a pending debounced save when the editor unregisters before it fires", async () => {
@@ -867,6 +877,7 @@ describe("useDocumentManager", () => {
     act(() => {
       unregister = result.current.registerEditor(editor);
     });
+    localRepo.get.mockClear();
     localRepo.save.mockClear();
 
     // An edit schedules the debounced save; the editor tears down before
@@ -878,9 +889,16 @@ describe("useDocumentManager", () => {
       unregister();
     });
 
-    await waitFor(() => expect(localRepo.save).toHaveBeenCalledTimes(1));
-    expect(localRepo.save.mock.calls[0][0].meta.id).toBe("L1");
-    expect(localRepo.save.mock.calls[0][0].snapshot).toBe(editedSnapshot);
+    await waitFor(() =>
+      expect(localRepo.updateSnapshot).toHaveBeenCalledTimes(1),
+    );
+    expect(localRepo.updateSnapshot).toHaveBeenCalledWith("L1", editedSnapshot);
+    // The flush must stay a single atomic repository operation. A
+    // get-then-save pair spans two storage transactions, and a document
+    // manager remounting after the teardown could read the stale
+    // snapshot between them.
+    expect(localRepo.get).not.toHaveBeenCalled();
+    expect(localRepo.save).not.toHaveBeenCalled();
   });
 
   it("skips the flush when a doc switch has already detached the editor", async () => {
@@ -912,10 +930,8 @@ describe("useDocumentManager", () => {
     await act(async () => {
       await result.current.selectDocument("L2");
     });
-    expect(
-      localRepo.save.mock.calls.every((call) => call[0].meta.id === "L1"),
-    ).toBe(true);
-    localRepo.save.mockClear();
+    expect(localRepo.updateSnapshot).toHaveBeenCalledWith("L1", editedSnapshot);
+    localRepo.updateSnapshot.mockClear();
 
     // The old editor's debounced save is still pending, but the switch
     // detached the editor after saving L1 itself; teardown must not
@@ -926,7 +942,7 @@ describe("useDocumentManager", () => {
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
-    expect(localRepo.save).not.toHaveBeenCalled();
+    expect(localRepo.updateSnapshot).not.toHaveBeenCalled();
   });
 
   it("treats createDocument({source: 'synced'}) as a no-op when no synced repository is configured", async () => {

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -669,26 +669,32 @@ export function useDocumentManager(params: {
         // 500ms; the clearTimeout above would silently drop them. That
         // matters when teardown is an app-level unmount — e.g. auth
         // resolving mid-editing-session swaps in the synced workspace —
-        // so flush the save instead. The snapshot is captured
-        // synchronously because the editor may be disposed as soon as
-        // this cleanup returns. The doc-id/source guard skips the flush
-        // when the active doc has already moved on (doc switches save
-        // through selectDocument first; flushing here would write this
-        // editor's content onto the newly active doc).
+        // so flush the save instead. The editor-identity check limits
+        // the flush to teardowns where this editor still belongs to the
+        // active doc: every path that moves the active doc (select,
+        // create, delete, convert) persists the outgoing doc itself and
+        // detaches the editor by nulling editorRef, and a flush fired
+        // during that hand-off could attribute this editor's content to
+        // the newly active doc through a late `pendingDocId` update.
         if (
           pendingDocId !== null &&
-          pendingDocId === activeDocumentIdRef.current &&
+          editorRef.current === nextEditor &&
           activeDocumentSourceRef.current === "local"
         ) {
+          // Captured synchronously: the editor may be disposed as soon
+          // as this cleanup returns.
           const { document } = getSnapshot(nextEditor.store);
-          void persistLocalSnapshot(pendingDocId, document);
+          void persistLocalSnapshot(pendingDocId, document).catch((error) =>
+            console.error("Failed to flush the pending local save", error),
+          );
         }
-        // The store-listen above debounces saveCurrentEditor by 500ms,
-        // and saveCurrentEditor reads `editorRef.current` directly.
-        // Without nulling the ref here, a save scheduled just before
-        // unregister can still fire and persist against a stale
-        // editor — the same teardown pattern used everywhere else in
-        // this file (see `editorRef.current = null` on doc switches).
+        // saveCurrentEditor reads `editorRef.current` directly, and
+        // callers outside this listener (the visibility/pagehide
+        // handlers, the doc actions) can still invoke it after this
+        // editor is gone. Nulling the ref keeps them from snapshotting
+        // a torn-down editor — the same teardown pattern used
+        // everywhere else in this file (see `editorRef.current = null`
+        // on doc switches).
         if (editorRef.current === nextEditor) {
           editorRef.current = null;
         }

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -670,17 +670,20 @@ export function useDocumentManager(params: {
           activeDocumentSourceRef.current === "local"
         ) {
           // Captured synchronously: the editor may be disposed as soon
-          // as this cleanup returns. updateSnapshot is a single
-          // readwrite transaction, so reads issued after this cleanup —
-          // e.g. by a document manager remounting once workspace
-          // discovery settles — are ordered behind it and observe the
-          // flushed snapshot (see LocalDocumentRepository).
-          const { document } = getSnapshot(nextEditor.store);
-          void localRepository
-            .updateSnapshot(pendingDocId, document)
-            .catch((error) =>
-              console.error("Failed to flush the pending local save", error),
-            );
+          // as this cleanup returns. updateSnapshot is atomic, so a
+          // manager remounting after this cleanup reads the flushed
+          // snapshot (see LocalDocumentRepository). The try keeps a
+          // failed capture from skipping the ref-nulling below.
+          try {
+            const { document } = getSnapshot(nextEditor.store);
+            void localRepository
+              .updateSnapshot(pendingDocId, document)
+              .catch((error) =>
+                console.error("Failed to flush the pending local save", error),
+              );
+          } catch (error) {
+            console.error("Failed to flush the pending local save", error);
+          }
         }
         // saveCurrentEditor reads `editorRef.current` directly, and
         // callers outside this listener (the visibility/pagehide

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { getSnapshot, type Editor, type TLStoreSnapshot } from "tldraw";
 import { v7 as uuidv7 } from "uuid";
-import type { DocumentRepository } from "./repository";
+import type { DocumentRepository, LocalDocumentRepository } from "./repository";
 import type {
   DocumentData,
   DocumentInput,
@@ -71,7 +71,7 @@ export type MigrationOverrides = Pick<
 >;
 
 export function useDocumentManager(params: {
-  localRepository: DocumentRepository;
+  localRepository: LocalDocumentRepository;
   syncedRepository?: DocumentRepository;
   /**
    * Optional test/dev injection point for the HTTP calls that
@@ -179,18 +179,6 @@ export function useDocumentManager(params: {
     return [...syncedList, ...localList];
   }, [localRepository, syncedRepository]);
 
-  const persistLocalSnapshot = useCallback(
-    async (docId: string, snapshot: TLStoreSnapshot) => {
-      const existing = await localRepository.get(docId);
-      if (!existing) return;
-      await localRepository.save({
-        ...existing,
-        snapshot,
-      });
-    },
-    [localRepository],
-  );
-
   const saveCurrentEditor = useCallback(async () => {
     // Only local-source documents are persisted via this hook — synced
     // documents are persisted by useSync over WebSocket.
@@ -201,8 +189,8 @@ export function useDocumentManager(params: {
     if (!editor || !docId) return;
 
     const { document } = getSnapshot(editor.store);
-    await persistLocalSnapshot(docId, document);
-  }, [persistLocalSnapshot]);
+    await localRepository.updateSnapshot(docId, document);
+  }, [localRepository]);
 
   useEffect(() => {
     let cancelled = false;
@@ -682,11 +670,17 @@ export function useDocumentManager(params: {
           activeDocumentSourceRef.current === "local"
         ) {
           // Captured synchronously: the editor may be disposed as soon
-          // as this cleanup returns.
+          // as this cleanup returns. updateSnapshot is a single
+          // readwrite transaction, so reads issued after this cleanup —
+          // e.g. by a document manager remounting once workspace
+          // discovery settles — are ordered behind it and observe the
+          // flushed snapshot (see LocalDocumentRepository).
           const { document } = getSnapshot(nextEditor.store);
-          void persistLocalSnapshot(pendingDocId, document).catch((error) =>
-            console.error("Failed to flush the pending local save", error),
-          );
+          void localRepository
+            .updateSnapshot(pendingDocId, document)
+            .catch((error) =>
+              console.error("Failed to flush the pending local save", error),
+            );
         }
         // saveCurrentEditor reads `editorRef.current` directly, and
         // callers outside this listener (the visibility/pagehide
@@ -701,7 +695,7 @@ export function useDocumentManager(params: {
         setEditor((current) => (current === nextEditor ? null : current));
       };
     },
-    [persistLocalSnapshot, saveCurrentEditor],
+    [localRepository, saveCurrentEditor],
   );
 
   // Best-effort save when the user leaves the page.

--- a/packages/app/src/documents/useDocumentManager.ts
+++ b/packages/app/src/documents/useDocumentManager.ts
@@ -179,6 +179,18 @@ export function useDocumentManager(params: {
     return [...syncedList, ...localList];
   }, [localRepository, syncedRepository]);
 
+  const persistLocalSnapshot = useCallback(
+    async (docId: string, snapshot: TLStoreSnapshot) => {
+      const existing = await localRepository.get(docId);
+      if (!existing) return;
+      await localRepository.save({
+        ...existing,
+        snapshot,
+      });
+    },
+    [localRepository],
+  );
+
   const saveCurrentEditor = useCallback(async () => {
     // Only local-source documents are persisted via this hook — synced
     // documents are persisted by useSync over WebSocket.
@@ -188,15 +200,9 @@ export function useDocumentManager(params: {
     const docId = activeDocumentIdRef.current;
     if (!editor || !docId) return;
 
-    const existing = await localRepository.get(docId);
-    if (!existing) return;
-
     const { document } = getSnapshot(editor.store);
-    await localRepository.save({
-      ...existing,
-      snapshot: document,
-    });
-  }, [localRepository]);
+    await persistLocalSnapshot(docId, document);
+  }, [persistLocalSnapshot]);
 
   useEffect(() => {
     let cancelled = false;
@@ -640,11 +646,16 @@ export function useDocumentManager(params: {
       // store event below so switching the active doc takes effect without
       // re-registering.
       let timer: ReturnType<typeof setTimeout> | undefined;
+      // The doc a scheduled-but-unfired save belongs to; read on teardown
+      // to flush that save instead of dropping it.
+      let pendingDocId: string | null = null;
       const stopListening = nextEditor.store.listen(
         () => {
           if (activeDocumentSourceRef.current !== "local") return;
           clearTimeout(timer);
+          pendingDocId = activeDocumentIdRef.current;
           timer = setTimeout(() => {
+            pendingDocId = null;
             saveCurrentEditor();
           }, 500);
         },
@@ -654,6 +665,24 @@ export function useDocumentManager(params: {
       return () => {
         clearTimeout(timer);
         stopListening();
+        // A save still pending here holds the edits made in the last
+        // 500ms; the clearTimeout above would silently drop them. That
+        // matters when teardown is an app-level unmount — e.g. auth
+        // resolving mid-editing-session swaps in the synced workspace —
+        // so flush the save instead. The snapshot is captured
+        // synchronously because the editor may be disposed as soon as
+        // this cleanup returns. The doc-id/source guard skips the flush
+        // when the active doc has already moved on (doc switches save
+        // through selectDocument first; flushing here would write this
+        // editor's content onto the newly active doc).
+        if (
+          pendingDocId !== null &&
+          pendingDocId === activeDocumentIdRef.current &&
+          activeDocumentSourceRef.current === "local"
+        ) {
+          const { document } = getSnapshot(nextEditor.store);
+          void persistLocalSnapshot(pendingDocId, document);
+        }
         // The store-listen above debounces saveCurrentEditor by 500ms,
         // and saveCurrentEditor reads `editorRef.current` directly.
         // Without nulling the ref here, a save scheduled just before
@@ -666,7 +695,7 @@ export function useDocumentManager(params: {
         setEditor((current) => (current === nextEditor ? null : current));
       };
     },
-    [saveCurrentEditor],
+    [persistLocalSnapshot, saveCurrentEditor],
   );
 
   // Best-effort save when the user leaves the page.


### PR DESCRIPTION
With the auth worker unreachable, `/auth/me` fails and SWR enters its error-retry loop. SWR's `isLoading` is true whenever a request is in flight with no data loaded, including every retry, and `App.tsx` gates rendering on the auth provider's `loading` with `return null`. Each retry therefore unmounted and remounted the entire app, tearing down the editor (and any live embedded media) every backoff interval.

`AuthProvider` now reports `loading` only until the first attempt settles: after the first failure the app stays mounted in the logged-out local experience while retries continue in the background. When a retry eventually succeeds, the session lands as before.

Separately, the local editor's unregister cleanup cleared its 500 ms debounced save, dropping the last edits whenever the editor tore down within that window. Keeping the app interactive during retries makes that window matter: an auth retry that succeeds mid-editing-session unmounts the local editor to swap in the synced workspace. The cleanup now flushes the pending save instead, through a new `LocalDocumentRepository.updateSnapshot` that performs the read-modify-write in a single IndexedDB readwrite transaction; the debounced autosave persists through the same call, so it too is now one transaction rather than a `get` and a `save`. IndexedDB starts a transaction only after every earlier-created overlapping readwrite transaction commits, so a document manager remounting after the teardown cannot read the document until the flush has landed. The flush runs only while the torn-down editor still belongs to the active document, since every path that switches documents persists the outgoing document itself and detaches the editor first.

`pnpm --filter app test` runs the regression tests: `loading` must stay false while a retry request is in flight, and the pending debounced save must be flushed as a single atomic repository operation when the editor unregisters. Both regress without the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication loading behavior after an initial user-fetch failure.
  * Retry attempts now correctly reflect the loading state instead of remaining stuck.
  * Improved local document saving to preserve the latest changes when switching documents or closing an editor.
  * Prevented duplicate saves during document switching.
  * Improved reliability when updating locally stored document snapshots.

* **Tests**
  * Added coverage for authentication retries, loading transitions, and reliable local document persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->