### PR TITLE
anipres: stabilize `getShapeVisibility` so re-renders can't recreate the editor

### DIFF
--- a/.changeset/stable-shape-visibility.md
+++ b/.changeset/stable-shape-visibility.md
@@ -1,0 +1,5 @@
+---
+"anipres": patch
+---
+
+Keep the editor alive across re-renders: `getShapeVisibility` is part of tldraw's editor-creation dependency list, so the previously inline callback made every re-render of `Anipres` dispose and recreate the `Editor` — on a synced store, every WebSocket reconnect did this, clearing undo history and remounting the canvas mid-presentation.

--- a/packages/anipres/src/Anipres.tsx
+++ b/packages/anipres/src/Anipres.tsx
@@ -683,28 +683,39 @@ const Inner = (props: InnerProps) => {
     };
   };
 
-  const determineShapeVisibility: TldrawProps["getShapeVisibility"] = (
-    shape,
-    editor,
-  ) => {
-    const presentationMode = perInstanceAtoms.$presentationMode.get();
-    if (!presentationMode) {
-      return "visible";
-    }
+  // Identity-stable across re-renders: `getShapeVisibility` is one of
+  // the props tldraw DISPOSES AND RECREATES the whole Editor over (it
+  // sits unwrapped in the editor-creation `useLayoutEffect` dep list —
+  // see
+  // https://github.com/tldraw/tldraw/blob/v3.15.5/packages/editor/src/lib/TldrawEditor.tsx).
+  // A fresh closure per render turns any re-render of this component —
+  // e.g. `useSync` handing over a new store-status wrapper on every
+  // WebSocket reconnect — into a full editor remount that clears undo
+  // history and tears down the canvas DOM.
+  const determineShapeVisibility = useCallback<
+    NonNullable<TldrawProps["getShapeVisibility"]>
+  >(
+    (shape, editor) => {
+      const presentationMode = perInstanceAtoms.$presentationMode.get();
+      if (!presentationMode) {
+        return "visible";
+      }
 
-    // This callback can be called before `onMount` is called and the refs are set.
-    // So we need to get presentationManager here using the editor object passed to this callback
-    // instead of relying on the refs that are set in `onMount`.
-    // `presentationManager.create` ensures that the same instance is returned for the same editor.
-    const presentationManager = PresentationManager.create(
-      editor,
-      $currentStepIndex,
-    );
+      // This callback can be called before `onMount` is called and the refs are set.
+      // So we need to get presentationManager here using the editor object passed to this callback
+      // instead of relying on the refs that are set in `onMount`.
+      // `presentationManager.create` ensures that the same instance is returned for the same editor.
+      const presentationManager = PresentationManager.create(
+        editor,
+        $currentStepIndex,
+      );
 
-    const shapeVisibilities =
-      presentationManager.$getShapeVisibilitiesInPresentationMode();
-    return shapeVisibilities[shape.id] ?? "hidden";
-  };
+      const shapeVisibilities =
+        presentationManager.$getShapeVisibilitiesInPresentationMode();
+      return shapeVisibilities[shape.id] ?? "hidden";
+    },
+    [perInstanceAtoms, $currentStepIndex],
+  );
 
   return (
     <Tldraw

--- a/packages/anipres/src/Anipres.tsx
+++ b/packages/anipres/src/Anipres.tsx
@@ -687,7 +687,7 @@ const Inner = (props: InnerProps) => {
   // the props tldraw DISPOSES AND RECREATES the whole Editor over (it
   // sits unwrapped in the editor-creation `useLayoutEffect` dep list —
   // see
-  // https://github.com/tldraw/tldraw/blob/v3.15.5/packages/editor/src/lib/TldrawEditor.tsx).
+  // https://github.com/tldraw/tldraw/blob/v3.15.5/packages/editor/src/lib/TldrawEditor.tsx#L456-L509).
   // A fresh closure per render turns any re-render of this component —
   // e.g. `useSync` handing over a new store-status wrapper on every
   // WebSocket reconnect — into a full editor remount that clears undo


### PR DESCRIPTION
`getShapeVisibility` is one of the props tldraw's `TldrawEditor` lists in the `useLayoutEffect` dependency array that constructs and disposes the `Editor`. `Anipres` passed it as an inline closure, so every render of the (memoized) inner component disposed and recreated the whole editor. A new prop identity is enough to get past `React.memo`, and on a synced document that happens in practice on every WebSocket reconnect: `useSync` hands over a new store-status wrapper when the connection status flips, so the canvas is torn down mid-presentation with the undo history cleared.

The callback is now wrapped in `useCallback` keyed on the two per-instance-stable values it reads, so re-renders leave the `Editor` alive.

There is no automated test: `packages/anipres` has no React-rendering test infra, and covering this would mean standing up jsdom plus a full tldraw render. `pnpm --filter anipres test` runs the existing suite.

The same change is currently also in #500; that branch drops it once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
