### PR TITLE
ci: run the `packages/app` unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,8 +224,7 @@ jobs:
       - name: Format check
         run: pnpm format --check
 
-  # Lint/format live in lint-app and typecheck in build-app (tsc -b),
-  # so this job only runs the unit tests.
+  # Lint, format, and typecheck for this package run in lint-app and build-app.
   test-app:
     runs-on: ubuntu-latest
     defaults:
@@ -249,6 +248,12 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
+      # Vitest loads vite.config.ts, whose Font.vite() plugin needs the
+      # cn-font-split native library at module load even though no test
+      # imports a font.
+      # https://github.com/KonghaYao/cn-font-split/issues/149
+      - run: pnpm cn-font-split i default
 
       - name: Test
         run: pnpm test
@@ -286,7 +291,7 @@ jobs:
         run: pnpm test
 
   build-app:
-    needs: [test-agent-core, lint-app]
+    needs: [test-agent-core, lint-app, test-app]
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,35 @@ jobs:
       - name: Format check
         run: pnpm format --check
 
+  # Lint/format live in lint-app and typecheck in build-app (tsc -b),
+  # so this job only runs the unit tests.
+  test-app:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/app
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: latest
+          run_install: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Test
+        run: pnpm test
+
   test-worker:
     needs: [test-agent-core]
 

--- a/packages/app/src/auth/auth-broadcast.test.ts
+++ b/packages/app/src/auth/auth-broadcast.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, it, vi } from "vitest";
 import { broadcastLogout, subscribeToAuthBroadcasts } from "./auth-broadcast";
 
