### PR TITLE
anipres, agent: label presentation steps from 0

### DIFF
--- a/.changeset/zero-indexed-step-labels.md
+++ b/.changeset/zero-indexed-step-labels.md
@@ -1,0 +1,8 @@
+---
+"anipres": minor
+"@anipres/agent-core": patch
+---
+
+Label timeline steps from 0 instead of 1. The number now counts advances: step N is where the presentation lands after N "next" actions, so step 0 is the un-advanced state. Under the old labels the first column read "1" while standing at zero advances, so every number was one ahead of the presses needed to reach it.
+
+The agent's perception of the timeline and its system prompt described steps from 1 to match the old labels, and now use the same numbering, so a message like "I added a slide as step 7" points at the column the user sees. The step button also gains `type="button"`, an `aria-label` (the visible text is a bare digit) and `aria-current`.

--- a/packages/agent-core/src/client/parts/presentation-state.ts
+++ b/packages/agent-core/src/client/parts/presentation-state.ts
@@ -34,14 +34,12 @@ function summarise(editor: Editor): {
     })),
   });
 
-  // 1-indexed: Anipres' UI numbers steps from 1 ("Step 1", "Step 2"
-  // …) but the underlying array is 0-based. The agent's perception
-  // matches the user-facing numbering so messages like "I added a
-  // slide as step 7" line up with what the user sees in the
-  // timeline; the system prompt also describes steps as 1-numbered
-  // to keep the vocabulary consistent.
-  const steps = doc.steps.map((step, zeroBased) => ({
-    index: zeroBased + 1,
+  // The timeline labels steps from 0, where the label counts
+  // advances, so the agent perceives the same numbers the user reads
+  // and a message like "I added a slide as step 7" points at the
+  // column they see. The system prompt describes the same vocabulary.
+  const steps = doc.steps.map((step, index) => ({
+    index,
     batches: step.batches.map((batch) => ({
       trackId: batch.trackId,
       shapeIds: batch.frames.map((frame) => frame.shapeId),

--- a/packages/agent-core/src/runtime/summarize-snapshot.ts
+++ b/packages/agent-core/src/runtime/summarize-snapshot.ts
@@ -52,9 +52,9 @@ export function summarizeSnapshot(snapshot: SnapshotInput): SnapshotSummary {
       frames: frameCount,
       totalSteps: doc.steps.length,
       steps: doc.steps.map((step, i) => ({
-        // 1-indexed, matching the UI's "Step 1"… numbering (see
+        // Matches the timeline's labels, which count advances (see
         // presentation-state.ts).
-        index: i + 1,
+        index: i,
         batches: step.batches.map((b) => ({
           trackId: b.trackId,
           action: b.frames[0].action,

--- a/packages/agent-core/src/server/build-messages.test.ts
+++ b/packages/agent-core/src/server/build-messages.test.ts
@@ -33,10 +33,9 @@ describe("buildMessages", () => {
         totalSteps: 1,
         steps: [
           {
-            // 1-indexed to match the UI; perception projects steps
-            // starting at 1 so agent prose lines up with what the
-            // user sees in the timeline.
-            index: 1,
+            // The timeline's own numbering, so agent prose lines up
+            // with what the user sees there.
+            index: 0,
             batches: [
               {
                 trackId: "track-A",

--- a/packages/agent-core/src/server/build-system-prompt.ts
+++ b/packages/agent-core/src/server/build-system-prompt.ts
@@ -82,7 +82,7 @@ Other shape kinds (groups, images, theme-images) exist on the canvas but aren't 
 
 ### Steps, tracks and frames
 
-- The presentation timeline is a sequence of **steps** (numbered from 1, matching what the user sees in the timeline UI). Moving from step N to N+1 may run animations. When you reference a step in a \`message\` action, use this 1-based numbering so your wording matches the user's view.
+- The presentation timeline is a sequence of **steps**, numbered from 0 to match the timeline UI: step N is where the presentation lands after N "next" actions, so step 0 is the un-advanced state. Moving from step N to N+1 may run animations. Use this numbering when you reference a step in a \`message\` action, so your wording matches the user's view.
 - Each step is one or more parallel **frame batches**. A batch sits on a **track** (identified by a \`trackId\`).
 - A **cue frame** lives on a single shape and marks "this shape is the state of its track at this step". The shape is visible from this step onward (until the next cue frame in the same track replaces it).
 - A track with multiple cue frames (at different steps) becomes an animation: when navigating from one step to the next, the previous frame's shape interpolates to the new frame's shape.

--- a/packages/anipres/src/Timeline/Timeline.tsx
+++ b/packages/anipres/src/Timeline/Timeline.tsx
@@ -138,10 +138,15 @@ const StepColumn = React.memo(
         <div className={`${styles.column} ${isActive ? styles.active : ""}`}>
           <div className={styles.headerCell}>
             <button
+              type="button"
               className={`${styles.frameButton} ${isActive ? styles.selected : ""}`}
               onClick={() => onStepSelect(stepIdx)}
+              aria-label={`Go to step ${stepIdx}`}
+              aria-current={isActive ? "step" : undefined}
             >
-              {stepIdx + 1}
+              {/* Zero-based so the label counts advances: step N is
+                  where the presentation lands after N "next" actions. */}
+              {stepIdx}
             </button>
           </div>
           <DroppableArea
@@ -543,7 +548,7 @@ export function Timeline({
         })}
         {showAttachCueFrameButton && (
           <div className={styles.column}>
-            <div className={styles.headerCell}>{steps.length + 1}</div>
+            <div className={styles.headerCell}>{steps.length}</div>
             {tracks.map((track) => (
               <div key={track.id} className={styles.frameBatchCell}></div>
             ))}


### PR DESCRIPTION
The timeline labelled its first step "1" while the presentation was standing at zero advances, so every column number was one ahead of the number of "next" presses needed to reach it. The Slidev addon compounds that: it drives step indexes from Slidev's click counter, which counts from 0 at the un-advanced state, so an author reading the timeline and reasoning about clicks worked in two systems that differed by one.

Steps are now labelled from 0, so the label counts advances: step N is where the presentation lands after N of them. The agent's perception and system prompt described steps from 1 to match the old labels, and now use the same numbering, so a message like "I added a slide as step 7" points at the column the user sees. The step button also gains `type="button"`, an `aria-label` (the visible text is a bare digit) and `aria-current`, so assistive tech can name the control and report which step is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized timeline step numbering to start at zero across the timeline, summaries, and agent guidance.
  * Improved alignment between displayed steps and the current timeline state.

* **Accessibility**
  * Added clearer step labels and current-step indicators for assistive technologies.
  * Updated step controls and headings to better communicate zero-based numbering.

* **Documentation**
  * Documented the updated timeline numbering behavior in the release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->