### PR TITLE
ci: push the release commit through the GitHub API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,8 +463,15 @@ jobs:
 
       - name: Package and Publish
         id: changesets
-        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        # v2 pushes the release commit and its tags through the GitHub
+        # API rather than the git CLI, which is what this upgrade is
+        # for: a CLI push that lands but loses its response is retried
+        # against a ref that has already moved, and reports a failure
+        # for work it completed. `push-with-git-cli` restores the old
+        # behavior if that is ever needed.
+        uses: changesets/action@22ccf9aa43179fe9e27dc62e575971d28cce197c # v2.0.0
         with:
-          publish: pnpm ci:publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # `publish` in v1; the token moved from the environment to an
+          # input, which v2 no longer reads from `GITHUB_TOKEN`.
+          publish-script: pnpm ci:publish
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release job failed on the merge of #513 with `cannot lock ref 'refs/heads/changeset-release/main': is at 7f35512e but expected b7ff62eb`. It made one push, no other run was racing it, and afterwards the ref held the very commit that push had just built. The push landed, its response was lost, and the retry was measured against a ref its own first attempt had already moved, so the job reported a failure for work it had completed and died before updating the version PR. Re-running it was enough and the release is out, but the same coin flip sits on every release.

`changesets/action` v2 pushes the release commit and its tags through the GitHub API rather than the git CLI, which removes the retry that causes this.

The upgrade is a major, and two of its breaking changes apply here: `publish` becomes `publish-script`, and the token moves from the environment to a `github-token` input, since v2 no longer reads `GITHUB_TOKEN`. It also drops the `.npmrc` handling it used to do when `NPM_TOKEN` was set, which nothing here relied on because publishing goes through OIDC. `push-with-git-cli: true` restores the old behavior if it is ever wanted.

The release job only runs on a push to the default branch, so nothing in this PR's checks exercises it. It is first tried for real by the release that follows the merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release automation to use the latest publishing workflow.
  * Improved release authentication and publishing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->