+// The BroadcastChannel here is Node's built-in (happy-dom provides
+// none), and it delivers across instances asynchronously with no
+// guarantee the message lands within any fixed number of event-loop
+// turns, so a `setTimeout(0)` wait loses the race on slow runners.
+// Positive assertions poll with `vi.waitFor`. Negative assertions
+// synchronize on a control channel that receives every message
+// unfiltered: once the control has seen the message, the subject
+// handler has had its delivery chance too.
+function nextBroadcast(): Promise<unknown> {
+  return new Promise((resolve) => {
+    const control = new BroadcastChannel("anipres:auth");
+    control.onmessage = (event: MessageEvent) => {
+      control.close();
+      resolve(event.data);
+    };
+  });
+}
+
 describe("auth broadcast", () => {
   it("delivers a logout message from another sender", async () => {
     const handler = vi.fn();
@@ -10,9 +28,7 @@ describe("auth broadcast", () => {
     externalChannel.postMessage({ type: "logout", senderId: "other-tab" });
     externalChannel.close();
 
-    await new Promise((r) => setTimeout(r, 0));
-
-    expect(handler).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(1));
     expect(handler.mock.calls[0][0]).toMatchObject({ type: "logout" });
     unsubscribe();
   });
@@ -21,7 +37,9 @@ describe("auth broadcast", () => {
     const handler = vi.fn();
     const unsubscribe = subscribeToAuthBroadcasts(handler);
 
+    const delivered = nextBroadcast();
     broadcastLogout();
+    await delivered;
     await new Promise((r) => setTimeout(r, 0));
 
     expect(handler).not.toHaveBeenCalled();
@@ -33,9 +51,11 @@ describe("auth broadcast", () => {
     const unsubscribe = subscribeToAuthBroadcasts(handler);
     unsubscribe();
 
+    const delivered = nextBroadcast();
     const externalChannel = new BroadcastChannel("anipres:auth");
     externalChannel.postMessage({ type: "logout", senderId: "other-tab" });
     externalChannel.close();
+    await delivered;
     await new Promise((r) => setTimeout(r, 0));
 
     expect(handler).not.toHaveBeenCalled();

--- a/packages/app/src/auth/auth-broadcast.test.ts
+++ b/packages/app/src/auth/auth-broadcast.test.ts
@@ -1,20 +1,25 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { broadcastLogout, subscribeToAuthBroadcasts } from "./auth-broadcast";
 
-// The BroadcastChannel here is Node's built-in (happy-dom provides
-// none), and it delivers across instances asynchronously with no
-// guarantee the message lands within any fixed number of event-loop
-// turns, so a `setTimeout(0)` wait loses the race on slow runners.
-// Positive assertions poll with `vi.waitFor`. Negative assertions
-// synchronize on a control channel that receives every message
-// unfiltered: once the control has seen the message, the subject
-// handler has had its delivery chance too.
-function nextBroadcast(): Promise<unknown> {
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  while (cleanups.length) {
+    cleanups.pop()!();
+  }
+});
+
+// Node's built-in BroadcastChannel (happy-dom provides none) delivers
+// across instances asynchronously, with no guarantee the message lands
+// within any fixed number of event-loop turns. A control channel that
+// takes every message unfiltered gives the negative assertions
+// something real to wait on; the extra turn awaited after it covers the
+// case where the control's port is served before the subject's.
+function nextBroadcast(): Promise<void> {
   return new Promise((resolve) => {
     const control = new BroadcastChannel("anipres:auth");
-    control.onmessage = (event: MessageEvent) => {
-      control.close();
-      resolve(event.data);
+    cleanups.push(() => control.close());
+    control.onmessage = () => {
+      resolve();
     };
   });
 }
@@ -22,7 +27,7 @@ function nextBroadcast(): Promise<unknown> {
 describe("auth broadcast", () => {
   it("delivers a logout message from another sender", async () => {
     const handler = vi.fn();
-    const unsubscribe = subscribeToAuthBroadcasts(handler);
+    cleanups.push(subscribeToAuthBroadcasts(handler));
 
     const externalChannel = new BroadcastChannel("anipres:auth");
     externalChannel.postMessage({ type: "logout", senderId: "other-tab" });
@@ -30,12 +35,11 @@ describe("auth broadcast", () => {
 
     await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(1));
     expect(handler.mock.calls[0][0]).toMatchObject({ type: "logout" });
-    unsubscribe();
   });
 
   it("ignores broadcasts originated by the same tab", async () => {
     const handler = vi.fn();
-    const unsubscribe = subscribeToAuthBroadcasts(handler);
+    cleanups.push(subscribeToAuthBroadcasts(handler));
 
     const delivered = nextBroadcast();
     broadcastLogout();
@@ -43,7 +47,6 @@ describe("auth broadcast", () => {
     await new Promise((r) => setTimeout(r, 0));
 
     expect(handler).not.toHaveBeenCalled();
-    unsubscribe();
   });
 
   it("removes the listener on unsubscribe", async () => {

--- a/packages/app/src/auth/auth-broadcast.test.ts
+++ b/packages/app/src/auth/auth-broadcast.test.ts
@@ -9,12 +9,11 @@ afterEach(() => {
 });
 
 // Node's built-in BroadcastChannel (happy-dom provides none) delivers
-// across instances asynchronously, with no guarantee the message lands
-// within any fixed number of event-loop turns, so the negative
-// assertions can't just sleep and check. They synchronize on delivery
-// instead: messages are delivered to each receiving channel in posting
-// order, so once a later message has provably arrived, the earlier one
-// had its chance.
+// across instances asynchronously, with no bound on how many event-loop
+// turns it takes, so no sleep makes "was not called" meaningful. The
+// tests wait on a delivery that must come after the one in question
+// instead: a receiving channel gets messages in posting order, and a
+// single message is fanned out to channels in creation order.
 describe("auth broadcast", () => {
   it("delivers a logout message from another sender", async () => {
     const handler = vi.fn();

--- a/packages/app/src/auth/auth-broadcast.test.ts
+++ b/packages/app/src/auth/auth-broadcast.test.ts
@@ -10,20 +10,11 @@ afterEach(() => {
 
 // Node's built-in BroadcastChannel (happy-dom provides none) delivers
 // across instances asynchronously, with no guarantee the message lands
-// within any fixed number of event-loop turns. A control channel that
-// takes every message unfiltered gives the negative assertions
-// something real to wait on; the extra turn awaited after it covers the
-// case where the control's port is served before the subject's.
-function nextBroadcast(): Promise<void> {
-  return new Promise((resolve) => {
-    const control = new BroadcastChannel("anipres:auth");
-    cleanups.push(() => control.close());
-    control.onmessage = () => {
-      resolve();
-    };
-  });
-}
-
+// within any fixed number of event-loop turns, so the negative
+// assertions can't just sleep and check. They synchronize on delivery
+// instead: messages are delivered to each receiving channel in posting
+// order, so once a later message has provably arrived, the earlier one
+// had its chance.
 describe("auth broadcast", () => {
   it("delivers a logout message from another sender", async () => {
     const handler = vi.fn();
@@ -41,26 +32,32 @@ describe("auth broadcast", () => {
     const handler = vi.fn();
     cleanups.push(subscribeToAuthBroadcasts(handler));
 
-    const delivered = nextBroadcast();
     broadcastLogout();
-    await delivered;
-    await new Promise((r) => setTimeout(r, 0));
+    // Posted after the same-tab broadcast. Delivery to a channel is
+    // FIFO, so the first call the handler ever receives is fixed: if
+    // the filter were broken it would be the own-tab message, and the
+    // payload assertion below would fail no matter when polling lands.
+    const externalChannel = new BroadcastChannel("anipres:auth");
+    externalChannel.postMessage({ type: "logout", senderId: "other-tab" });
+    externalChannel.close();
 
-    expect(handler).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(handler).toHaveBeenCalled());
+    expect(handler.mock.calls[0][0]).toMatchObject({ senderId: "other-tab" });
   });
 
   it("removes the listener on unsubscribe", async () => {
     const handler = vi.fn();
     const unsubscribe = subscribeToAuthBroadcasts(handler);
     unsubscribe();
+    // A second, still-open subscriber proves the message went out.
+    const witness = vi.fn();
+    cleanups.push(subscribeToAuthBroadcasts(witness));
 
-    const delivered = nextBroadcast();
     const externalChannel = new BroadcastChannel("anipres:auth");
     externalChannel.postMessage({ type: "logout", senderId: "other-tab" });
     externalChannel.close();
-    await delivered;
-    await new Promise((r) => setTimeout(r, 0));
 
+    await vi.waitFor(() => expect(witness).toHaveBeenCalledTimes(1));
     expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/documents/local-docs-broadcast.test.ts
+++ b/packages/app/src/documents/local-docs-broadcast.test.ts
@@ -1,8 +1,27 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   broadcastLocalDocsChanged,
   subscribeToLocalDocsChanges,
 } from "./local-docs-broadcast";
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  while (cleanups.length) {
+    cleanups.pop()!();
+  }
+});
+
+// See auth-broadcast.test.ts for why the waits must be event-based:
+// Node's BroadcastChannel has no same-turn delivery guarantee.
+function nextBroadcast(): Promise<void> {
+  return new Promise((resolve) => {
+    const control = new BroadcastChannel("anipres:local-docs");
+    cleanups.push(() => control.close());
+    control.onmessage = () => {
+      resolve();
+    };
+  });
+}
 
 // Same-realm BroadcastChannel cross-instance behavior is what's
 // being exercised: a message posted on a fresh "anipres:local-docs"
@@ -11,7 +30,7 @@ import {
 describe("local-docs broadcast", () => {
   it("delivers to a subscriber when the broadcast comes from another sender", async () => {
     const handler = vi.fn();
-    const unsubscribe = subscribeToLocalDocsChanges(handler);
+    cleanups.push(subscribeToLocalDocsChanges(handler));
 
     // Simulate "another tab" by posting raw on the same channel name
     // — that channel has a different sender id by construction.
@@ -19,22 +38,19 @@ describe("local-docs broadcast", () => {
     externalChannel.postMessage({ senderId: "other-tab" });
     externalChannel.close();
 
-    // BroadcastChannel delivery is asynchronous; yield once.
-    await new Promise((r) => setTimeout(r, 0));
-
-    expect(handler).toHaveBeenCalledTimes(1);
-    unsubscribe();
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(1));
   });
 
   it("ignores broadcasts originated by the same tab", async () => {
     const handler = vi.fn();
-    const unsubscribe = subscribeToLocalDocsChanges(handler);
+    cleanups.push(subscribeToLocalDocsChanges(handler));
 
+    const delivered = nextBroadcast();
     broadcastLocalDocsChanged();
+    await delivered;
     await new Promise((r) => setTimeout(r, 0));
 
     expect(handler).not.toHaveBeenCalled();
-    unsubscribe();
   });
 
   it("removes the listener on unsubscribe", async () => {
@@ -42,9 +58,11 @@ describe("local-docs broadcast", () => {
     const unsubscribe = subscribeToLocalDocsChanges(handler);
     unsubscribe();
 
+    const delivered = nextBroadcast();
     const externalChannel = new BroadcastChannel("anipres:local-docs");
     externalChannel.postMessage({ senderId: "other-tab" });
     externalChannel.close();
+    await delivered;
     await new Promise((r) => setTimeout(r, 0));
 
     expect(handler).not.toHaveBeenCalled();

--- a/packages/app/src/documents/local-docs-broadcast.test.ts
+++ b/packages/app/src/documents/local-docs-broadcast.test.ts
@@ -11,22 +11,13 @@ afterEach(() => {
   }
 });
 
-// See auth-broadcast.test.ts for why the waits must be event-based:
-// Node's BroadcastChannel has no same-turn delivery guarantee.
-function nextBroadcast(): Promise<void> {
-  return new Promise((resolve) => {
-    const control = new BroadcastChannel("anipres:local-docs");
-    cleanups.push(() => control.close());
-    control.onmessage = () => {
-      resolve();
-    };
-  });
-}
-
 // Same-realm BroadcastChannel cross-instance behavior is what's
 // being exercised: a message posted on a fresh "anipres:local-docs"
 // channel should reach a subscriber on a separate channel of the
-// same name, except when the sender id matches.
+// same name, except when the sender id matches. See
+// auth-broadcast.test.ts for why the waits synchronize on delivery
+// instead of sleeping: Node's BroadcastChannel has no same-turn
+// delivery guarantee.
 describe("local-docs broadcast", () => {
   it("delivers to a subscriber when the broadcast comes from another sender", async () => {
     const handler = vi.fn();
@@ -44,27 +35,37 @@ describe("local-docs broadcast", () => {
   it("ignores broadcasts originated by the same tab", async () => {
     const handler = vi.fn();
     cleanups.push(subscribeToLocalDocsChanges(handler));
+    // The subject handler takes no payload, so a bare call count can't
+    // distinguish "filtered the own-tab message" from "the external
+    // message hasn't arrived yet". The witness closes that gap: created
+    // after the subject, it is served each message after the subject
+    // is, so once it has seen the external message the subject has
+    // fully processed both messages and its count is final.
+    const witness = vi.fn();
+    cleanups.push(subscribeToLocalDocsChanges(witness));
 
-    const delivered = nextBroadcast();
     broadcastLocalDocsChanged();
-    await delivered;
-    await new Promise((r) => setTimeout(r, 0));
+    const externalChannel = new BroadcastChannel("anipres:local-docs");
+    externalChannel.postMessage({ senderId: "other-tab" });
+    externalChannel.close();
 
-    expect(handler).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(witness).toHaveBeenCalledTimes(1));
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 
   it("removes the listener on unsubscribe", async () => {
     const handler = vi.fn();
     const unsubscribe = subscribeToLocalDocsChanges(handler);
     unsubscribe();
+    // A second, still-open subscriber proves the message went out.
+    const witness = vi.fn();
+    cleanups.push(subscribeToLocalDocsChanges(witness));
 
-    const delivered = nextBroadcast();
     const externalChannel = new BroadcastChannel("anipres:local-docs");
     externalChannel.postMessage({ senderId: "other-tab" });
     externalChannel.close();
-    await delivered;
-    await new Promise((r) => setTimeout(r, 0));
 
+    await vi.waitFor(() => expect(witness).toHaveBeenCalledTimes(1));
     expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/documents/local-docs-broadcast.test.ts
+++ b/packages/app/src/documents/local-docs-broadcast.test.ts
@@ -35,21 +35,26 @@ describe("local-docs broadcast", () => {
   it("ignores broadcasts originated by the same tab", async () => {
     const handler = vi.fn();
     cleanups.push(subscribeToLocalDocsChanges(handler));
-    // The subject handler takes no payload, so a bare call count can't
-    // distinguish "filtered the own-tab message" from "the external
-    // message hasn't arrived yet". The witness closes that gap: created
-    // after the subject, it is served each message after the subject
-    // is, so once it has seen the external message the subject has
-    // fully processed both messages and its count is final.
-    const witness = vi.fn();
-    cleanups.push(subscribeToLocalDocsChanges(witness));
+    // Created after the subject, so the fan-out serves it after the
+    // subject for every message; once it has the external message the
+    // subject has processed both and its count is final. Unfiltered on
+    // purpose: the filter is what's under test here.
+    const externalArrived = new Promise<void>((resolve) => {
+      const barrier = new BroadcastChannel("anipres:local-docs");
+      cleanups.push(() => barrier.close());
+      barrier.onmessage = (e: MessageEvent<{ senderId?: string }>) => {
+        if (e.data?.senderId === "other-tab") {
+          resolve();
+        }
+      };
+    });
 
     broadcastLocalDocsChanged();
     const externalChannel = new BroadcastChannel("anipres:local-docs");
     externalChannel.postMessage({ senderId: "other-tab" });
     externalChannel.close();
 
-    await vi.waitFor(() => expect(witness).toHaveBeenCalledTimes(1));
+    await externalArrived;
     expect(handler).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
`packages/app` has a co-located Vitest suite, but no CI job executed it: `lint-app` only lints and checks formatting, and `build-app` only typechecks and builds. Test regressions in the app could land unnoticed.

This adds a `test-app` job that installs and runs `pnpm test` in `packages/app`, mirroring the sibling `test-agent-core` job. Lint, format, and typecheck steps are deliberately omitted since the existing jobs already cover them; the `pnpm cn-font-split i default` step is required because Vitest loads `vite.config.ts`, whose `Font.vite()` plugin needs the native library at module load. `build-app` now also gates on `test-app`, matching the file's build-gates-on-tests pattern.

`auth-broadcast.test.ts` and `local-docs-broadcast.test.ts` carry a latent flake that only a CI runner surfaces: they wait a single `setTimeout(0)` turn for Node's `BroadcastChannel` to deliver, which is not guaranteed and loses the race on a slow machine. The tests now wait on delivery instead: `vi.waitFor` for the positive cases, and elsewhere a message whose arrival proves the one under test already had its chance. The fix rides along here because this is the PR that first puts the suite in front of CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
