### PR TITLE
anipres: lock a video's aspect ratio, and settle its timeline row order within a step

### DIFF
--- a/.changeset/video-embed-editing.md
+++ b/.changeset/video-embed-editing.md
@@ -1,0 +1,7 @@
+---
+"anipres": patch
+---
+
+Lock a YouTube embed's aspect ratio while resizing. The embedded player is letterboxed inside whatever box the shape is given, so a shape reshaped away from the video's own ratio grew bars rather than picture, and the handles moved without the video following them.
+
+Order a video's own movement ahead of its media events where both fall in the same step of its timeline row. A step's batches run concurrently, so which of the two reads first carries no meaning and cannot be dragged into a different one; left to the derivation it came out in frame-id order, which is to say arbitrarily, and differently for every video.

--- a/packages/anipres/src/Timeline/frame-ui-data.test.ts
+++ b/packages/anipres/src/Timeline/frame-ui-data.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { calcFrameBatchUIData } from "./frame-ui-data";
 import { deriveTimeline } from "../timeline-model";
-import type { CueFrame } from "../timeline-model";
+import type { CueFrame, TimelineDoc } from "../timeline-model";
 
 function cue(
   id: string,
@@ -75,33 +75,31 @@ describe("a video's row when a step holds movement and an event", () => {
     // Both tracks describe one video, so they share a row, and both
     // have a batch in step 0. Frame ids decide nothing here: the media
     // event's sorts ahead of the movement's.
-    const doc = {
+    const doc: TimelineDoc = {
+      version: 1,
+      detachedFrames: [],
       steps: [
         {
           id: "s0",
           orderKey: "a1",
           batches: [
             {
-              id: "b-event",
               trackId: "T-media",
               frames: [
                 {
-                  id: "aaa-event",
+                  frameId: "aaa-event",
                   shapeId: "shape:marker",
-                  type: "cue" as const,
-                  action: { type: "mediaControl" as const, command: "play" },
+                  action: { type: "mediaControl", command: "play" },
                 },
               ],
             },
             {
-              id: "b-move",
               trackId: "T-video",
               frames: [
                 {
-                  id: "zzz-move",
+                  frameId: "zzz-move",
                   shapeId: "shape:video",
-                  type: "cue" as const,
-                  action: { type: "shapeAnimation" as const },
+                  action: { type: "shapeAnimation" },
                 },
               ],
             },
@@ -111,7 +109,7 @@ describe("a video's row when a step holds movement and an event", () => {
       diagnostics: [],
     };
 
-    const { tracks } = calcFrameBatchUIData(doc as never, {
+    const { tracks } = calcFrameBatchUIData(doc, {
       "T-media": "video-key",
       "T-video": "video-key",
     });
@@ -120,6 +118,12 @@ describe("a video's row when a step holds movement and an event", () => {
     expect(tracks[0].frameBatches.map((b) => b.trackId)).toEqual([
       "T-video",
       "T-media",
+    ]);
+    // The cue frame's own id travels into the row, which a fixture
+    // naming the field wrongly would leave undefined.
+    expect(tracks[0].frameBatches.map((b) => b.data[0].id)).toEqual([
+      "zzz-move",
+      "aaa-event",
     ]);
   });
 });

--- a/packages/anipres/src/Timeline/frame-ui-data.test.ts
+++ b/packages/anipres/src/Timeline/frame-ui-data.test.ts
@@ -69,3 +69,57 @@ describe("calcFrameBatchUIData track grouping", () => {
     expect(grouped.steps).toEqual(ungrouped.steps);
   });
 });
+
+describe("a video's row when a step holds movement and an event", () => {
+  it("reads the movement first, whatever ids the frames were minted", () => {
+    // Both tracks describe one video, so they share a row, and both
+    // have a batch in step 0. Frame ids decide nothing here: the media
+    // event's sorts ahead of the movement's.
+    const doc = {
+      steps: [
+        {
+          id: "s0",
+          orderKey: "a1",
+          batches: [
+            {
+              id: "b-event",
+              trackId: "T-media",
+              frames: [
+                {
+                  id: "aaa-event",
+                  shapeId: "shape:marker",
+                  type: "cue" as const,
+                  action: { type: "mediaControl" as const, command: "play" },
+                },
+              ],
+            },
+            {
+              id: "b-move",
+              trackId: "T-video",
+              frames: [
+                {
+                  id: "zzz-move",
+                  shapeId: "shape:video",
+                  type: "cue" as const,
+                  action: { type: "shapeAnimation" as const },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      diagnostics: [],
+    };
+
+    const { tracks } = calcFrameBatchUIData(doc as never, {
+      "T-media": "video-key",
+      "T-video": "video-key",
+    });
+
+    expect(tracks).toHaveLength(1);
+    expect(tracks[0].frameBatches.map((b) => b.trackId)).toEqual([
+      "T-video",
+      "T-media",
+    ]);
+  });
+});

--- a/packages/anipres/src/Timeline/frame-ui-data.ts
+++ b/packages/anipres/src/Timeline/frame-ui-data.ts
@@ -36,6 +36,11 @@ export interface Track {
   frameBatches: FrameBatchUIData[];
 }
 
+/** Movement before the events that ride on the same row. */
+function withinStepRank(batch: FrameBatchUIData): number {
+  return batch.data[0].action.type === "mediaControl" ? 1 : 0;
+}
+
 export function calcFrameBatchUIData(
   doc: TimelineDoc,
   /** Track id → group key; tracks with the same key merge into one row. */
@@ -114,8 +119,20 @@ export function calcFrameBatchUIData(
   const tracks: Track[] = [...trackById.values()];
   for (const track of tracks) {
     // Merged rows collect batches per source track; re-order by step so
-    // the row reads left to right.
-    track.frameBatches.sort((a, b) => a.globalIndex - b.globalIndex);
+    // the row reads left to right. Two of them can share a step — a
+    // video moving and one of its own events — and a step's batches
+    // run concurrently, so which reads first carries no meaning and
+    // cannot be dragged into a different one. Left to the derivation
+    // it would come out in frame-id order, which is to say arbitrarily
+    // and differently for every video, so the video's own movement is
+    // put ahead of the events it carries and equal ranks fall back to
+    // the track id.
+    track.frameBatches.sort(
+      (a, b) =>
+        a.globalIndex - b.globalIndex ||
+        withinStepRank(a) - withinStepRank(b) ||
+        (a.trackId < b.trackId ? -1 : a.trackId > b.trackId ? 1 : 0),
+    );
   }
   tracks.sort((a, b) => {
     // cameraZoom should be at the top

--- a/packages/anipres/src/media/video-movement.test.ts
+++ b/packages/anipres/src/media/video-movement.test.ts
@@ -1968,6 +1968,31 @@ describe("one key, a video on each of two pages", () => {
   });
 });
 
+describe("resizing a video", () => {
+  it("keeps the aspect ratio the embedded player is fixed at", () => {
+    const [editor, dispose] = loadHeadlessEditor();
+    try {
+      const videoId = createVideo(editor, "video");
+      const before = editor.getShape(videoId);
+      if (!isYouTubeEmbedShape(before)) throw new Error("expected a video");
+      const ratio = before.props.w / before.props.h;
+
+      // Dragging a corner handle out along one axis only.
+      editor.select(videoId);
+      editor.resizeShape(videoId, { x: 2, y: 1 });
+
+      const after = editor.getShape(videoId);
+      if (!isYouTubeEmbedShape(after)) throw new Error("expected a video");
+      expect(after.props.w).toBeGreaterThan(before.props.w);
+      // The player is letterboxed inside whatever box it is given, so a
+      // shape reshaped away from this grows bars rather than picture.
+      expect(after.props.w / after.props.h).toBeCloseTo(ratio, 5);
+    } finally {
+      dispose();
+    }
+  });
+});
+
 describe("a locked carrier", () => {
   it("still receives the video's configuration and its repair", () => {
     const [editor, dispose] = loadHeadlessEditor({ soleWriter: true });

--- a/packages/anipres/src/shapes/youtube-embed/YouTubeEmbedShapeUtil.tsx
+++ b/packages/anipres/src/shapes/youtube-embed/YouTubeEmbedShapeUtil.tsx
@@ -38,6 +38,14 @@ export class YouTubeEmbedShapeUtil extends BaseBoxShapeUtil<YouTubeEmbedShape> {
   static override readonly type = YouTubeEmbedShapeType;
   static override readonly props = youTubeEmbedShapeProps;
 
+  // The embedded video has a fixed aspect ratio of its own, and the
+  // player is letterboxed inside whatever box it is given, so a shape
+  // reshaped away from it grows bars rather than picture: the handles
+  // move but the video does not follow them.
+  override isAspectRatioLocked() {
+    return true;
+  }
+
   override getDefaultProps(): YouTubeEmbedShape["props"] {
     return {
       w: 480,


### PR DESCRIPTION
Two things about editing a YouTube embed.

A video's shape could be reshaped to any aspect ratio while the player inside it keeps its own. The player is letterboxed into whatever box the shape is given, so pulling a handle grew bars rather than picture and the video stopped following the handle. The ratio is locked now, as it already is for images.

Where a video's own movement and one of its media events fall in the same step, they share a timeline row and read in whichever order their frame ids happened to sort, which is arbitrary and differs per video. The movement reads first now, with the track id as a tiebreak.

That second one is presentation only, and worth being plain about: a step's batches run concurrently, so neither order means anything at runtime, and no drag can express the other one because there is no field for it to write. The model's way to say "this happens after that" is a sub-frame, which runs sequentially inside one batch; a media event never uses it, since attaching one always mints a new track. Sequencing an event against a movement would be that change, and is not this one.

`pnpm --filter anipres test -- --run` runs the tests. The resize test pulls one axis only and asserts the ratio holds, which comes out 3.56 against 1.78 without the lock; the ordering test gives the media event a frame id that sorts ahead of the movement's, so it fails if the row falls back to id order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - YouTube embeds now preserve their original aspect ratio when resized, preventing distortion.
  - Timeline actions are ordered consistently when movement and media events occur at the same moment, ensuring movement is processed first.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->